### PR TITLE
instructorFeedbackSessions: mention that archived sessions are not shown #2861

### DIFF
--- a/src/main/webapp/jsp/instructorFeedbacks.jsp
+++ b/src/main/webapp/jsp/instructorFeedbacks.jsp
@@ -686,7 +686,8 @@
                 }
             %>
         </table>
-        <br> <br> <br>
+		<p align=center>Note: The table above does not contain sessions from archived courses. To view sessions from an archived course, unarchive the course first.</p>
+        <br> <br>
         <%
                 if (sessionIdx == -1) {
         %>


### PR DESCRIPTION
fixes #2861 
Added a msg to inform the instructor ,that Archived messages are not
displayed in the sessions table.