### PR TITLE
Reduce the load on the backend for 'Omit archived courses' #1711

### DIFF
--- a/src/main/java/teammates/client/scripts/DataMigrationForInstructorsCourseArchiving.java
+++ b/src/main/java/teammates/client/scripts/DataMigrationForInstructorsCourseArchiving.java
@@ -13,6 +13,8 @@ import teammates.storage.entity.Instructor;
  * Script to retrieve and put instructor entities without modification.
  * Originally used to generate indexes to allow the 'isArchived' field to be filtered.
  * Can be used for generating indexes for other fields in the future.
+ * 
+ * Uses low level DB calls for efficiency.
  */
 public class DataMigrationForInstructorsCourseArchiving extends RemoteApiClient {
     
@@ -25,8 +27,9 @@ public class DataMigrationForInstructorsCourseArchiving extends RemoteApiClient 
     protected void doOperation() {
         Datastore.initialize();
         
-        String query = "select from " + Instructor.class.getName();
+        // Recreate indexes for instructor entity
         
+        String query = "select from " + Instructor.class.getName();
         @SuppressWarnings("unchecked")
         List<Instructor> instructorList = (List<Instructor>) Datastore.getPersistenceManager()
                 .newQuery(query).execute();
@@ -37,6 +40,13 @@ public class DataMigrationForInstructorsCourseArchiving extends RemoteApiClient 
             // This re-creates indexes for the entity in the process.
             JDOHelper.makeDirty(instructor, "isArchived");
         }
+        
+        // Generate registration key if null
+        
+        for (Instructor instructor : instructorList) {
+            instructor.setGeneratedKeyIfNull();
+        }
+        
         
         Datastore.getPersistenceManager().close();
     }

--- a/src/main/java/teammates/client/scripts/DataMigrationForInstructorsCourseArchiving.java
+++ b/src/main/java/teammates/client/scripts/DataMigrationForInstructorsCourseArchiving.java
@@ -1,0 +1,43 @@
+package teammates.client.scripts;
+
+import java.io.IOException;
+import java.util.List;
+
+import javax.jdo.JDOHelper;
+
+import teammates.client.remoteapi.RemoteApiClient;
+import teammates.storage.datastore.Datastore;
+import teammates.storage.entity.Instructor;
+
+/**
+ * Script to retrieve and put instructor entities without modification.
+ * Originally used to generate indexes to allow the 'isArchived' field to be filtered.
+ * Can be used for generating indexes for other fields in the future.
+ */
+public class DataMigrationForInstructorsCourseArchiving extends RemoteApiClient {
+    
+    public static void main(String[] args) throws IOException {
+        DataMigrationForInstructorsCourseArchiving migrator = new DataMigrationForInstructorsCourseArchiving();
+        migrator.doOperationRemotely();
+    }
+
+    @Override
+    protected void doOperation() {
+        Datastore.initialize();
+        
+        String query = "select from " + Instructor.class.getName();
+        
+        @SuppressWarnings("unchecked")
+        List<Instructor> instructorList = (List<Instructor>) Datastore.getPersistenceManager()
+                .newQuery(query).execute();
+        
+        for (Instructor instructor : instructorList) {
+            // This makes persistence manager think that isArchived has been modified,
+            // and makes it rewrite the entity to the database.
+            // This re-creates indexes for the entity in the process.
+            JDOHelper.makeDirty(instructor, "isArchived");
+        }
+        
+        Datastore.getPersistenceManager().close();
+    }
+}

--- a/src/main/java/teammates/logic/api/Logic.java
+++ b/src/main/java/teammates/logic/api/Logic.java
@@ -711,12 +711,12 @@ public class Logic {
      * @return A less detailed version of courses for this instructor without stats
      *   Returns an empty list if none found.
      */
-    public HashMap<String, CourseSummaryBundle> getCourseSummariesWithoutStatsForInstructor(String googleId) 
+    public HashMap<String, CourseSummaryBundle> getCourseSummariesWithoutStatsForInstructor(String googleId, boolean omitArchived) 
             throws EntityDoesNotExistException {
         
         Assumption.assertNotNull(ERROR_NULL_PARAMETER, googleId);
         
-        return coursesLogic.getCoursesSummaryWithoutStatsForInstructor(googleId);
+        return coursesLogic.getCoursesSummaryWithoutStatsForInstructor(googleId, omitArchived);
     }
 
     /**

--- a/src/main/java/teammates/logic/api/Logic.java
+++ b/src/main/java/teammates/logic/api/Logic.java
@@ -840,6 +840,21 @@ public class Logic {
     
     }
     
+    /**
+     * Preconditions: <br>
+     * * All parameters are non-null.
+     * 
+     * @return Courses the given instructors is in.
+     */
+    public List<CourseAttributes> getCoursesForInstructor(List<InstructorAttributes> instructorList)
+            throws EntityDoesNotExistException {
+        
+        Assumption.assertNotNull(ERROR_NULL_PARAMETER, instructorList);
+    
+        return coursesLogic.getCoursesForInstructor(instructorList);
+    
+    }
+    
     public void updateCourse(CourseAttributes course) throws NotImplementedException {
         throw new NotImplementedException("Not implemented because we do "
                 + "not allow editing courses");
@@ -1440,6 +1455,15 @@ public class Logic {
 
         return evaluationsLogic.getEvaluationsListForInstructor(instructorId, omitArchived);
     }
+    
+
+    public ArrayList<EvaluationAttributes> getEvaluationsListForInstructor(List<InstructorAttributes> instructorList) 
+            throws EntityDoesNotExistException {
+
+        Assumption.assertNotNull(ERROR_NULL_PARAMETER, instructorList);
+        
+        return evaluationsLogic.getEvaluationsListForInstructor(instructorList);
+    }
 
     /**
      * Preconditions: <br>
@@ -1775,6 +1799,14 @@ public class Logic {
         Assumption.assertNotNull(ERROR_NULL_PARAMETER, googleId);
         
         return feedbackSessionsLogic.getFeedbackSessionsListForInstructor(googleId, omitArchived);
+    }
+    
+    public List<FeedbackSessionAttributes>
+        getFeedbackSessionsListForInstructor(List<InstructorAttributes> instructorList) throws EntityDoesNotExistException{
+    
+        Assumption.assertNotNull(ERROR_NULL_PARAMETER, instructorList);
+        
+        return feedbackSessionsLogic.getFeedbackSessionsListForInstructor(instructorList);
     }
     
     /**

--- a/src/main/java/teammates/logic/api/Logic.java
+++ b/src/main/java/teammates/logic/api/Logic.java
@@ -706,6 +706,7 @@ public class Logic {
     }
 
     /**
+     * Omits archived courses if omitArchived == true<br>
      * Preconditions: <br>
      * * All parameters are non-null. 
      * @return A less detailed version of courses for this instructor without stats
@@ -720,17 +721,18 @@ public class Logic {
     }
 
     /**
+     * Omits archived courses if omitArchived == true<br>
      * Preconditions: <br>
      * * All parameters are non-null. 
      * @return A more detailed version of courses for this instructor. 
-     *   Returns an empty list if none found.
+     *   Returns an empty list if none found.\
      */
     public HashMap<String, CourseDetailsBundle> getCourseDetailsListForInstructor(
-            String instructorId) throws EntityDoesNotExistException {
+            String instructorId, boolean omitArchived) throws EntityDoesNotExistException {
         
         Assumption.assertNotNull(ERROR_NULL_PARAMETER, instructorId);
 
-        return coursesLogic.getCoursesDetailsListForInstructor(instructorId);    
+        return coursesLogic.getCoursesDetailsListForInstructor(instructorId, omitArchived);    
     }
     
     /**
@@ -744,7 +746,7 @@ public class Logic {
         
         Assumption.assertNotNull(ERROR_NULL_PARAMETER, googleId);
         
-        return coursesLogic.getCourseSummariesForInstructor(googleId);
+        return coursesLogic.getCourseSummariesForInstructor(googleId, false);
     }
     
     /**

--- a/src/main/java/teammates/logic/api/Logic.java
+++ b/src/main/java/teammates/logic/api/Logic.java
@@ -422,6 +422,13 @@ public class Logic {
         return instructorsLogic.getInstructorsForGoogleId(googleId);
     }
     
+    public List<InstructorAttributes> getInstructorsForGoogleId(String googleId, boolean omitArchived) {
+        
+        Assumption.assertNotNull(ERROR_NULL_PARAMETER, googleId);
+        
+        return instructorsLogic.getInstructorsForGoogleId(googleId, omitArchived);
+    }
+    
     /**
      * Preconditions: <br>
      * * All parameters are non-null. 
@@ -814,9 +821,22 @@ public class Logic {
     public List<CourseAttributes> getCoursesForInstructor(String googleId)
             throws EntityDoesNotExistException {
         
+        return getCoursesForInstructor(googleId, false);
+    }
+    
+    /**
+     * Omits archived courses if omitArchived == true<br>
+     * Preconditions: <br>
+     * * All parameters are non-null.
+     * 
+     * @return Courses the instructor is in.
+     */
+    public List<CourseAttributes> getCoursesForInstructor(String googleId, boolean omitArchived)
+            throws EntityDoesNotExistException {
+        
         Assumption.assertNotNull(ERROR_NULL_PARAMETER, googleId);
     
-        return coursesLogic.getCoursesForInstructor(googleId);
+        return coursesLogic.getCoursesForInstructor(googleId, omitArchived);
     
     }
     
@@ -1400,11 +1420,25 @@ public class Logic {
     public ArrayList<EvaluationAttributes> getEvaluationsListForInstructor(String instructorId) 
             throws EntityDoesNotExistException {
         
+        return getEvaluationsListForInstructor(instructorId, false);
+    }
+    
+    /**
+     * Omits evaluations from archived courses if omitArchived == true<br>
+     * Preconditions: <br>
+     * * All parameters are non-null. <br>
+     * 
+     * @return List of Instructor's evaluations. <br>
+     * Returns an empty list if none found.
+     */
+    public ArrayList<EvaluationAttributes> getEvaluationsListForInstructor(String instructorId, boolean omitArchived) 
+            throws EntityDoesNotExistException {
+        
         Assumption.assertNotNull(ERROR_NULL_PARAMETER, instructorId);
         
         instructorsLogic.verifyInstructorExists(instructorId);
 
-        return evaluationsLogic.getEvaluationsListForInstructor(instructorId);
+        return evaluationsLogic.getEvaluationsListForInstructor(instructorId, omitArchived);
     }
 
     /**
@@ -1724,9 +1758,23 @@ public class Logic {
     public List<FeedbackSessionAttributes>
         getFeedbackSessionsListForInstructor(String googleId) throws EntityDoesNotExistException{
         
+        return getFeedbackSessionsListForInstructor(googleId, false);
+    }
+    
+    /**
+     * Omits feedback sessions from archived courses if omitArchived == true<br>
+     * Preconditions: <br>
+     * * All parameters are non-null. <br>
+     * 
+     * @return List(without details) of Instructor's feedback sessions. <br>
+     * Returns an empty list if none found.
+     */
+    public List<FeedbackSessionAttributes>
+        getFeedbackSessionsListForInstructor(String googleId, boolean omitArchived) throws EntityDoesNotExistException{
+        
         Assumption.assertNotNull(ERROR_NULL_PARAMETER, googleId);
         
-        return feedbackSessionsLogic.getFeedbackSessionsListForInstructor(googleId);
+        return feedbackSessionsLogic.getFeedbackSessionsListForInstructor(googleId, omitArchived);
     }
     
     /**

--- a/src/main/java/teammates/logic/core/CoursesLogic.java
+++ b/src/main/java/teammates/logic/core/CoursesLogic.java
@@ -629,7 +629,6 @@ public class CoursesLogic {
         }
         for (FeedbackSessionAttributes fsb : feedbackSessionList) {
             CourseSummaryBundle courseSummary = courseList.get(fsb.courseId);
-            // TODO: remove null check? to be done after the todo above, to omit archived sessions.
             if (courseSummary != null) {
                 courseSummary.feedbackSessions.add(fsb);
             }

--- a/src/main/java/teammates/logic/core/CoursesLogic.java
+++ b/src/main/java/teammates/logic/core/CoursesLogic.java
@@ -512,7 +512,13 @@ public class CoursesLogic {
 
     public List<CourseAttributes> getCoursesForInstructor(String googleId) throws EntityDoesNotExistException {
 
-        List<InstructorAttributes> instructorList = instructorsLogic.getInstructorsForGoogleId(googleId);
+        return getCoursesForInstructor(googleId, false);
+    }
+    
+    public List<CourseAttributes> getCoursesForInstructor(String googleId, boolean omitArchived)
+            throws EntityDoesNotExistException {
+
+        List<InstructorAttributes> instructorList = instructorsLogic.getInstructorsForGoogleId(googleId, omitArchived);
 
         ArrayList<CourseAttributes> courseList = new ArrayList<CourseAttributes>();
 

--- a/src/main/java/teammates/logic/core/CoursesLogic.java
+++ b/src/main/java/teammates/logic/core/CoursesLogic.java
@@ -525,6 +525,8 @@ public class CoursesLogic {
     
     public List<CourseAttributes> getCoursesForInstructor(List<InstructorAttributes> instructorList)
             throws EntityDoesNotExistException {
+        
+        Assumption.assertNotNull("Supplied parameter was null\n", instructorList);
 
         ArrayList<CourseAttributes> courseList = new ArrayList<CourseAttributes>();
 

--- a/src/main/java/teammates/logic/core/CoursesLogic.java
+++ b/src/main/java/teammates/logic/core/CoursesLogic.java
@@ -584,11 +584,10 @@ public class CoursesLogic {
         // getEvaluationsDetailsForInstructor
         // getFeedbackSessionDetailsForInstructor
         // The above functions make repeated calls to get InstructorAttributes
-        // TODO: omit archived sessions and evaluations
         ArrayList<EvaluationDetailsBundle> evaluationList = 
-                evaluationsLogic.getEvaluationsDetailsForInstructor(instructorId);
+                evaluationsLogic.getEvaluationsDetailsForInstructor(instructorId, omitArchived);
         List<FeedbackSessionDetailsBundle> feedbackSessionList = 
-                feedbackSessionsLogic.getFeedbackSessionDetailsForInstructor(instructorId);
+                feedbackSessionsLogic.getFeedbackSessionDetailsForInstructor(instructorId, omitArchived);
         
         for (EvaluationDetailsBundle edd : evaluationList) {
             CourseDetailsBundle courseSummary = courseList.get(edd.evaluation.courseId);
@@ -617,11 +616,10 @@ public class CoursesLogic {
         // getFeedbackSessionsListForInstructor
         // The above functions make repeated calls to get InstructorAttributes
 
-        // TODO: omit archived sessions and evaluations
         ArrayList<EvaluationAttributes> evaluationList = 
-                evaluationsLogic.getEvaluationsListForInstructor(instructorId);
+                evaluationsLogic.getEvaluationsListForInstructor(instructorId, omitArchived);
         List<FeedbackSessionAttributes> feedbackSessionList = 
-                feedbackSessionsLogic.getFeedbackSessionsListForInstructor(instructorId);
+                feedbackSessionsLogic.getFeedbackSessionsListForInstructor(instructorId, omitArchived);
         
         for (EvaluationAttributes edd : evaluationList) {
             CourseSummaryBundle courseSummary = courseList.get(edd.courseId);

--- a/src/main/java/teammates/logic/core/CoursesLogic.java
+++ b/src/main/java/teammates/logic/core/CoursesLogic.java
@@ -520,6 +520,12 @@ public class CoursesLogic {
 
         List<InstructorAttributes> instructorList = instructorsLogic.getInstructorsForGoogleId(googleId, omitArchived);
 
+        return getCoursesForInstructor(instructorList);
+    }
+    
+    public List<CourseAttributes> getCoursesForInstructor(List<InstructorAttributes> instructorList)
+            throws EntityDoesNotExistException {
+
         ArrayList<CourseAttributes> courseList = new ArrayList<CourseAttributes>();
 
         for (InstructorAttributes instructor : instructorList) {

--- a/src/main/java/teammates/logic/core/EvaluationsLogic.java
+++ b/src/main/java/teammates/logic/core/EvaluationsLogic.java
@@ -191,9 +191,15 @@ public class EvaluationsLogic {
     public ArrayList<EvaluationAttributes> getEvaluationsListForInstructor(
             String instructorId, boolean omitArchived) throws EntityDoesNotExistException {
         
-        ArrayList<EvaluationAttributes> evaluationSummaryList = new ArrayList<EvaluationAttributes>();
-
         List<InstructorAttributes> instructorList = instructorsLogic.getInstructorsForGoogleId(instructorId, omitArchived);
+        
+        return getEvaluationsListForInstructor(instructorList);
+    }
+    
+    public ArrayList<EvaluationAttributes> getEvaluationsListForInstructor(
+            List<InstructorAttributes> instructorList) throws EntityDoesNotExistException {
+        
+        ArrayList<EvaluationAttributes> evaluationSummaryList = new ArrayList<EvaluationAttributes>();
         for (InstructorAttributes id : instructorList) {
             evaluationSummaryList.addAll(getEvaluationsForCourse(id.courseId));
         }

--- a/src/main/java/teammates/logic/core/EvaluationsLogic.java
+++ b/src/main/java/teammates/logic/core/EvaluationsLogic.java
@@ -199,6 +199,8 @@ public class EvaluationsLogic {
     public ArrayList<EvaluationAttributes> getEvaluationsListForInstructor(
             List<InstructorAttributes> instructorList) throws EntityDoesNotExistException {
         
+        Assumption.assertNotNull("Supplied parameter was null\n", instructorList);
+        
         ArrayList<EvaluationAttributes> evaluationSummaryList = new ArrayList<EvaluationAttributes>();
         for (InstructorAttributes id : instructorList) {
             evaluationSummaryList.addAll(getEvaluationsForCourse(id.courseId));

--- a/src/main/java/teammates/logic/core/EvaluationsLogic.java
+++ b/src/main/java/teammates/logic/core/EvaluationsLogic.java
@@ -167,9 +167,15 @@ public class EvaluationsLogic {
     public ArrayList<EvaluationDetailsBundle> getEvaluationsDetailsForInstructor(
             String instructorId) throws EntityDoesNotExistException {
         
+        return getEvaluationsDetailsForInstructor(instructorId, false);
+    }
+    
+    public ArrayList<EvaluationDetailsBundle> getEvaluationsDetailsForInstructor(
+            String instructorId, boolean omitArchived) throws EntityDoesNotExistException {
+        
         ArrayList<EvaluationDetailsBundle> evaluationSummaryList = new ArrayList<EvaluationDetailsBundle>();
 
-        List<InstructorAttributes> instructorList = instructorsLogic.getInstructorsForGoogleId(instructorId);
+        List<InstructorAttributes> instructorList = instructorsLogic.getInstructorsForGoogleId(instructorId, omitArchived);
         for (InstructorAttributes id : instructorList) {
             evaluationSummaryList.addAll(getEvaluationsDetailsForCourse(id.courseId));
         }
@@ -179,9 +185,15 @@ public class EvaluationsLogic {
     public ArrayList<EvaluationAttributes> getEvaluationsListForInstructor(
             String instructorId) throws EntityDoesNotExistException {
         
+        return getEvaluationsListForInstructor(instructorId, false);
+    }
+    
+    public ArrayList<EvaluationAttributes> getEvaluationsListForInstructor(
+            String instructorId, boolean omitArchived) throws EntityDoesNotExistException {
+        
         ArrayList<EvaluationAttributes> evaluationSummaryList = new ArrayList<EvaluationAttributes>();
 
-        List<InstructorAttributes> instructorList = instructorsLogic.getInstructorsForGoogleId(instructorId);
+        List<InstructorAttributes> instructorList = instructorsLogic.getInstructorsForGoogleId(instructorId, omitArchived);
         for (InstructorAttributes id : instructorList) {
             evaluationSummaryList.addAll(getEvaluationsForCourse(id.courseId));
         }

--- a/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
@@ -170,9 +170,27 @@ public class FeedbackSessionsLogic {
             String googleId)
             throws EntityDoesNotExistException {
 
+        return getFeedbackSessionDetailsForInstructor(googleId, false);
+    }
+    
+    /**
+     * Returns a {@code List} of all feedback sessions bundled with their
+     * response statistics for a instructor given by his googleId.<br>
+     * Does not return private sessions unless the instructor is the creator.
+     * <br>
+     * Omits archived sessions if omitArchived == true
+     * 
+     * @param googleId
+     * @return
+     * @throws EntityDoesNotExistException
+     */
+    public List<FeedbackSessionDetailsBundle> getFeedbackSessionDetailsForInstructor(
+            String googleId, boolean omitArchived)
+            throws EntityDoesNotExistException {
+
         List<FeedbackSessionDetailsBundle> fsDetails = new ArrayList<FeedbackSessionDetailsBundle>();
         List<InstructorAttributes> instructors =
-                instructorsLogic.getInstructorsForGoogleId(googleId);
+                instructorsLogic.getInstructorsForGoogleId(googleId, omitArchived);
 
         for (InstructorAttributes instructor : instructors) {
             fsDetails.addAll(getFeedbackSessionDetailsForCourse(
@@ -195,9 +213,27 @@ public class FeedbackSessionsLogic {
             String googleId)
             throws EntityDoesNotExistException {
 
+        return getFeedbackSessionsListForInstructor(googleId, false);
+    }
+    
+    /**
+     * Returns a {@code List} of all feedback sessions WITHOUT their response
+     * statistics for a instructor given by his googleId.<br>
+     * Does not return private sessions unless the instructor is the creator.
+     * <br>
+     * Omits sessions from archived courses if omitArchived == true
+     * 
+     * @param googleId
+     * @return
+     * @throws EntityDoesNotExistException
+     */
+    public List<FeedbackSessionAttributes> getFeedbackSessionsListForInstructor(
+            String googleId, boolean omitArchived)
+            throws EntityDoesNotExistException {
+
         List<FeedbackSessionAttributes> fsList = new ArrayList<FeedbackSessionAttributes>();
         List<InstructorAttributes> instructors =
-                instructorsLogic.getInstructorsForGoogleId(googleId);
+                instructorsLogic.getInstructorsForGoogleId(googleId, omitArchived);
 
         for (InstructorAttributes instructor : instructors) {
             fsList.addAll(getFeedbackSessionsListForCourse(instructor.courseId,

--- a/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
@@ -231,11 +231,20 @@ public class FeedbackSessionsLogic {
             String googleId, boolean omitArchived)
             throws EntityDoesNotExistException {
 
-        List<FeedbackSessionAttributes> fsList = new ArrayList<FeedbackSessionAttributes>();
-        List<InstructorAttributes> instructors =
+        List<InstructorAttributes> instructorList =
                 instructorsLogic.getInstructorsForGoogleId(googleId, omitArchived);
 
-        for (InstructorAttributes instructor : instructors) {
+
+        return getFeedbackSessionsListForInstructor(instructorList);
+    }
+    
+    public List<FeedbackSessionAttributes> getFeedbackSessionsListForInstructor(
+            List<InstructorAttributes> instructorList)
+            throws EntityDoesNotExistException {
+
+        List<FeedbackSessionAttributes> fsList = new ArrayList<FeedbackSessionAttributes>();
+        
+        for (InstructorAttributes instructor : instructorList) {
             fsList.addAll(getFeedbackSessionsListForCourse(instructor.courseId,
                     instructor.email));
         }

--- a/src/main/java/teammates/logic/core/InstructorsLogic.java
+++ b/src/main/java/teammates/logic/core/InstructorsLogic.java
@@ -113,10 +113,15 @@ public class InstructorsLogic {
         
         return instructorsDb.getInstructorsForCourse(courseId);
     }
-
+    
     public List<InstructorAttributes> getInstructorsForGoogleId(String googleId) {
         
-        return instructorsDb.getInstructorsForGoogleId(googleId);
+        return getInstructorsForGoogleId(googleId, false);
+    }
+
+    public List<InstructorAttributes> getInstructorsForGoogleId(String googleId, boolean omitArchived) {
+        
+        return instructorsDb.getInstructorsForGoogleId(googleId, omitArchived);
     }
     
     public String getKeyForInstructor(String courseId, String email)
@@ -374,7 +379,7 @@ public class InstructorsLogic {
     }
 
     public void deleteInstructorsForGoogleIdAndCascade(String googleId) {
-        List<InstructorAttributes> instructors = instructorsDb.getInstructorsForGoogleId(googleId);
+        List<InstructorAttributes> instructors = instructorsDb.getInstructorsForGoogleId(googleId, false);
         
         //Cascade delete instructors
         for (InstructorAttributes instructor : instructors) {

--- a/src/main/java/teammates/storage/api/InstructorsDb.java
+++ b/src/main/java/teammates/storage/api/InstructorsDb.java
@@ -516,7 +516,9 @@ public class InstructorsDb extends EntitiesDb{
      */
     private List<Instructor> getInstructorEntitiesForGoogleId(String googleId, boolean omitArchived) {
         
-        if (omitArchived) {
+        if (!omitArchived) {
+            return getInstructorEntitiesForGoogleId(googleId);
+        } else {
             Query q = getPM().newQuery(Instructor.class);
             q.declareParameters("String googleIdParam, boolean omitArchivedParam");
             // Omit archived == true, get instructors with isArchived != true
@@ -524,11 +526,7 @@ public class InstructorsDb extends EntitiesDb{
             
             @SuppressWarnings("unchecked")
             List<Instructor> instructorList = (List<Instructor>) q.execute(googleId, omitArchived);
-            System.out.println("1- " + instructorList.size());
-            System.out.println("2- " + getInstructorEntitiesForGoogleId(googleId).size());
             return instructorList;
-        } else {
-            return getInstructorEntitiesForGoogleId(googleId);
         }
     }
     

--- a/src/main/java/teammates/storage/api/InstructorsDb.java
+++ b/src/main/java/teammates/storage/api/InstructorsDb.java
@@ -206,13 +206,14 @@ public class InstructorsDb extends EntitiesDb{
     /**
      * Preconditions: <br>
      *  * All parameters are non-null.
+     *  
      * @return empty list if no matching objects. 
      */
-    public List<InstructorAttributes> getInstructorsForGoogleId(String googleId) {
+    public List<InstructorAttributes> getInstructorsForGoogleId(String googleId, boolean omitArchived) {
         
         Assumption.assertNotNull(Const.StatusCodes.DBLEVEL_NULL_INPUT, googleId);
         
-        List<Instructor> instructorList = getInstructorEntitiesForGoogleId(googleId);
+        List<Instructor> instructorList = getInstructorEntitiesForGoogleId(googleId, omitArchived);
         
         List<InstructorAttributes> instructorDataList = new ArrayList<InstructorAttributes>();
         for (Instructor i : instructorList) {
@@ -502,10 +503,33 @@ public class InstructorsDb extends EntitiesDb{
         q.declareParameters("String googleIdParam");
         q.setFilter("googleId == googleIdParam");
         
+        
         @SuppressWarnings("unchecked")
         List<Instructor> instructorList = (List<Instructor>) q.execute(googleId);
         
         return instructorList;
+    }
+    
+    /**
+     * Omits instructors with isArchived == omitArchived.
+     * This means that the corresponding course is archived by the instructor.
+     */
+    private List<Instructor> getInstructorEntitiesForGoogleId(String googleId, boolean omitArchived) {
+        
+        if (omitArchived) {
+            Query q = getPM().newQuery(Instructor.class);
+            q.declareParameters("String googleIdParam, boolean omitArchivedParam");
+            // Omit archived == true, get instructors with isArchived != true
+            q.setFilter("googleId == googleIdParam && isArchived != omitArchivedParam");
+            
+            @SuppressWarnings("unchecked")
+            List<Instructor> instructorList = (List<Instructor>) q.execute(googleId, omitArchived);
+            System.out.println("1- " + instructorList.size());
+            System.out.println("2- " + getInstructorEntitiesForGoogleId(googleId).size());
+            return instructorList;
+        } else {
+            return getInstructorEntitiesForGoogleId(googleId);
+        }
     }
     
     private List<Instructor> getInstructorEntitiesForEmail(String email) {

--- a/src/main/java/teammates/storage/entity/Instructor.java
+++ b/src/main/java/teammates/storage/entity/Instructor.java
@@ -36,7 +36,6 @@ public class Instructor {
     
     /** new attribute. Default value: Old Entity--null  New Entity--false*/
     @Persistent
-    @Extension(vendorName = "datanucleus", key = "gae.unindexed", value = "true")
     private Boolean isArchived;
 
     /** The instructor's name used for this course. */

--- a/src/main/java/teammates/ui/controller/InstructorFeedbackAddAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbackAddAction.java
@@ -85,14 +85,11 @@ public class InstructorFeedbackAddAction extends InstructorFeedbacksPageAction {
         // if isError == true, (an exception occurred above)
         
 
-        data.instructors = loadCourseInstructorMap();
-        // Get courseDetailsBundles
         boolean omitArchived = true;
-        courseDetailsList = logic.getCourseDetailsListForInstructor(account.googleId, omitArchived);
-        
-        data.courses = loadCoursesList();
-        data.existingEvalSessions = loadEvaluationsList();
-        data.existingFeedbackSessions = loadFeedbackSessionsList();
+        data.instructors = loadCourseInstructorMap(omitArchived);
+        data.courses = loadCoursesList(omitArchived);
+        data.existingEvalSessions = loadEvaluationsList(omitArchived);
+        data.existingFeedbackSessions = loadFeedbackSessionsList(omitArchived);
         
         if (data.existingFeedbackSessions.size() == 0) {
             statusToUser.add(Const.StatusMessages.FEEDBACK_SESSION_ADD_DB_INCONSISTENCY);

--- a/src/main/java/teammates/ui/controller/InstructorFeedbackAddAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbackAddAction.java
@@ -87,9 +87,10 @@ public class InstructorFeedbackAddAction extends InstructorFeedbacksPageAction {
 
         boolean omitArchived = true;
         data.instructors = loadCourseInstructorMap(omitArchived);
-        data.courses = loadCoursesList(omitArchived);
-        data.existingEvalSessions = loadEvaluationsList(omitArchived);
-        data.existingFeedbackSessions = loadFeedbackSessionsList(omitArchived);
+        List<InstructorAttributes> instructorList = new ArrayList<InstructorAttributes>(data.instructors.values());
+        data.courses = loadCoursesList(instructorList);
+        data.existingEvalSessions = loadEvaluationsList(instructorList);
+        data.existingFeedbackSessions = loadFeedbackSessionsList(instructorList);
         
         if (data.existingFeedbackSessions.size() == 0) {
             statusToUser.add(Const.StatusMessages.FEEDBACK_SESSION_ADD_DB_INCONSISTENCY);

--- a/src/main/java/teammates/ui/controller/InstructorFeedbackAddAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbackAddAction.java
@@ -89,9 +89,7 @@ public class InstructorFeedbackAddAction extends InstructorFeedbacksPageAction {
         // Get courseDetailsBundles
         boolean omitArchived = true;
         courseDetailsList = logic.getCourseDetailsListForInstructor(account.googleId, omitArchived);
-        if (omitArchived) {
-            // omitArchivedCourses(data.instructors);
-        }
+        
         data.courses = loadCoursesList();
         data.existingEvalSessions = loadEvaluationsList();
         data.existingFeedbackSessions = loadFeedbackSessionsList();

--- a/src/main/java/teammates/ui/controller/InstructorFeedbackAddAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbackAddAction.java
@@ -88,9 +88,9 @@ public class InstructorFeedbackAddAction extends InstructorFeedbacksPageAction {
         data.instructors = loadCourseInstructorMap();
         // Get courseDetailsBundles
         boolean omitArchived = true;
-        courseDetailsList = logic.getCourseDetailsListForInstructor(account.googleId);
+        courseDetailsList = logic.getCourseDetailsListForInstructor(account.googleId, omitArchived);
         if (omitArchived) {
-            omitArchivedCourses(data.instructors);
+            // omitArchivedCourses(data.instructors);
         }
         data.courses = loadCoursesList();
         data.existingEvalSessions = loadEvaluationsList();

--- a/src/main/java/teammates/ui/controller/InstructorFeedbackCopyAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbackCopyAction.java
@@ -60,14 +60,12 @@ public class InstructorFeedbackCopyAction extends InstructorFeedbacksPageAction 
         
         // if isError == true, (an exception occurred above)
 
-        data.instructors = loadCourseInstructorMap();
-        // Get courseDetailsBundles
+
         boolean omitArchived = true;
-        courseDetailsList = logic.getCourseDetailsListForInstructor(account.googleId, omitArchived);
-        
-        data.courses = loadCoursesList();
-        data.existingEvalSessions = loadEvaluationsList();
-        data.existingFeedbackSessions = loadFeedbackSessionsList();
+        data.instructors = loadCourseInstructorMap(omitArchived);
+        data.courses = loadCoursesList(omitArchived);
+        data.existingEvalSessions = loadEvaluationsList(omitArchived);
+        data.existingFeedbackSessions = loadFeedbackSessionsList(omitArchived);
         
         if (data.existingFeedbackSessions.size() == 0) {
             statusToUser.add(Const.StatusMessages.FEEDBACK_SESSION_ADD_DB_INCONSISTENCY);

--- a/src/main/java/teammates/ui/controller/InstructorFeedbackCopyAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbackCopyAction.java
@@ -64,9 +64,7 @@ public class InstructorFeedbackCopyAction extends InstructorFeedbacksPageAction 
         // Get courseDetailsBundles
         boolean omitArchived = true;
         courseDetailsList = logic.getCourseDetailsListForInstructor(account.googleId, omitArchived);
-        if (omitArchived) {
-            // omitArchivedCourses(data.instructors);
-        }
+        
         data.courses = loadCoursesList();
         data.existingEvalSessions = loadEvaluationsList();
         data.existingFeedbackSessions = loadFeedbackSessionsList();

--- a/src/main/java/teammates/ui/controller/InstructorFeedbackCopyAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbackCopyAction.java
@@ -1,5 +1,8 @@
 package teammates.ui.controller;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import teammates.common.datatransfer.EvaluationAttributes;
 import teammates.common.datatransfer.FeedbackSessionAttributes;
 import teammates.common.datatransfer.InstructorAttributes;
@@ -63,9 +66,10 @@ public class InstructorFeedbackCopyAction extends InstructorFeedbacksPageAction 
 
         boolean omitArchived = true;
         data.instructors = loadCourseInstructorMap(omitArchived);
-        data.courses = loadCoursesList(omitArchived);
-        data.existingEvalSessions = loadEvaluationsList(omitArchived);
-        data.existingFeedbackSessions = loadFeedbackSessionsList(omitArchived);
+        List<InstructorAttributes> instructorList = new ArrayList<InstructorAttributes>(data.instructors.values());
+        data.courses = loadCoursesList(instructorList);
+        data.existingEvalSessions = loadEvaluationsList(instructorList);
+        data.existingFeedbackSessions = loadFeedbackSessionsList(instructorList);
         
         if (data.existingFeedbackSessions.size() == 0) {
             statusToUser.add(Const.StatusMessages.FEEDBACK_SESSION_ADD_DB_INCONSISTENCY);

--- a/src/main/java/teammates/ui/controller/InstructorFeedbackCopyAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbackCopyAction.java
@@ -63,9 +63,9 @@ public class InstructorFeedbackCopyAction extends InstructorFeedbacksPageAction 
         data.instructors = loadCourseInstructorMap();
         // Get courseDetailsBundles
         boolean omitArchived = true;
-        courseDetailsList = logic.getCourseDetailsListForInstructor(account.googleId);
+        courseDetailsList = logic.getCourseDetailsListForInstructor(account.googleId, omitArchived);
         if (omitArchived) {
-            omitArchivedCourses(data.instructors);
+            // omitArchivedCourses(data.instructors);
         }
         data.courses = loadCoursesList();
         data.existingEvalSessions = loadEvaluationsList();

--- a/src/main/java/teammates/ui/controller/InstructorFeedbacksPageAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbacksPageAction.java
@@ -40,8 +40,9 @@ public class InstructorFeedbacksPageAction extends Action {
         // HashMap with courseId as key and InstructorAttributes as value
         data.instructors = loadCourseInstructorMap(omitArchived);
         
+        List<InstructorAttributes> instructorList = new ArrayList<InstructorAttributes>(data.instructors.values());
+        data.courses = loadCoursesList(instructorList);
         
-        data.courses = loadCoursesList(omitArchived);
         if (data.courses.size() == 0) {
             statusToUser.add(Const.StatusMessages.COURSE_EMPTY_IN_EVALUATION.replace("${user}", "?user="+account.googleId));
         }
@@ -50,8 +51,8 @@ public class InstructorFeedbacksPageAction extends Action {
             data.existingEvalSessions = new ArrayList<EvaluationAttributes>();
             data.existingFeedbackSessions = new ArrayList<FeedbackSessionAttributes>();
         } else {
-            data.existingEvalSessions = loadEvaluationsList(omitArchived);
-            data.existingFeedbackSessions = loadFeedbackSessionsList(omitArchived);
+            data.existingEvalSessions = loadEvaluationsList(instructorList);
+            data.existingFeedbackSessions = loadFeedbackSessionsList(instructorList);
             if (data.existingFeedbackSessions.isEmpty() &&
                 data.existingEvalSessions.isEmpty()) {
                 statusToUser.add(Const.StatusMessages.EVALUATION_EMPTY);
@@ -68,24 +69,24 @@ public class InstructorFeedbacksPageAction extends Action {
         return createShowPageResult(Const.ViewURIs.INSTRUCTOR_FEEDBACKS, data);
     }
     
-    protected List<FeedbackSessionAttributes> loadFeedbackSessionsList(boolean omitArchived)
+    protected List<FeedbackSessionAttributes> loadFeedbackSessionsList(List<InstructorAttributes> instructorList)
             throws EntityDoesNotExistException {
         
-        List<FeedbackSessionAttributes> sessions =  logic.getFeedbackSessionsListForInstructor(account.googleId, omitArchived);
+        List<FeedbackSessionAttributes> sessions =  logic.getFeedbackSessionsListForInstructor(instructorList);
         return sessions;
     }
 
-    protected List<EvaluationAttributes> loadEvaluationsList(boolean omitArchived)
+    protected List<EvaluationAttributes> loadEvaluationsList(List<InstructorAttributes> instructorList)
             throws EntityDoesNotExistException {
-        List<EvaluationAttributes> evaluations =  logic.getEvaluationsListForInstructor(account.googleId, omitArchived);
+        List<EvaluationAttributes> evaluations =  logic.getEvaluationsListForInstructor(instructorList);
         
         return evaluations;
     }
     
-    protected List<CourseAttributes> loadCoursesList(boolean omitArchived)
+    protected List<CourseAttributes> loadCoursesList(List<InstructorAttributes> instructorList)
             throws EntityDoesNotExistException {
         
-        List<CourseAttributes> courses = logic.getCoursesForInstructor(account.googleId, omitArchived); 
+        List<CourseAttributes> courses = logic.getCoursesForInstructor(instructorList);
         
         Collections.sort(courses, new Comparator<CourseAttributes>() {
             @Override

--- a/src/main/java/teammates/ui/controller/InstructorFeedbacksPageAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbacksPageAction.java
@@ -45,9 +45,9 @@ public class InstructorFeedbacksPageAction extends Action {
         
         // Get courseDetailsBundles
         boolean omitArchived = true; // TODO: implement as a request parameter
-        courseDetailsList = logic.getCourseDetailsListForInstructor(account.googleId);
+        courseDetailsList = logic.getCourseDetailsListForInstructor(account.googleId, omitArchived);
         if (omitArchived) {
-            omitArchivedCourses(data.instructors);
+            // omitArchivedCourses(data.instructors);
         }
         
         data.courses = loadCoursesList();

--- a/src/main/java/teammates/ui/controller/InstructorFeedbacksPageAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbacksPageAction.java
@@ -14,7 +14,6 @@ import teammates.common.datatransfer.InstructorAttributes;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.util.Const;
 import teammates.logic.api.GateKeeper;
-import teammates.logic.api.Logic;
 
 public class InstructorFeedbacksPageAction extends Action {
 
@@ -46,9 +45,6 @@ public class InstructorFeedbacksPageAction extends Action {
         // Get courseDetailsBundles
         boolean omitArchived = true; // TODO: implement as a request parameter
         courseDetailsList = logic.getCourseDetailsListForInstructor(account.googleId, omitArchived);
-        if (omitArchived) {
-            // omitArchivedCourses(data.instructors);
-        }
         
         data.courses = loadCoursesList();
         if (data.courses.size() == 0) {
@@ -131,23 +127,4 @@ public class InstructorFeedbacksPageAction extends Action {
         }
         return courseInstructorMap;
     }
-    
-    /**
-     * Removes archived courses from courseDetailsList
-     * @param instructors 
-     */
-    protected void omitArchivedCourses(HashMap<String, InstructorAttributes> instructors) {
-        HashMap<String, CourseDetailsBundle> newCourseDetailsList = new HashMap<String, CourseDetailsBundle>();
-        for (CourseDetailsBundle courseDetails : courseDetailsList.values()) {
-            CourseAttributes course = courseDetails.course;
-            String courseId = course.id;
-            InstructorAttributes instructor = instructors.get(courseId);
-            
-            if (!Logic.isCourseArchived(course, instructor)) {
-                newCourseDetailsList.put(courseId, courseDetails);
-            }
-        }
-        courseDetailsList = newCourseDetailsList;
-    }
-    
 }

--- a/src/main/java/teammates/ui/controller/InstructorHomePageAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorHomePageAction.java
@@ -36,7 +36,8 @@ public class InstructorHomePageAction extends Action {
             data.sortCriteria = Const.DEFAULT_SORT_CRITERIA;
         }
         
-        HashMap<String, CourseSummaryBundle> courses = logic.getCourseSummariesWithoutStatsForInstructor(account.googleId);
+        boolean omitArchived = true;
+        HashMap<String, CourseSummaryBundle> courses = logic.getCourseSummariesWithoutStatsForInstructor(account.googleId, omitArchived);
         
         
         ArrayList<CourseSummaryBundle> courseList = new ArrayList<CourseSummaryBundle>(courses.values());

--- a/src/test/java/teammates/test/cases/logic/CoursesLogicTest.java
+++ b/src/test/java/teammates/test/cases/logic/CoursesLogicTest.java
@@ -825,8 +825,6 @@ public class CoursesLogicTest extends BaseComponentTestCase {
 
     public void testGetCourseSummariesForInstructor() throws Exception {
 
-        // TODO: test omitting archived courses
-        
         ______TS("Instructor with 2 courses");
     
         InstructorAttributes instructor = dataBundle.instructors.get("instructor3OfCourse1");
@@ -836,6 +834,14 @@ public class CoursesLogicTest extends BaseComponentTestCase {
             // check if course belongs to this instructor
             assertTrue(InstructorsLogic.inst().isGoogleIdOfInstructorOfCourse(instructor.googleId, cdd.course.id));
         }
+        
+        ______TS("Instructor with 1 archived, 1 unarchived course");
+        
+        InstructorsLogic.inst().setArchiveStatusOfInstructor(instructor.googleId, "idOfTypicalCourse1", true);
+        courseList = coursesLogic.getCourseSummariesForInstructor(instructor.googleId, true);
+        assertEquals(1, courseList.size());
+        InstructorsLogic.inst().setArchiveStatusOfInstructor(instructor.googleId, "idOfTypicalCourse1", false);
+        
     
         ______TS("Instructor with 0 courses");
         courseList = coursesLogic.getCourseSummariesForInstructor("instructorWithoutCourses", false);
@@ -864,8 +870,6 @@ public class CoursesLogicTest extends BaseComponentTestCase {
 
     public void testGetCourseDetailsListForInstructor() throws Exception {
 
-        // TODO: test omitting archived courses
-        
         ______TS("Typical case");
     
         HashMap<String, CourseDetailsBundle> courseListForInstructor = coursesLogic
@@ -908,6 +912,14 @@ public class CoursesLogicTest extends BaseComponentTestCase {
         assertEquals(0,
                 courseListForInstructor.get("idOfCourseNoEvals").evaluations
                         .size());
+        
+        ______TS("Instructor has an archived course");
+
+        InstructorsLogic.inst().setArchiveStatusOfInstructor("idOfInstructor4", "idOfCourseNoEvals", true);
+        courseListForInstructor = coursesLogic
+                .getCoursesDetailsListForInstructor("idOfInstructor4", true);
+        assertEquals(0, courseListForInstructor.size());
+        InstructorsLogic.inst().setArchiveStatusOfInstructor("idOfInstructor4", "idOfCourseNoEvals", false);
     
         ______TS("Instructor with 0 courses");
         
@@ -936,8 +948,6 @@ public class CoursesLogicTest extends BaseComponentTestCase {
 
     public void testGetCoursesSummaryWithoutStatsForInstructor() throws Exception {
         
-        // TODO: test omitting archived courses
-
         ______TS("Typical case");
 
         HashMap<String, CourseSummaryBundle> courseListForInstructor = coursesLogic
@@ -980,6 +990,15 @@ public class CoursesLogicTest extends BaseComponentTestCase {
         assertEquals(0,
                 courseListForInstructor.get("idOfCourseNoEvals").evaluations
                         .size());
+        
+        ______TS("Instructor has an archived course");
+
+        InstructorsLogic.inst().setArchiveStatusOfInstructor("idOfInstructor4", "idOfCourseNoEvals", true);
+        courseListForInstructor = coursesLogic
+                .getCoursesSummaryWithoutStatsForInstructor("idOfInstructor4", true);
+        assertEquals(0, courseListForInstructor.size());
+        InstructorsLogic.inst().setArchiveStatusOfInstructor("idOfInstructor4", "idOfCourseNoEvals", true);
+        
     
         ______TS("Instructor with 0 courses");
         

--- a/src/test/java/teammates/test/cases/logic/CoursesLogicTest.java
+++ b/src/test/java/teammates/test/cases/logic/CoursesLogicTest.java
@@ -169,7 +169,14 @@ public class CoursesLogicTest extends BaseComponentTestCase {
         ______TS("Null parameter");
     
         try {
-            coursesLogic.getCoursesForInstructor(null);
+            coursesLogic.getCoursesForInstructor((String) null);
+            signalFailureToDetectException();
+        } catch (AssertionError e) {
+            assertEquals("Supplied parameter was null\n", e.getMessage());
+        }
+        
+        try {
+            coursesLogic.getCoursesForInstructor((List<InstructorAttributes>) null);
             signalFailureToDetectException();
         } catch (AssertionError e) {
             assertEquals("Supplied parameter was null\n", e.getMessage());

--- a/src/test/java/teammates/test/cases/logic/CoursesLogicTest.java
+++ b/src/test/java/teammates/test/cases/logic/CoursesLogicTest.java
@@ -825,10 +825,12 @@ public class CoursesLogicTest extends BaseComponentTestCase {
 
     public void testGetCourseSummariesForInstructor() throws Exception {
 
+        // TODO: test omitting archived courses
+        
         ______TS("Instructor with 2 courses");
     
         InstructorAttributes instructor = dataBundle.instructors.get("instructor3OfCourse1");
-        HashMap<String, CourseDetailsBundle> courseList = coursesLogic.getCourseSummariesForInstructor(instructor.googleId);
+        HashMap<String, CourseDetailsBundle> courseList = coursesLogic.getCourseSummariesForInstructor(instructor.googleId, false);
         assertEquals(2, courseList.size());
         for (CourseDetailsBundle cdd : courseList.values()) {
             // check if course belongs to this instructor
@@ -836,13 +838,13 @@ public class CoursesLogicTest extends BaseComponentTestCase {
         }
     
         ______TS("Instructor with 0 courses");
-        courseList = coursesLogic.getCourseSummariesForInstructor("instructorWithoutCourses");
+        courseList = coursesLogic.getCourseSummariesForInstructor("instructorWithoutCourses", false);
         assertEquals(0, courseList.size());
    
         ______TS("Non-existent instructor");
     
         try {
-            coursesLogic.getCourseSummariesForInstructor("non-existent-instructor");
+            coursesLogic.getCourseSummariesForInstructor("non-existent-instructor", false);
             signalFailureToDetectException();
         } catch (EntityDoesNotExistException e) {
             AssertHelper.assertContains("does not exist",
@@ -852,7 +854,7 @@ public class CoursesLogicTest extends BaseComponentTestCase {
         ______TS("Null parameter");
     
         try {
-            coursesLogic.getCourseSummariesForInstructor(null);
+            coursesLogic.getCourseSummariesForInstructor(null, false);
             signalFailureToDetectException();
         } catch (AssertionError e) {
             assertEquals("Supplied parameter was null\n", e.getMessage());
@@ -862,10 +864,12 @@ public class CoursesLogicTest extends BaseComponentTestCase {
 
     public void testGetCourseDetailsListForInstructor() throws Exception {
 
+        // TODO: test omitting archived courses
+        
         ______TS("Typical case");
     
         HashMap<String, CourseDetailsBundle> courseListForInstructor = coursesLogic
-                .getCoursesDetailsListForInstructor("idOfInstructor3");
+                .getCoursesDetailsListForInstructor("idOfInstructor3", false);
         assertEquals(2, courseListForInstructor.size());
         String course1Id = "idOfTypicalCourse1";
     
@@ -899,7 +903,7 @@ public class CoursesLogicTest extends BaseComponentTestCase {
         ______TS("Instructor has a course with 0 evaluations");
 
         courseListForInstructor = coursesLogic
-                .getCoursesDetailsListForInstructor("idOfInstructor4");
+                .getCoursesDetailsListForInstructor("idOfInstructor4", false);
         assertEquals(1, courseListForInstructor.size());
         assertEquals(0,
                 courseListForInstructor.get("idOfCourseNoEvals").evaluations
@@ -907,13 +911,13 @@ public class CoursesLogicTest extends BaseComponentTestCase {
     
         ______TS("Instructor with 0 courses");
         
-        courseListForInstructor = coursesLogic.getCoursesDetailsListForInstructor("instructorWithoutCourses");
+        courseListForInstructor = coursesLogic.getCoursesDetailsListForInstructor("instructorWithoutCourses", false);
         assertEquals(0, courseListForInstructor.size());
    
         ______TS("Non-existent instructor");
     
         try {
-            coursesLogic.getCoursesDetailsListForInstructor("non-existent-instructor");
+            coursesLogic.getCoursesDetailsListForInstructor("non-existent-instructor", false);
             signalFailureToDetectException();
         } catch (EntityDoesNotExistException e) {
             AssertHelper.assertContains("does not exist",
@@ -923,7 +927,7 @@ public class CoursesLogicTest extends BaseComponentTestCase {
         ______TS("Null parameter");
     
         try {
-            coursesLogic.getCoursesDetailsListForInstructor(null);
+            coursesLogic.getCoursesDetailsListForInstructor(null, false);
             signalFailureToDetectException();
         } catch (AssertionError e) {
             assertEquals("Supplied parameter was null\n", e.getMessage());
@@ -931,11 +935,13 @@ public class CoursesLogicTest extends BaseComponentTestCase {
     }
 
     public void testGetCoursesSummaryWithoutStatsForInstructor() throws Exception {
+        
+        // TODO: test omitting archived courses
 
         ______TS("Typical case");
 
         HashMap<String, CourseSummaryBundle> courseListForInstructor = coursesLogic
-                .getCoursesSummaryWithoutStatsForInstructor("idOfInstructor3");
+                .getCoursesSummaryWithoutStatsForInstructor("idOfInstructor3", false);
         assertEquals(2, courseListForInstructor.size());
         String course1Id = "idOfTypicalCourse1";
     
@@ -969,7 +975,7 @@ public class CoursesLogicTest extends BaseComponentTestCase {
         ______TS("Instructor has a course with 0 evaluations");
 
         courseListForInstructor = coursesLogic
-                .getCoursesSummaryWithoutStatsForInstructor("idOfInstructor4");
+                .getCoursesSummaryWithoutStatsForInstructor("idOfInstructor4", false);
         assertEquals(1, courseListForInstructor.size());
         assertEquals(0,
                 courseListForInstructor.get("idOfCourseNoEvals").evaluations
@@ -977,13 +983,13 @@ public class CoursesLogicTest extends BaseComponentTestCase {
     
         ______TS("Instructor with 0 courses");
         
-        courseListForInstructor = coursesLogic.getCoursesSummaryWithoutStatsForInstructor("instructorWithoutCourses");
+        courseListForInstructor = coursesLogic.getCoursesSummaryWithoutStatsForInstructor("instructorWithoutCourses", false);
         assertEquals(0, courseListForInstructor.size());
    
         ______TS("Non-existent instructor");
     
         try {
-            coursesLogic.getCoursesSummaryWithoutStatsForInstructor("non-existent-instructor");
+            coursesLogic.getCoursesSummaryWithoutStatsForInstructor("non-existent-instructor", false);
             signalFailureToDetectException();
         } catch (EntityDoesNotExistException e) {
             AssertHelper.assertContains("does not exist",
@@ -993,7 +999,7 @@ public class CoursesLogicTest extends BaseComponentTestCase {
         ______TS("Null parameter");
     
         try {
-            coursesLogic.getCoursesSummaryWithoutStatsForInstructor(null);
+            coursesLogic.getCoursesSummaryWithoutStatsForInstructor(null, false);
             signalFailureToDetectException();
         } catch (AssertionError e) {
             assertEquals("Supplied parameter was null\n", e.getMessage());

--- a/src/test/java/teammates/test/cases/logic/CoursesLogicTest.java
+++ b/src/test/java/teammates/test/cases/logic/CoursesLogicTest.java
@@ -150,7 +150,14 @@ public class CoursesLogicTest extends BaseComponentTestCase {
         List<CourseAttributes> courses = coursesLogic.getCoursesForInstructor(instructorId);
 
         assertEquals(2, courses.size());
-
+        
+        ______TS("omit archived courses");
+        
+        InstructorsLogic.inst().setArchiveStatusOfInstructor(instructorId, courses.get(0).id, true);
+        courses = coursesLogic.getCoursesForInstructor(instructorId, true);
+        assertEquals(1, courses.size());
+        InstructorsLogic.inst().setArchiveStatusOfInstructor(instructorId, courses.get(0).id, false);
+                
         ______TS("boundary: instructor without any courses");
         
         instructorId = dataBundle.accounts.get("instructorWithoutCourses").googleId;

--- a/src/test/java/teammates/test/cases/logic/EvaluationsLogicTest.java
+++ b/src/test/java/teammates/test/cases/logic/EvaluationsLogicTest.java
@@ -363,7 +363,14 @@ public class EvaluationsLogicTest extends BaseComponentTestCase{
         ______TS("Failure case: null parameters");
     
         try {
-            evaluationsLogic.getEvaluationsListForInstructor(null);
+            evaluationsLogic.getEvaluationsListForInstructor((String)null);
+            signalFailureToDetectException();
+        } catch (AssertionError e) {
+            AssertHelper.assertContains("Supplied parameter was null", e.getMessage());
+        }
+        
+        try {
+            evaluationsLogic.getEvaluationsListForInstructor((List<InstructorAttributes>)null);
             signalFailureToDetectException();
         } catch (AssertionError e) {
             AssertHelper.assertContains("Supplied parameter was null", e.getMessage());

--- a/src/test/java/teammates/test/cases/storage/InstructorsDbTest.java
+++ b/src/test/java/teammates/test/cases/storage/InstructorsDbTest.java
@@ -231,11 +231,13 @@ public class InstructorsDbTest extends BaseComponentTestCase {
     @Test
     public void testGetInstructorsForGoogleId() throws Exception {
         
+        // TODO: test omitting archived course instructors
+        
         ______TS("Success: get instructors with specific googleId");
         
         String googleId = "idOfInstructor3";
         
-        List<InstructorAttributes> retrieved = instructorsDb.getInstructorsForGoogleId(googleId);
+        List<InstructorAttributes> retrieved = instructorsDb.getInstructorsForGoogleId(googleId, false);
         assertEquals(2, retrieved.size());
         
         InstructorAttributes instructor1 = retrieved.get(0);
@@ -246,13 +248,13 @@ public class InstructorsDbTest extends BaseComponentTestCase {
         
         ______TS("Failure: instructor does not exist");
         
-        retrieved = instructorsDb.getInstructorsForGoogleId("non-exist-id");
+        retrieved = instructorsDb.getInstructorsForGoogleId("non-exist-id", false);
         assertEquals(0, retrieved.size());
         
         ______TS("Failure: null parameters");
 
         try {
-            instructorsDb.getInstructorsForGoogleId(null);
+            instructorsDb.getInstructorsForGoogleId(null, false);
             signalFailureToDetectException();
         } catch (AssertionError e) {
             assertEquals(Const.StatusCodes.DBLEVEL_NULL_INPUT, e.getMessage());
@@ -437,7 +439,7 @@ public class InstructorsDbTest extends BaseComponentTestCase {
         String googleId = "instructorWithOnlyOneSampleCourse";
         instructorsDb.deleteInstructorsForGoogleId(googleId);
         
-        List<InstructorAttributes> retrieved = instructorsDb.getInstructorsForGoogleId(googleId);
+        List<InstructorAttributes> retrieved = instructorsDb.getInstructorsForGoogleId(googleId, false);
         assertEquals(0, retrieved.size());
         
         ______TS("Failure: try to delete where there's no instructors associated with the googleId, should fail silently");

--- a/src/test/java/teammates/test/cases/storage/InstructorsDbTest.java
+++ b/src/test/java/teammates/test/cases/storage/InstructorsDbTest.java
@@ -26,6 +26,7 @@ import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Const;
 import teammates.common.util.StringHelper;
+import teammates.logic.core.InstructorsLogic;
 import teammates.storage.api.EntitiesDb;
 import teammates.storage.api.InstructorsDb;
 import teammates.test.cases.BaseComponentTestCase;
@@ -231,8 +232,6 @@ public class InstructorsDbTest extends BaseComponentTestCase {
     @Test
     public void testGetInstructorsForGoogleId() throws Exception {
         
-        // TODO: test omitting archived course instructors
-        
         ______TS("Success: get instructors with specific googleId");
         
         String googleId = "idOfInstructor3";
@@ -245,6 +244,14 @@ public class InstructorsDbTest extends BaseComponentTestCase {
         
         assertEquals("idOfTypicalCourse1", instructor1.courseId);
         assertEquals("idOfTypicalCourse2", instructor2.courseId);
+        
+
+        ______TS("Success: get instructors with specific googleId, with 1 archived course.");
+        
+        InstructorsLogic.inst().setArchiveStatusOfInstructor(googleId, instructor1.courseId, true);
+        retrieved = instructorsDb.getInstructorsForGoogleId(googleId, true);
+        assertEquals(1, retrieved.size());
+        InstructorsLogic.inst().setArchiveStatusOfInstructor(googleId, instructor1.courseId, false);
         
         ______TS("Failure: instructor does not exist");
         

--- a/src/test/resources/data/typicalDataBundle.json
+++ b/src/test/resources/data/typicalDataBundle.json
@@ -188,6 +188,7 @@
         "instructor3OfCourse1":{
             "googleId":"idOfInstructor3",
             "courseId":"idOfTypicalCourse1",
+            "isArchived":"false",
             "name":"Instructor3 Course1",
             "email":"instructor3@course1.tmt",
             "role":"Co-owner",
@@ -208,6 +209,7 @@
         "instructor4":{
             "googleId":"idOfInstructor4",
             "courseId":"idOfCourseNoEvals",
+            "isArchived":false,
             "name":"Instructor4 name",
             "email":"instructor4@courseNoEvals.tmt",
             "role":"Co-owner",


### PR DESCRIPTION
Fixes #1711 

Need to run the migration script DataMigrationForInstructorsCourseArchiving.java to create isArchived indexes for filtering.
Script also generates registration key if null.

There are still repeated DB calls, where instructor list is retrieved multiple times. Added todos for that issue.