### PR TITLE
 instructor: Results display format can be improved for questions with no recipient #2844 

### DIFF
--- a/src/main/java/teammates/common/datatransfer/FeedbackSessionResultsBundle.java
+++ b/src/main/java/teammates/common/datatransfer/FeedbackSessionResultsBundle.java
@@ -323,7 +323,7 @@ public class FeedbackSessionResultsBundle implements SessionResultsBundle{
      */
     public String getTeamNameFromRoster(String participantIdentifier) {
         if (participantIdentifier.equals(Const.GENERAL_QUESTION)) {
-            return Const.USER_NOBODY_TEXT;
+            return Const.TEAM_FOR_GENERAL_QUESTION;
         }
         
         if (isParticipantIdentifierStudent(participantIdentifier)) {
@@ -939,8 +939,10 @@ public class FeedbackSessionResultsBundle implements SessionResultsBundle{
     
     public String getTeamNameForEmail(String email) {
         String teamName = emailTeamNameTable.get(email);
-        if (teamName == null || email.equals(Const.GENERAL_QUESTION) ) {
+        if (teamName == null) {
             return Const.USER_NOBODY_TEXT;
+        } else if (email.equals(Const.GENERAL_QUESTION)) {
+            return Const.TEAM_FOR_GENERAL_QUESTION;
         } else {
             return PageData.sanitizeForHtml(teamName);
         }

--- a/src/main/java/teammates/common/util/Const.java
+++ b/src/main/java/teammates/common/util/Const.java
@@ -1132,6 +1132,7 @@ public class Const {
     public static final String USER_NOBODY_TEXT = "-";
     public static final String USER_UNKNOWN_TEXT = "Unknown user";
     public static final String TEAM_OF_EMAIL_OWNER = "'s Team";
+    public static final String TEAM_FOR_GENERAL_QUESTION = "[General Feedback]";
     
     public static final String FEEDBACK_SESSION_QUESTIONS_HIDDEN = "Some questions may be hidden due to visibility options";
     public static final String NONE_OF_THE_ABOVE = "None of the above";


### PR DESCRIPTION
Fixes #2844

Shouldn't have any side effects, the methods affected are:
`getTeamNameFromRoster()` - Getter used in csv string builder for recipients in `FeedbackSessionsLogic`.
`getTeamNameForEmail()` - Getter used in `Feedback*QuestionDetails` classes.

"[General Feedback]" should suggest sufficiently that it is a question targeted at nobody specifically while being an impossible team name (as it starts with a non-alphanumeric character). [This mockup](http://codepen.io/yj-soh/full/ZYZLpg) can be used to test potential replacement strings.

![general-feedback](https://cloud.githubusercontent.com/assets/8586080/6940086/be86b622-d8a5-11e4-8660-4786dab4634c.png)

The replacement string is still tentative, but the following tests will have to be revised upon confirmation, before merging:
> logic.FeedbackSessionsLogictest
> ui.browsertests.InstructorFeedbackResultsPageUiTest
> ui.browsertests.StudentFeedbackResultsPageUiTest
> ui.browsertests.AdminHomePageUiTest

All else is dev green.