### PR TITLE
studentCommentsView page should be sorted 'recent on top' #2679

### DIFF
--- a/src/main/java/teammates/common/datatransfer/FeedbackSessionAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/FeedbackSessionAttributes.java
@@ -484,27 +484,4 @@ public class FeedbackSessionAttributes extends EntityAttributes implements Sessi
     public String getSessionName() {
         return this.feedbackSessionName;
     }
-    
-    /*
-     * Comparator to sort by endTime in descending order
-     */
-    public static final Comparator<FeedbackSessionAttributes> compareByEndTimeDesc = new Comparator<FeedbackSessionAttributes>() {
-
-        @Override
-        public int compare(FeedbackSessionAttributes o1,
-                FeedbackSessionAttributes o2) {
-            Date date1 = o1.endTime;
-            Date date2 = o2.endTime;
-            if (date1 == null && date2 == null) {
-                return 0;
-            }
-            if (date1 == null) {
-                return 1;
-            }
-            if (date2 == null) {
-                return -1;
-            }
-            return date2.compareTo(date1);
-        }
-    };
 }

--- a/src/main/java/teammates/common/datatransfer/FeedbackSessionAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/FeedbackSessionAttributes.java
@@ -484,4 +484,27 @@ public class FeedbackSessionAttributes extends EntityAttributes implements Sessi
     public String getSessionName() {
         return this.feedbackSessionName;
     }
+    
+    /*
+     * Comparator to sort by endTime in descending order
+     */
+    public static final Comparator<FeedbackSessionAttributes> compareByEndTimeDesc = new Comparator<FeedbackSessionAttributes>() {
+
+        @Override
+        public int compare(FeedbackSessionAttributes o1,
+                FeedbackSessionAttributes o2) {
+            Date date1 = o1.endTime;
+            Date date2 = o2.endTime;
+            if (date1 == null && date2 == null) {
+                return 0;
+            }
+            if (date1 == null) {
+                return 1;
+            }
+            if (date2 == null) {
+                return -1;
+            }
+            return date2.compareTo(date1);
+        }
+    };
 }

--- a/src/main/java/teammates/ui/controller/StudentCommentsPageAction.java
+++ b/src/main/java/teammates/ui/controller/StudentCommentsPageAction.java
@@ -15,6 +15,7 @@ import teammates.common.datatransfer.FeedbackResponseAttributes;
 import teammates.common.datatransfer.FeedbackResponseCommentAttributes;
 import teammates.common.datatransfer.FeedbackSessionAttributes;
 import teammates.common.datatransfer.FeedbackSessionResultsBundle;
+import teammates.common.datatransfer.SessionAttributes;
 import teammates.common.datatransfer.StudentAttributes;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.UnauthorizedAccessException;
@@ -143,32 +144,26 @@ public class StudentCommentsPageAction extends Action {
      * Returns a sorted map(LinkedHashMap) of FeedbackSessionResultsBundle,
      * where the sessions are sorted in descending order of their endTime
      */
-    private Map<String, FeedbackSessionResultsBundle> getFeedbackResultBundles(
-            CourseRoster roster)
+    private Map<String, FeedbackSessionResultsBundle> getFeedbackResultBundles(CourseRoster roster)
             throws EntityDoesNotExistException {
         Map<String, FeedbackSessionResultsBundle> feedbackResultBundles = new LinkedHashMap<String, FeedbackSessionResultsBundle>();
-        List<FeedbackSessionAttributes> fsList = logic
-                .getFeedbackSessionsForCourse(courseId);
-        Collections
-                .sort(fsList, FeedbackSessionAttributes.compareByEndTimeDesc);
-        for (FeedbackSessionAttributes fs : fsList) {
-            if (!fs.isPublished())
-                continue;
-
-            FeedbackSessionResultsBundle bundle =
-                    logic.getFeedbackSessionResultsForStudent(
-                            fs.feedbackSessionName, courseId, studentEmail,
-                            roster);
-            if (bundle != null) {
+        List<FeedbackSessionAttributes> fsList = logic.getFeedbackSessionsForCourse(courseId);
+        Collections.sort(fsList, SessionAttributes.DESCENDING_ORDER);
+        for(FeedbackSessionAttributes fs : fsList){
+            if(!fs.isPublished()) continue;
+            
+            FeedbackSessionResultsBundle bundle = 
+                    logic.getFeedbackSessionResultsForStudent(fs.feedbackSessionName, courseId, studentEmail, roster);
+            if(bundle != null){
                 removeQuestionsAndResponsesWithoutFeedbackResponseComment(bundle);
-                if (bundle.questions.size() != 0) {
+                if(bundle.questions.size() != 0){
                     feedbackResultBundles.put(fs.feedbackSessionName, bundle);
                 }
             }
         }
         return feedbackResultBundles;
     }
-    
+
     private void removeQuestionsAndResponsesWithoutFeedbackResponseComment(FeedbackSessionResultsBundle bundle) {
         List<FeedbackResponseAttributes> responsesWithFeedbackResponseComment = new ArrayList<FeedbackResponseAttributes>();
         for(FeedbackResponseAttributes fr: bundle.responses){

--- a/src/main/java/teammates/ui/controller/StudentCommentsPageAction.java
+++ b/src/main/java/teammates/ui/controller/StudentCommentsPageAction.java
@@ -1,7 +1,9 @@
 package teammates.ui.controller;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -137,25 +139,36 @@ public class StudentCommentsPageAction extends Action {
         }
     }
     
-    private Map<String, FeedbackSessionResultsBundle> getFeedbackResultBundles(CourseRoster roster)
+    /*
+     * Returns a sorted map(LinkedHashMap) of FeedbackSessionResultsBundle,
+     * where the sessions are sorted in descending order of their endTime
+     */
+    private Map<String, FeedbackSessionResultsBundle> getFeedbackResultBundles(
+            CourseRoster roster)
             throws EntityDoesNotExistException {
-        Map<String, FeedbackSessionResultsBundle> feedbackResultBundles = new HashMap<String, FeedbackSessionResultsBundle>();
-        List<FeedbackSessionAttributes> fsList = logic.getFeedbackSessionsForCourse(courseId);
-        for(FeedbackSessionAttributes fs : fsList){
-            if(!fs.isPublished()) continue;
-            
-            FeedbackSessionResultsBundle bundle = 
-                    logic.getFeedbackSessionResultsForStudent(fs.feedbackSessionName, courseId, studentEmail, roster);
-            if(bundle != null){
+        Map<String, FeedbackSessionResultsBundle> feedbackResultBundles = new LinkedHashMap<String, FeedbackSessionResultsBundle>();
+        List<FeedbackSessionAttributes> fsList = logic
+                .getFeedbackSessionsForCourse(courseId);
+        Collections
+                .sort(fsList, FeedbackSessionAttributes.compareByEndTimeDesc);
+        for (FeedbackSessionAttributes fs : fsList) {
+            if (!fs.isPublished())
+                continue;
+
+            FeedbackSessionResultsBundle bundle =
+                    logic.getFeedbackSessionResultsForStudent(
+                            fs.feedbackSessionName, courseId, studentEmail,
+                            roster);
+            if (bundle != null) {
                 removeQuestionsAndResponsesWithoutFeedbackResponseComment(bundle);
-                if(bundle.questions.size() != 0){
+                if (bundle.questions.size() != 0) {
                     feedbackResultBundles.put(fs.feedbackSessionName, bundle);
                 }
             }
         }
         return feedbackResultBundles;
     }
-
+    
     private void removeQuestionsAndResponsesWithoutFeedbackResponseComment(FeedbackSessionResultsBundle bundle) {
         List<FeedbackResponseAttributes> responsesWithFeedbackResponseComment = new ArrayList<FeedbackResponseAttributes>();
         for(FeedbackResponseAttributes fr: bundle.responses){


### PR DESCRIPTION
Fixes #2679. Dev green. Now - 
1) First the Comments for students, ordered in reverse chronological order of comment
creation time appears. (This was already the case)
2) Next each Feedback session appears. Those sessions which have the latest comment come first. (This was NOT the case earlier).
3) Within each feedback session, questions are sorted as per their question no (This was already the case)
4) Within each question, comments are sorted such that earlier comment comes first (This was already the case)
Let me know if any changes are to be made.  
@damithc 