### PR TITLE
Duplicated definitions of '#navbar li a' and '#navbar li a:hover' in teammates.css #3093

### DIFF
--- a/src/main/webapp/stylesheets/teammates.css
+++ b/src/main/webapp/stylesheets/teammates.css
@@ -165,15 +165,6 @@ h2 {
     font-weight: bold;
 }
 
-#navbar li a {
-   color: white;
-   text-decoration: none;
-}
-
-#navbar li a:hover {
-   text-decoration: underline;
-}
-
 #loginHolder input{
     color: #00FF00;
        font-weight: bold;


### PR DESCRIPTION
Fixes #3093