### PR TITLE
Word 'gray' misspelled as 'grey' in teammatesCommon.css #3214

### DIFF
--- a/src/main/webapp/stylesheets/teammatesCommon.css
+++ b/src/main/webapp/stylesheets/teammatesCommon.css
@@ -533,7 +533,7 @@ Apply to thead to make headers not bold.
     background-color: black;
     background-image: linear-gradient(to bottom, #3c3c3c 0, #222 100%);
     bottom: 0px;
-    color: grey;
+    color: gray;
     height: 20px;
     margin: 0px;
     position: fixed;


### PR DESCRIPTION
Fixes #3214.
Few text-editors were highlighting it. So, I thought of correcting it to comply with the general spelling of the color used in the web. 