### PR TITLE
Simplified and updated runtests.sh #3123

### DIFF
--- a/runtests.sh
+++ b/runtests.sh
@@ -16,39 +16,19 @@ cp ./src/test/testng.xml .
 
 # construct the classpath
 tempcp=.
-tempcp=$tempcp:$1/lib/shared/appengine-local-runtime-shared.jar
-tempcp=$tempcp:$1/lib/shared/el-api.jar
-tempcp=$tempcp:$1/lib/shared/jsp-api.jar
-tempcp=$tempcp:$1/lib/shared/servlet-api.jar
-tempcp=$tempcp:$1/lib/shared/jsp/repackaged-appengine-ant-1.7.1.jar
-tempcp=$tempcp:$1/lib/shared/jsp/repackaged-appengine-ant-launcher-1.7.1.jar
-tempcp=$tempcp:$1/lib/shared/jsp/repackaged-appengine-jasper-6.0.29.jar
-tempcp=$tempcp:$1/lib/shared/jsp/repackaged-appengine-jasper-el-6.0.29.jar
-tempcp=$tempcp:$1/lib/shared/jsp/repackaged-appengine-tomcat-juli-6.0.29.jar
-tempcp=$tempcp:$1/lib/opt/user/appengine-api-labs/v1/appengine-api-labs.jar
-tempcp=$tempcp:$1/lib/opt/user/appengine-endpoints/v1/appengine-endpoints.jar
-tempcp=$tempcp:$1/lib/opt/user/appengine-endpoints/v1/appengine-endpoints-deps.jar
-tempcp=$tempcp:$1/lib/opt/user/jsr107/v1/appengine-jsr107cache-1.9.4.jar
-tempcp=$tempcp:$1/lib/opt/user/jsr107/v1/jsr107cache-1.1.jar
-tempcp=$tempcp:$1/lib/opt/user/datanucleus/v1/datanucleus-appengine-1.0.10.final.jar
-tempcp=$tempcp:$1/lib/opt/user/datanucleus/v1/datanucleus-core-1.1.5.jar
-tempcp=$tempcp:$1/lib/opt/user/datanucleus/v1/datanucleus-jpa-1.1.5.jar
-tempcp=$tempcp:$1/lib/opt/user/datanucleus/v1/geronimo-jpa_3.0_spec-1.1.1.jar
-tempcp=$tempcp:$1/lib/opt/user/datanucleus/v1/geronimo-jta_1.1_spec-1.1.1.jar
-tempcp=$tempcp:$1/lib/opt/user/datanucleus/v1/jdo2-api-2.3-eb.jar
-tempcp=$tempcp:$1/lib/appengine-tools-api.jar
+tempcp=$tempcp:$1/lib/shared/*
+tempcp=$tempcp:$1/lib/shared/jsp/*
+tempcp=$tempcp:$1/lib/opt/user/appengine-api-labs/v1/*
+tempcp=$tempcp:$1/lib/opt/user/jsr107/v1/*
+tempcp=$tempcp:$1/lib/opt/user/datanucleus/v1/*
+tempcp=$tempcp:$1/lib/*
 tempcp=$tempcp:$2/src/main/webapp/WEB-INF/classes
-tempcp=$tempcp:$2/src/test/resources/lib/javamail/mail.jar
-tempcp=$tempcp:$2/src/main/webapp/WEB-INF/lib/gson-2.2.2.jar
-tempcp=$tempcp:$2/src/main/webapp/WEB-INF/lib/xercesImpl-2.9.1.jar
-tempcp=$tempcp:$2/src/test/resources/lib/appengine/appengine-remote-api.jar
-tempcp=$tempcp:$2/src/test/resources/lib/appengine/appengine-testing.jar
-tempcp=$tempcp:$2/src/test/resources/lib/appengine/appengine-api.jar
-tempcp=$tempcp:$2/src/test/resources/lib/appengine/appengine-api-stubs.jar
-tempcp=$tempcp:$2/src/test/resources/lib/appengine/appengine-api-labs.jar
-tempcp=$tempcp:$2/src/test/resources/lib/selenium/selenium-server-standalone-2.41.0.jar
-tempcp=$tempcp:$2/src/test/resources/lib/httpunit/httpunit.jar
-tempcp=$tempcp:$2/src/test/resources/lib/testng/testng.jar
+tempcp=$tempcp:$2/src/test/resources/lib/javamail/*
+tempcp=$tempcp:$2/src/main/webapp/WEB-INF/lib/*
+tempcp=$tempcp:$2/src/test/resources/lib/appengine/*
+tempcp=$tempcp:$2/src/test/resources/lib/selenium/*
+tempcp=$tempcp:$2/src/test/resources/lib/httpunit/*
+tempcp=$tempcp:$2/src/test/resources/lib/testng/*
 echo $tempcp
 
 # run test suite once and retry failed ones five times
@@ -56,10 +36,9 @@ args="-Duser.timezone=UTC -Dfile.encoding=UTF8"
 echo $args
 
 java -cp $tempcp $args org.testng.TestNG $3 $4 ./testng.xml
-java -cp $tempcp $args org.testng.TestNG ./test-output/testng-failed.xml
-java -cp $tempcp $args org.testng.TestNG ./test-output/testng-failed.xml
-java -cp $tempcp $args org.testng.TestNG ./test-output/testng-failed.xml
-java -cp $tempcp $args org.testng.TestNG ./test-output/testng-failed.xml
-java -cp $tempcp $args org.testng.TestNG ./test-output/testng-failed.xml
+for(( i=1; i <= 5; i++ ))
+do
+    java -cp $tempcp $args org.testng.TestNG ./test-output/testng-failed.xml
+done
 
 cd ..


### PR DESCRIPTION
Instead of hardcoding all the jar files in the classpath, use wildchars to include the jars in a folder. This will reduce hard to debug errors due to typos in hardcoded jar file names.
Running the failed tests 5 times can be put in a loop that is run 5 times, instead of writing the same line 5 times.
Please review and push to master if the changes look good. Fixes #3123 