### PR TITLE
StudentHomePageActionTest and StudentCommentsPageActionTest fail if they run together #2859

### DIFF
--- a/src/test/java/teammates/test/cases/ui/StudentCommentsPageActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/StudentCommentsPageActionTest.java
@@ -14,6 +14,7 @@ import teammates.ui.controller.ShowPageResult;
 import teammates.ui.controller.StudentCommentsPageAction;
 import teammates.ui.controller.StudentCommentsPageData;
 
+//Priority added due to conflict between StudentHomePageActionTest and StudentCommentsPageActionTest
 @Priority(-1)
 public class StudentCommentsPageActionTest extends BaseActionTest {
 

--- a/src/test/java/teammates/test/cases/ui/StudentCommentsPageActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/StudentCommentsPageActionTest.java
@@ -9,10 +9,12 @@ import teammates.common.datatransfer.DataBundle;
 import teammates.common.datatransfer.StudentAttributes;
 import teammates.common.util.Const;
 import teammates.test.driver.AssertHelper;
+import teammates.test.util.Priority;
 import teammates.ui.controller.ShowPageResult;
 import teammates.ui.controller.StudentCommentsPageAction;
 import teammates.ui.controller.StudentCommentsPageData;
 
+@Priority(-1)
 public class StudentCommentsPageActionTest extends BaseActionTest {
 
     private final DataBundle dataBundle = getTypicalDataBundle();

--- a/src/test/java/teammates/test/cases/ui/StudentHomePageActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/StudentHomePageActionTest.java
@@ -4,7 +4,6 @@ import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertNotNull;
 
 import org.testng.annotations.BeforeClass;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import teammates.common.datatransfer.AccountAttributes;
@@ -25,6 +24,7 @@ import teammates.ui.controller.ShowPageResult;
 import teammates.ui.controller.StudentHomePageAction;
 import teammates.ui.controller.StudentHomePageData;
 
+// Priority added due to conflict between StudentHomePageActionTest and StudentCommentsPageActionTest
 @Priority(-2)
 public class StudentHomePageActionTest extends BaseActionTest {
 

--- a/src/test/java/teammates/test/cases/ui/StudentHomePageActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/StudentHomePageActionTest.java
@@ -20,10 +20,12 @@ import teammates.logic.core.EvaluationsLogic;
 import teammates.storage.api.AccountsDb;
 import teammates.test.cases.common.EvaluationAttributesTest;
 import teammates.test.driver.AssertHelper;
+import teammates.test.util.Priority;
 import teammates.ui.controller.ShowPageResult;
 import teammates.ui.controller.StudentHomePageAction;
 import teammates.ui.controller.StudentHomePageData;
 
+@Priority(-2)
 public class StudentHomePageActionTest extends BaseActionTest {
 
     private final DataBundle dataBundle = getTypicalDataBundle();


### PR DESCRIPTION
Fixes #2859

Fixing the priority/order of the tests seems to prevent the conflict.
This does not solve the root cause however, as both tests (and many others) use the typicalDataBundle.json for testing.