### PR TITLE
Fix message text overflow in statusMessage

### DIFF
--- a/src/main/webapp/jsp/statusMessage.jsp
+++ b/src/main/webapp/jsp/statusMessage.jsp
@@ -9,7 +9,7 @@
 <%
     if(!statusMessage.isEmpty()) {
 %>
-    <div id="statusMessage"
+    <div id="statusMessage" style="white-space: pre-wrap; white-space: -moz-pre-wrap; white-space: -pre-wrap; white-space: -o-pre-wrap; word-wrap: break-word;"
         <%if(isError) out.print(" class=\"alert alert-danger\""); else out.print(" class=\"alert alert-warning\"");%>>
         <%=statusMessage%>
     </div>


### PR DESCRIPTION
The text content inside the "statusMessage" overflows and crosses the bounding-box of "statusMessage" div.  

So, I have added style args to statusMessage div element. This ensures that the textContent inside the statusMessage div remains within the bounds of it's parent div. 

Now, it works fine.



Alternatively we can also create a css-rule in appropriate stylesheet also.
#statusMessage
{
   white-space: pre-wrap;      /* CSS3 */   
   white-space: -moz-pre-wrap; /* Firefox */    
   white-space: -pre-wrap;     /* Opera <7 */   
   white-space: -o-pre-wrap;   /* Opera 7 */    
   word-wrap: break-word;      /* IE */
}

The issue::
![issue_Screenshot](https://cloud.githubusercontent.com/assets/5702679/6549007/c01e667e-c630-11e4-81f5-f265a38c6fb5.png)

The fix::
![fix_Screenshot](https://cloud.githubusercontent.com/assets/5702679/6549006/c009ca7a-c630-11e4-841e-fdaee6f925ee.png)