### PR TITLE
Simplified and updated runtests.bat. #3125

### DIFF
--- a/runtests.bat
+++ b/runtests.bat
@@ -18,48 +18,26 @@ copy /Y .\src\test\testng.xml .
 rem ### construct the classpath
 @echo off
 set tempcp=.
-set tempcp=%tempcp%;%1\lib\shared\appengine-local-runtime-shared.jar
-set tempcp=%tempcp%;%1\lib\shared\-api.jar
-set tempcp=%tempcp%;%1\lib\shared\jsp-api.jar
-set tempcp=%tempcp%;%1\lib\shared\servlet-api.jar
-set tempcp=%tempcp%;%1\lib\shared\jsp\repackaged-appengine-ant-1.7.1.jar
-set tempcp=%tempcp%;%1\lib\shared\jsp\repackaged-appengine-ant-launcher-1.7.1.jar
-set tempcp=%tempcp%;%1\lib\shared\jsp\repackaged-appengine-jasper-6.0.29.jar
-set tempcp=%tempcp%;%1\lib\shared\jsp\repackaged-appengine-jasper-el-6.0.29.jar
-set tempcp=%tempcp%;%1\lib\shared\jsp\repackaged-appengine-tomcat-juli-6.0.29.jar
-set tempcp=%tempcp%;%1\lib\opt\user\appengine-api-labs\v1\appengine-api-labs.jar
-set tempcp=%tempcp%;%1\lib\opt\user\appengine-endpoints\v1\appengine-endpoints.jar
-set tempcp=%tempcp%;%1\lib\opt\user\appengine-endpoints\v1\appengine-endpoints-deps.jar
-set tempcp=%tempcp%;%1\lib\opt\user\jsr107\v1\appengine-jsr107cache-1.9.4.jar
-set tempcp=%tempcp%;%1\lib\opt\user\jsr107\v1\jsr107cache-1.1.jar
-set tempcp=%tempcp%;%1\lib\opt\user\datanucleus\v1\datanucleus-appengine-1.0.10.final.jar
-set tempcp=%tempcp%;%1\lib\opt\user\datanucleus\v1\datanucleus-core-1.1.5.jar
-set tempcp=%tempcp%;%1\lib\opt\user\datanucleus\v1\datanucleus-jpa-1.1.5.jar
-set tempcp=%tempcp%;%1\lib\opt\user\datanucleus\v1\geronimo-jpa_3.0_spec-1.1.1.jar
-set tempcp=%tempcp%;%1\lib\opt\user\datanucleus\v1\geronimo-jta_1.1_spec-1.1.1.jar
-set tempcp=%tempcp%;%1\lib\opt\user\datanucleus\v1\jdo2-api-2.3-eb.jar
-set tempcp=%tempcp%;%1\lib\appengine-tools-api.jar
+set tempcp=%tempcp%;%1\lib\shared\*
+set tempcp=%tempcp%;%1\lib\shared\jsp\*
+set tempcp=%tempcp%;%1\lib\opt\user\appengine-api-labs\v1\*
+set tempcp=%tempcp%;%1\lib\opt\user\jsr107\v1\*
+set tempcp=%tempcp%;%1\lib\opt\user\datanucleus\v1\*
+set tempcp=%tempcp%;%1\lib\*
 set tempcp=%tempcp%;%2\src\main\webapp\WEB-INF\classes
-set tempcp=%tempcp%;%2\src\test\resources\lib\javamail\mail.jar
-set tempcp=%tempcp%;%2\src\main\webapp\WEB-INF\lib\gson-2.2.2.jar
-set tempcp=%tempcp%;%2\src\main\webapp\WEB-INF\lib\xercesImpl-2.9.1.jar
-set tempcp=%tempcp%;%2\src\test\resources\lib\appengine\appengine-remote-api.jar
-set tempcp=%tempcp%;%2\src\test\resources\lib\appengine\appengine-testing.jar
-set tempcp=%tempcp%;%2\src\test\resources\lib\appengine\appengine-api.jar
-set tempcp=%tempcp%;%2\src\test\resources\lib\appengine\appengine-api-stubs.jar
-set tempcp=%tempcp%;%2\src\test\resources\lib\appengine\appengine-api-labs.jar
-set tempcp=%tempcp%;%2\src\test\resources\lib\selenium\selenium-server-standalone-2.41.0.jar
-set tempcp=%tempcp%;%2\src\test\resources\lib\httpunit\httpunit.jar
-set tempcp=%tempcp%;%2\src\test\resources\lib\testng\testng.jar
+set tempcp=%tempcp%;%2\src\test\resources\lib\*
+set tempcp=%tempcp%;%2\src\main\webapp\WEB-INF\lib\*
+set tempcp=%tempcp%;%2\src\test\resources\lib\appengine\*
+set tempcp=%tempcp%;%2\src\test\resources\lib\selenium\*
+set tempcp=%tempcp%;%2\src\test\resources\lib\httpunit\*
+set tempcp=%tempcp%;%2\src\test\resources\lib\testng\*
 @echo on
 
 rem ### run test suite once and retry failed ones five times
 set vmparams=-Duser.timezone=UTC -Dfile.encoding=UTF8
 java -cp "%tempcp%" %vmparams% org.testng.TestNG %3 %4 .\testng.xml
-java -cp "%tempcp%" %vmparams% org.testng.TestNG .\test-output\testng-failed.xml
-java -cp "%tempcp%" %vmparams% org.testng.TestNG .\test-output\testng-failed.xml
-java -cp "%tempcp%" %vmparams% org.testng.TestNG .\test-output\testng-failed.xml
-java -cp "%tempcp%" %vmparams% org.testng.TestNG .\test-output\testng-failed.xml
-java -cp "%tempcp%" %vmparams% org.testng.TestNG .\test-output\testng-failed.xml
+for /l %i in (1, 1, 5) do (
+   java -cp "%tempcp%" %vmparams% org.testng.TestNG .\test-output\testng-failed.xml
+)
 
 cd ..


### PR DESCRIPTION
Instead of hardcoding all the jar files in the classpath, use wildchars to include the jars in a folder. This will reduce hard to debug errors due to typos in hardcoded jar file names.
Running the failed tests 5 times can be put in a loop that is run 5 times, instead of writing the same line 5 times.
Please review and push to master. Fixes #3125 