### PR TITLE
Instructor feedback results: typo in tooltip about CC #3255

### DIFF
--- a/src/main/java/teammates/common/datatransfer/FeedbackContributionQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/FeedbackContributionQuestionDetails.java
@@ -283,7 +283,7 @@ public class FeedbackContributionQuestionDetails extends FeedbackQuestionDetails
         html += FeedbackQuestionFormTemplates.populateTemplate(
                 FeedbackQuestionFormTemplates.CONTRIB_RESULT_STATS,
                 "${contribFragments}", contribFragments,
-                "${Const.Tooltips.CLAIMED}", Const.Tooltips.CLAIMED,
+                "${Const.Tooltips.CLAIMED}", Sanitizer.sanitizeForHtml(Const.Tooltips.CLAIMED),
                 "${Const.Tooltips.PERCEIVED}", Const.Tooltips.PERCEIVED,
                 "${Const.Tooltips.EVALUATION_POINTS_RECEIVED}", Const.Tooltips.EVALUATION_POINTS_RECEIVED,
                 "${Const.Tooltips.EVALUATION_DIFF}", Const.Tooltips.EVALUATION_DIFF);

--- a/src/main/java/teammates/common/util/Const.java
+++ b/src/main/java/teammates/common/util/Const.java
@@ -92,7 +92,7 @@ public class Const {
         public static final String COURSE_DELETE = "Delete the course and its corresponding students and sessions";
         public static final String COURSE_ARCHIVE = "Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)";
         public static final String COURSE_ADD_EVALUATION = "Add a feedback session for the course";
-        public static final String CLAIMED = "This is the students own estimation of his/her contributions";
+        public static final String CLAIMED = "This is the student&#39;s own estimation of his/her contributions";
         public static final String PERCEIVED = "This is the average of what other team members think this student contributed";
         public static final String PERCEIVED_CLAIMED = "Difference between claimed and perceived contribution points";
     

--- a/src/main/java/teammates/common/util/Const.java
+++ b/src/main/java/teammates/common/util/Const.java
@@ -92,7 +92,7 @@ public class Const {
         public static final String COURSE_DELETE = "Delete the course and its corresponding students and sessions";
         public static final String COURSE_ARCHIVE = "Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)";
         public static final String COURSE_ADD_EVALUATION = "Add a feedback session for the course";
-        public static final String CLAIMED = "This is the student&#39;s own estimation of his/her contributions";
+        public static final String CLAIMED = "This is the student's own estimation of his/her contributions";
         public static final String PERCEIVED = "This is the average of what other team members think this student contributed";
         public static final String PERCEIVED_CLAIMED = "Difference between claimed and perceived contribution points";
     

--- a/src/main/webapp/instructorHelp.html
+++ b/src/main/webapp/instructorHelp.html
@@ -5480,7 +5480,7 @@
                                                                             <td class="button-sort-none" id="button_sortname" onclick="toggleSort(this,2)">Student
                                                                                 <span class="icon-sort unsorted"></span>
                                                                             </td>
-                                                                            <td class="button-sort-none" id="button_sortclaimed" onclick="toggleSort(this,3,sortByPoint)" data-toggle="tooltip" data-placement="top" data-container="body" title="" data-original-title="This is the students own estimation of his/her contributions">
+                                                                            <td class="button-sort-none" id="button_sortclaimed" onclick="toggleSort(this,3,sortByPoint)" data-toggle="tooltip" data-placement="top" data-container="body" title="" data-original-title="This is the student's own estimation of his/her contributions">
                                                                                 <abbr title="Claimed Contribution">CC</abbr>
                                                                                 <span class="icon-sort unsorted"></span>
                                                                             </td>

--- a/src/main/webapp/jsp/instructorEvalResults.jsp
+++ b/src/main/webapp/jsp/instructorEvalResults.jsp
@@ -220,7 +220,7 @@
             <div class="row">
             <div class="col-sm-4">
             <h4><span class="label label-info" data-toggle="tooltip" data-placement="top" data-container="body"  
-                        title='<%=Const.Tooltips.CLAIMED%>'>CC</span> Claimed Contribution 
+                        title='<%=sanitizeForHtml(Const.Tooltips.CLAIMED)%>'>CC</span> Claimed Contribution 
             </h4>
             </div>
             <div class="col-sm-5"> 
@@ -349,7 +349,7 @@
                             <div class="col-md-4">
                               <div class="pull-right">
                                 <span data-toggle="tooltip" data-placement="top" data-container="body"  
-                                    title='<%=Const.Tooltips.CLAIMED%>'>
+                                    title='<%=sanitizeForHtml(Const.Tooltips.CLAIMED)%>'>
                                 Claimed contribution: <%=InstructorEvalResultsPageData.getPointsInEqualShareFormatAsHtml(studentResult.summary.claimedToInstructor,true)%>
                                 </span>
                               </div>

--- a/src/main/webapp/jsp/instructorEvalSubmission.jsp
+++ b/src/main/webapp/jsp/instructorEvalSubmission.jsp
@@ -5,6 +5,7 @@
 <%@ page import="teammates.common.datatransfer.EvaluationDetailsBundle"%>
 <%@ page import="teammates.common.datatransfer.SubmissionAttributes"%>
 <%@ page import="teammates.ui.controller.InstructorEvalSubmissionPageData"%>
+<%@ page import="static teammates.ui.controller.PageData.sanitizeForHtml" %>
 <%
     InstructorEvalSubmissionPageData data = (InstructorEvalSubmissionPageData)request.getAttribute("data");
 %>
@@ -80,7 +81,7 @@
                     </div>
                     <div class="col-md-4">
                         <span class="resultHeader"
-                            title="<%=Const.Tooltips.CLAIMED%>"
+                            title="<%=sanitizeForHtml(Const.Tooltips.CLAIMED)%>"
                             data-toggle="tooltip"
                             data-placement="top">
                             Claimed Contribution:

--- a/src/main/webapp/jsp/instructorStudentRecords.jsp
+++ b/src/main/webapp/jsp/instructorStudentRecords.jsp
@@ -20,6 +20,7 @@
 <%@ page import="teammates.ui.controller.InstructorEvalSubmissionPageData"%>
 <%@ page import="teammates.ui.controller.InstructorStudentRecordsPageData"%>
 <%@ page import="static teammates.ui.controller.PageData.sanitizeForJs"%>
+<%@ page import="static teammates.ui.controller.PageData.sanitizeForHtml" %>
 <%
 	InstructorStudentRecordsPageData data = (InstructorStudentRecordsPageData)request.getAttribute("data");
 %>
@@ -593,7 +594,7 @@
                                             <td class="col-sm-4"><%=byReviewee ? "Reviewee" : "Reviewer"%>: <strong><%=InstructorStudentRecordsPageData.sanitizeForHtml(data.student.name)%></strong>
                                             </td>
                                             <td class="col-sm-4">
-                                                <div class="pull-right"><span data-toggle="tooltip" data-placement="top" title="<%=Const.Tooltips.CLAIMED%>">Claimed Contribution: </span>
+                                                <div class="pull-right"><span data-toggle="tooltip" data-placement="top" title="<%=sanitizeForHtml(Const.Tooltips.CLAIMED)%>">Claimed Contribution: </span>
                                                     <%=InstructorEvalSubmissionPageData.getPointsInEqualShareFormatAsHtml(studentResult.summary.claimedToInstructor,true)%>
                                                 </div>
                                             </td>

--- a/src/test/resources/pages/instructorEvalResultsClosedEval.html
+++ b/src/test/resources/pages/instructorEvalResultsClosedEval.html
@@ -134,7 +134,7 @@
         <div id="instructorEvaluationSummaryTable" class="evaluation_result">
             <div class="row">
             <div class="col-sm-4">
-            <h4><span data-original-title="This is the students own estimation of his/her contributions" class="label label-info" data-toggle="tooltip" data-placement="top" data-container="body" title="">CC</span> Claimed Contribution 
+            <h4><span data-original-title="This is the student's own estimation of his/her contributions" class="label label-info" data-toggle="tooltip" data-placement="top" data-container="body" title="">CC</span> Claimed Contribution 
             </h4>
             </div>
             <div class="col-sm-5"> 
@@ -267,7 +267,7 @@
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-positive"> E +20%</span>
                                 </span>
                               </div>
@@ -334,7 +334,7 @@
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-negative"> E -10%</span>
                                 </span>
                               </div>
@@ -417,7 +417,7 @@
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-negative"> E -3%</span>
                                 </span>
                               </div>
@@ -491,7 +491,7 @@
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-negative"> E -3%</span>
                                 </span>
                               </div>
@@ -565,7 +565,7 @@
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-positive"> E +6%</span>
                                 </span>
                               </div>
@@ -660,7 +660,7 @@
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-positive"> E +20%</span>
                                 </span>
                               </div>
@@ -719,7 +719,7 @@
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-negative"> E -10%</span>
                                 </span>
                               </div>
@@ -794,7 +794,7 @@
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-negative"> E -3%</span>
                                 </span>
                               </div>
@@ -860,7 +860,7 @@
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-negative"> E -3%</span>
                                 </span>
                               </div>
@@ -926,7 +926,7 @@
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-positive"> E +6%</span>
                                 </span>
                               </div>

--- a/src/test/resources/pages/instructorEvalResultsOpenEval.html
+++ b/src/test/resources/pages/instructorEvalResultsOpenEval.html
@@ -135,7 +135,7 @@
         <div id="instructorEvaluationSummaryTable" class="evaluation_result">
             <div class="row">
             <div class="col-sm-4">
-            <h4><span data-original-title="This is the students own estimation of his/her contributions" class="label label-info" data-toggle="tooltip" data-placement="top" data-container="body" title="">CC</span> Claimed Contribution 
+            <h4><span data-original-title="This is the student's own estimation of his/her contributions" class="label label-info" data-toggle="tooltip" data-placement="top" data-container="body" title="">CC</span> Claimed Contribution 
             </h4>
             </div>
             <div class="col-sm-5"> 
@@ -268,7 +268,7 @@
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-negative"> E -5%</span>
                                 </span>
                               </div>
@@ -340,7 +340,7 @@ Nothing</td>
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-positive"> E +5%</span>
                                 </span>
                               </div>
@@ -423,7 +423,7 @@ Nothing</td>
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-positive"> E +3%</span>
                                 </span>
                               </div>
@@ -497,7 +497,7 @@ Nothing</td>
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-positive"> E +10%</span>
                                 </span>
                               </div>
@@ -571,7 +571,7 @@ Nothing</td>
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-positive"> E +10%</span>
                                 </span>
                               </div>
@@ -666,7 +666,7 @@ Nothing</td>
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-negative"> E -5%</span>
                                 </span>
                               </div>
@@ -725,7 +725,7 @@ Nothing</td>
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-positive"> E +5%</span>
                                 </span>
                               </div>
@@ -805,7 +805,7 @@ Nothing</td>
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-positive"> E +3%</span>
                                 </span>
                               </div>
@@ -871,7 +871,7 @@ Nothing</td>
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-positive"> E +10%</span>
                                 </span>
                               </div>
@@ -937,7 +937,7 @@ Nothing</td>
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-positive"> E +10%</span>
                                 </span>
                               </div>

--- a/src/test/resources/pages/instructorEvalResultsOpenEvalByReviewee.html
+++ b/src/test/resources/pages/instructorEvalResultsOpenEvalByReviewee.html
@@ -136,7 +136,7 @@
         <div style="display: none;" id="instructorEvaluationSummaryTable" class="evaluation_result">
             <div class="row">
             <div class="col-sm-4">
-            <h4><span data-original-title="This is the students own estimation of his/her contributions" class="label label-info" data-toggle="tooltip" data-placement="top" data-container="body" title="">CC</span> Claimed Contribution 
+            <h4><span data-original-title="This is the student's own estimation of his/her contributions" class="label label-info" data-toggle="tooltip" data-placement="top" data-container="body" title="">CC</span> Claimed Contribution 
             </h4>
             </div>
             <div class="col-sm-5"> 
@@ -269,7 +269,7 @@
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-negative"> E -5%</span>
                                 </span>
                               </div>
@@ -341,7 +341,7 @@ Nothing</td>
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-positive"> E +5%</span>
                                 </span>
                               </div>
@@ -424,7 +424,7 @@ Nothing</td>
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-positive"> E +3%</span>
                                 </span>
                               </div>
@@ -498,7 +498,7 @@ Nothing</td>
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-positive"> E +10%</span>
                                 </span>
                               </div>
@@ -572,7 +572,7 @@ Nothing</td>
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-positive"> E +10%</span>
                                 </span>
                               </div>
@@ -667,7 +667,7 @@ Nothing</td>
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-negative"> E -5%</span>
                                 </span>
                               </div>
@@ -726,7 +726,7 @@ Nothing</td>
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-positive"> E +5%</span>
                                 </span>
                               </div>
@@ -806,7 +806,7 @@ Nothing</td>
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-positive"> E +3%</span>
                                 </span>
                               </div>
@@ -872,7 +872,7 @@ Nothing</td>
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-positive"> E +10%</span>
                                 </span>
                               </div>
@@ -938,7 +938,7 @@ Nothing</td>
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-positive"> E +10%</span>
                                 </span>
                               </div>

--- a/src/test/resources/pages/instructorEvalResultsOpenEvalByReviewer.html
+++ b/src/test/resources/pages/instructorEvalResultsOpenEvalByReviewer.html
@@ -136,7 +136,7 @@
         <div style="display: none;" id="instructorEvaluationSummaryTable" class="evaluation_result">
             <div class="row">
             <div class="col-sm-4">
-            <h4><span data-original-title="This is the students own estimation of his/her contributions" class="label label-info" data-toggle="tooltip" data-placement="top" data-container="body" title="">CC</span> Claimed Contribution 
+            <h4><span data-original-title="This is the student's own estimation of his/her contributions" class="label label-info" data-toggle="tooltip" data-placement="top" data-container="body" title="">CC</span> Claimed Contribution 
             </h4>
             </div>
             <div class="col-sm-5"> 
@@ -269,7 +269,7 @@
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-negative"> E -5%</span>
                                 </span>
                               </div>
@@ -341,7 +341,7 @@ Nothing</td>
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-positive"> E +5%</span>
                                 </span>
                               </div>
@@ -424,7 +424,7 @@ Nothing</td>
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-positive"> E +3%</span>
                                 </span>
                               </div>
@@ -498,7 +498,7 @@ Nothing</td>
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-positive"> E +10%</span>
                                 </span>
                               </div>
@@ -572,7 +572,7 @@ Nothing</td>
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-positive"> E +10%</span>
                                 </span>
                               </div>
@@ -667,7 +667,7 @@ Nothing</td>
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-negative"> E -5%</span>
                                 </span>
                               </div>
@@ -726,7 +726,7 @@ Nothing</td>
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-positive"> E +5%</span>
                                 </span>
                               </div>
@@ -806,7 +806,7 @@ Nothing</td>
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-positive"> E +3%</span>
                                 </span>
                               </div>
@@ -872,7 +872,7 @@ Nothing</td>
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-positive"> E +10%</span>
                                 </span>
                               </div>
@@ -938,7 +938,7 @@ Nothing</td>
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-positive"> E +10%</span>
                                 </span>
                               </div>

--- a/src/test/resources/pages/instructorEvalResultsP2PDisabled.html
+++ b/src/test/resources/pages/instructorEvalResultsP2PDisabled.html
@@ -136,7 +136,7 @@
         <div id="instructorEvaluationSummaryTable" class="evaluation_result">
             <div class="row">
             <div class="col-sm-4">
-            <h4><span data-original-title="This is the students own estimation of his/her contributions" class="label label-info" data-toggle="tooltip" data-placement="top" data-container="body" title="">CC</span> Claimed Contribution 
+            <h4><span data-original-title="This is the student's own estimation of his/her contributions" class="label label-info" data-toggle="tooltip" data-placement="top" data-container="body" title="">CC</span> Claimed Contribution 
             </h4>
             </div>
             <div class="col-sm-5"> 
@@ -269,7 +269,7 @@
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-positive"> E +20%</span>
                                 </span>
                               </div>
@@ -336,7 +336,7 @@
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-negative"> E -10%</span>
                                 </span>
                               </div>
@@ -419,7 +419,7 @@
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-negative"> E -3%</span>
                                 </span>
                               </div>
@@ -493,7 +493,7 @@
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-negative"> E -3%</span>
                                 </span>
                               </div>
@@ -567,7 +567,7 @@
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-positive"> E +6%</span>
                                 </span>
                               </div>
@@ -662,7 +662,7 @@
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-positive"> E +20%</span>
                                 </span>
                               </div>
@@ -721,7 +721,7 @@
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-negative"> E -10%</span>
                                 </span>
                               </div>
@@ -796,7 +796,7 @@
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-negative"> E -3%</span>
                                 </span>
                               </div>
@@ -862,7 +862,7 @@
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-negative"> E -3%</span>
                                 </span>
                               </div>
@@ -928,7 +928,7 @@
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-positive"> E +6%</span>
                                 </span>
                               </div>

--- a/src/test/resources/pages/instructorEvalResultsP2PDisabledByReviewee.html
+++ b/src/test/resources/pages/instructorEvalResultsP2PDisabledByReviewee.html
@@ -136,7 +136,7 @@
         <div style="display: none;" id="instructorEvaluationSummaryTable" class="evaluation_result">
             <div class="row">
             <div class="col-sm-4">
-            <h4><span data-original-title="This is the students own estimation of his/her contributions" class="label label-info" data-toggle="tooltip" data-placement="top" data-container="body" title="">CC</span> Claimed Contribution 
+            <h4><span data-original-title="This is the student's own estimation of his/her contributions" class="label label-info" data-toggle="tooltip" data-placement="top" data-container="body" title="">CC</span> Claimed Contribution 
             </h4>
             </div>
             <div class="col-sm-5"> 
@@ -269,7 +269,7 @@
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-positive"> E +20%</span>
                                 </span>
                               </div>
@@ -336,7 +336,7 @@
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-negative"> E -10%</span>
                                 </span>
                               </div>
@@ -419,7 +419,7 @@
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-negative"> E -3%</span>
                                 </span>
                               </div>
@@ -493,7 +493,7 @@
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-negative"> E -3%</span>
                                 </span>
                               </div>
@@ -567,7 +567,7 @@
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-positive"> E +6%</span>
                                 </span>
                               </div>
@@ -662,7 +662,7 @@
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-positive"> E +20%</span>
                                 </span>
                               </div>
@@ -721,7 +721,7 @@
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-negative"> E -10%</span>
                                 </span>
                               </div>
@@ -796,7 +796,7 @@
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-negative"> E -3%</span>
                                 </span>
                               </div>
@@ -862,7 +862,7 @@
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-negative"> E -3%</span>
                                 </span>
                               </div>
@@ -928,7 +928,7 @@
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-positive"> E +6%</span>
                                 </span>
                               </div>

--- a/src/test/resources/pages/instructorEvalResultsP2PDisabledByReviewer.html
+++ b/src/test/resources/pages/instructorEvalResultsP2PDisabledByReviewer.html
@@ -135,7 +135,7 @@
         <div style="display: none;" id="instructorEvaluationSummaryTable" class="evaluation_result">
             <div class="row">
             <div class="col-sm-4">
-            <h4><span data-original-title="This is the students own estimation of his/her contributions" class="label label-info" data-toggle="tooltip" data-placement="top" data-container="body" title="">CC</span> Claimed Contribution 
+            <h4><span data-original-title="This is the student's own estimation of his/her contributions" class="label label-info" data-toggle="tooltip" data-placement="top" data-container="body" title="">CC</span> Claimed Contribution 
             </h4>
             </div>
             <div class="col-sm-5"> 
@@ -268,7 +268,7 @@
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-positive"> E +20%</span>
                                 </span>
                               </div>
@@ -335,7 +335,7 @@
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-negative"> E -10%</span>
                                 </span>
                               </div>
@@ -418,7 +418,7 @@
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-negative"> E -3%</span>
                                 </span>
                               </div>
@@ -492,7 +492,7 @@
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-negative"> E -3%</span>
                                 </span>
                               </div>
@@ -566,7 +566,7 @@
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-positive"> E +6%</span>
                                 </span>
                               </div>
@@ -661,7 +661,7 @@
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-positive"> E +20%</span>
                                 </span>
                               </div>
@@ -720,7 +720,7 @@
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-negative"> E -10%</span>
                                 </span>
                               </div>
@@ -795,7 +795,7 @@
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-negative"> E -3%</span>
                                 </span>
                               </div>
@@ -861,7 +861,7 @@
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-negative"> E -3%</span>
                                 </span>
                               </div>
@@ -927,7 +927,7 @@
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-positive"> E +6%</span>
                                 </span>
                               </div>

--- a/src/test/resources/pages/instructorEvalResultsPublishedEval.html
+++ b/src/test/resources/pages/instructorEvalResultsPublishedEval.html
@@ -135,7 +135,7 @@
         <div id="instructorEvaluationSummaryTable" class="evaluation_result">
             <div class="row">
             <div class="col-sm-4">
-            <h4><span data-original-title="This is the students own estimation of his/her contributions" class="label label-info" data-toggle="tooltip" data-placement="top" data-container="body" title="">CC</span> Claimed Contribution 
+            <h4><span data-original-title="This is the student's own estimation of his/her contributions" class="label label-info" data-toggle="tooltip" data-placement="top" data-container="body" title="">CC</span> Claimed Contribution 
             </h4>
             </div>
             <div class="col-sm-5"> 
@@ -268,7 +268,7 @@
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color_neutral">N/A</span>
                                 </span>
                               </div>
@@ -335,7 +335,7 @@
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-negative">Not sure</span>
                                 </span>
                               </div>
@@ -418,7 +418,7 @@
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-positive"> E +100%</span>
                                 </span>
                               </div>
@@ -492,7 +492,7 @@
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-negative"> E -3%</span>
                                 </span>
                               </div>
@@ -566,7 +566,7 @@
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-positive"> E </span>
                                 </span>
                               </div>
@@ -661,7 +661,7 @@
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color_neutral">N/A</span>
                                 </span>
                               </div>
@@ -720,7 +720,7 @@
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-negative">Not sure</span>
                                 </span>
                               </div>
@@ -795,7 +795,7 @@
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-positive"> E +100%</span>
                                 </span>
                               </div>
@@ -861,7 +861,7 @@
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-negative"> E -3%</span>
                                 </span>
                               </div>
@@ -927,7 +927,7 @@
                             </div>
                             <div class="col-md-4">
                               <div class="pull-right">
-                                <span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                                <span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                                 Claimed contribution: <span class="badge background-color-white color-positive"> E </span>
                                 </span>
                               </div>

--- a/src/test/resources/pages/instructorEvalSubmissionView.html
+++ b/src/test/resources/pages/instructorEvalSubmissionView.html
@@ -136,7 +136,7 @@
                         </strong>
                      </div>
                      <div class="col-md-4" >
-                        <span class="resultHeader"  data-original-title="This is the students own estimation of his/her contributions"  data-placement="top"  data-toggle="tooltip"  title="" >
+                        <span class="resultHeader"  data-original-title="This is the student's own estimation of his/her contributions"  data-placement="top"  data-toggle="tooltip"  title="" >
                            Claimed Contribution:
                         </span>
                         <span class="badge background-color-white color-positive" >
@@ -249,7 +249,7 @@
                         </strong>
                      </div>
                      <div class="col-md-4" >
-                        <span class="resultHeader"  data-original-title="This is the students own estimation of his/her contributions"  data-placement="top"  data-toggle="tooltip"  title="" >
+                        <span class="resultHeader"  data-original-title="This is the student's own estimation of his/her contributions"  data-placement="top"  data-toggle="tooltip"  title="" >
                            Claimed Contribution:
                         </span>
                         <span class="badge background-color-white color-positive" >

--- a/src/test/resources/pages/instructorEvalSubmissionViewP2pDisabled.html
+++ b/src/test/resources/pages/instructorEvalSubmissionViewP2pDisabled.html
@@ -136,7 +136,7 @@
                         </strong>
                      </div>
                      <div class="col-md-4" >
-                        <span class="resultHeader"  data-original-title="This is the students own estimation of his/her contributions"  data-placement="top"  data-toggle="tooltip"  title="" >
+                        <span class="resultHeader"  data-original-title="This is the student's own estimation of his/her contributions"  data-placement="top"  data-toggle="tooltip"  title="" >
                            Claimed Contribution:
                         </span>
                         <span class="badge background-color-white color-positive" >
@@ -253,7 +253,7 @@
                         </strong>
                      </div>
                      <div class="col-md-4" >
-                        <span class="resultHeader"  data-original-title="This is the students own estimation of his/her contributions"  data-placement="top"  data-toggle="tooltip"  title="" >
+                        <span class="resultHeader"  data-original-title="This is the student's own estimation of his/her contributions"  data-placement="top"  data-toggle="tooltip"  title="" >
                            Claimed Contribution:
                         </span>
                         <span class="badge background-color-white color-positive" >

--- a/src/test/resources/pages/instructorFeedbackResultsFilteredBySectionA.html
+++ b/src/test/resources/pages/instructorFeedbackResultsFilteredBySectionA.html
@@ -2376,7 +2376,7 @@
                         <span class="icon-sort unsorted"></span></td>
                     <td class="button-sort-none" id="button_sortname" onclick="toggleSort(this,2)">Student
                         <span class="icon-sort unsorted"></span></td>
-                    <td data-original-title="This is the students own estimation of his/her contributions" class="button-sort-none" id="button_sortclaimed" onclick="toggleSort(this,3,sortByPoint)" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                    <td data-original-title="This is the student's own estimation of his/her contributions" class="button-sort-none" id="button_sortclaimed" onclick="toggleSort(this,3,sortByPoint)" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                         <abbr title="Claimed Contribution">CC</abbr>
                         <span class="icon-sort unsorted"></span></td>
                     <td data-original-title="This is the average of what other team members think this student contributed" class="button-sort-none" id="button_sortperceived" onclick="toggleSort(this,4,sortByPoint)" data-toggle="tooltip" data-placement="top" data-container="body" title="">

--- a/src/test/resources/pages/instructorFeedbackResultsPageOpen.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageOpen.html
@@ -2777,7 +2777,7 @@ ul #nav {
                         <span class="icon-sort unsorted"></span></td>
                     <td onclick="toggleSort(this,2)" id="button_sortname" class="button-sort-none">Student
                         <span class="icon-sort unsorted"></span></td>
-                    <td title="" data-container="body" data-placement="top" data-toggle="tooltip" onclick="toggleSort(this,3,sortByPoint)" id="button_sortclaimed" class="button-sort-none" data-original-title="This is the students own estimation of his/her contributions">
+                    <td title="" data-container="body" data-placement="top" data-toggle="tooltip" onclick="toggleSort(this,3,sortByPoint)" id="button_sortclaimed" class="button-sort-none" data-original-title="This is the student's own estimation of his/her contributions">
                         <abbr title="Claimed Contribution">CC</abbr>
                         <span class="icon-sort unsorted"></span></td>
                     <td title="" data-container="body" data-placement="top" data-toggle="tooltip" onclick="toggleSort(this,4,sortByPoint)" id="button_sortperceived" class="button-sort-none" data-original-title="This is the average of what other team members think this student contributed">

--- a/src/test/resources/pages/instructorFeedbackResultsPageOpenWithHelperView2.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageOpenWithHelperView2.html
@@ -2444,7 +2444,7 @@
                         <span class="icon-sort unsorted"></span></td>
                     <td class="button-sort-none" id="button_sortname" onclick="toggleSort(this,2)">Student
                         <span class="icon-sort unsorted"></span></td>
-                    <td data-original-title="This is the students own estimation of his/her contributions" class="button-sort-none" id="button_sortclaimed" onclick="toggleSort(this,3,sortByPoint)" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                    <td data-original-title="This is the student's own estimation of his/her contributions" class="button-sort-none" id="button_sortclaimed" onclick="toggleSort(this,3,sortByPoint)" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                         <abbr title="Claimed Contribution">CC</abbr>
                         <span class="icon-sort unsorted"></span></td>
                     <td data-original-title="This is the average of what other team members think this student contributed" class="button-sort-none" id="button_sortperceived" onclick="toggleSort(this,4,sortByPoint)" data-toggle="tooltip" data-placement="top" data-container="body" title="">

--- a/src/test/resources/pages/instructorFeedbackResultsSortQuestion.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortQuestion.html
@@ -2490,7 +2490,7 @@
                         <span class="icon-sort unsorted"></span></td>
                     <td class="button-sort-none" id="button_sortname" onclick="toggleSort(this,2)">Student
                         <span class="icon-sort unsorted"></span></td>
-                    <td data-original-title="This is the students own estimation of his/her contributions" class="button-sort-none" id="button_sortclaimed" onclick="toggleSort(this,3,sortByPoint)" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                    <td data-original-title="This is the student's own estimation of his/her contributions" class="button-sort-none" id="button_sortclaimed" onclick="toggleSort(this,3,sortByPoint)" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                         <abbr title="Claimed Contribution">CC</abbr>
                         <span class="icon-sort unsorted"></span></td>
                     <td data-original-title="This is the average of what other team members think this student contributed" class="button-sort-none" id="button_sortperceived" onclick="toggleSort(this,4,sortByPoint)" data-toggle="tooltip" data-placement="top" data-container="body" title="">

--- a/src/test/resources/pages/instructorFeedbackResultsSortQuestionSearch.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortQuestionSearch.html
@@ -2490,7 +2490,7 @@
                         <span class="icon-sort unsorted"></span></td>
                     <td class="button-sort-none" id="button_sortname" onclick="toggleSort(this,2)">Student
                         <span class="icon-sort unsorted"></span></td>
-                    <td data-original-title="This is the students own estimation of his/her contributions" class="button-sort-none" id="button_sortclaimed" onclick="toggleSort(this,3,sortByPoint)" data-toggle="tooltip" data-placement="top" data-container="body" title="">
+                    <td data-original-title="This is the student's own estimation of his/her contributions" class="button-sort-none" id="button_sortclaimed" onclick="toggleSort(this,3,sortByPoint)" data-toggle="tooltip" data-placement="top" data-container="body" title="">
                         <abbr title="Claimed Contribution">CC</abbr>
                         <span class="icon-sort unsorted"></span></td>
                     <td data-original-title="This is the average of what other team members think this student contributed" class="button-sort-none" id="button_sortperceived" onclick="toggleSort(this,4,sortByPoint)" data-toggle="tooltip" data-placement="top" data-container="body" title="">

--- a/src/test/resources/pages/instructorStudentRecords.html
+++ b/src/test/resources/pages/instructorStudentRecords.html
@@ -619,7 +619,7 @@
                                             <td class="col-sm-4">Reviewee: <strong>Benny Charlés</strong>
                                             </td>
                                             <td class="col-sm-4">
-                                                <div class="pull-right"><span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" title="">Claimed Contribution: </span>
+                                                <div class="pull-right"><span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" title="">Claimed Contribution: </span>
                                                     <span class="badge background-color-white color_neutral">N/A</span>
                                                 </div>
                                             </td>
@@ -688,7 +688,7 @@
                                             <td class="col-sm-4">Reviewer: <strong>Benny Charlés</strong>
                                             </td>
                                             <td class="col-sm-4">
-                                                <div class="pull-right"><span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" title="">Claimed Contribution: </span>
+                                                <div class="pull-right"><span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" title="">Claimed Contribution: </span>
                                                     <span class="badge background-color-white color_neutral">N/A</span>
                                                 </div>
                                             </td>
@@ -768,7 +768,7 @@
                                             <td class="col-sm-4">Reviewee: <strong>Benny Charlés</strong>
                                             </td>
                                             <td class="col-sm-4">
-                                                <div class="pull-right"><span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" title="">Claimed Contribution: </span>
+                                                <div class="pull-right"><span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" title="">Claimed Contribution: </span>
                                                     <span class="badge background-color-white color_neutral">N/A</span>
                                                 </div>
                                             </td>
@@ -837,7 +837,7 @@
                                             <td class="col-sm-4">Reviewer: <strong>Benny Charlés</strong>
                                             </td>
                                             <td class="col-sm-4">
-                                                <div class="pull-right"><span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" title="">Claimed Contribution: </span>
+                                                <div class="pull-right"><span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" title="">Claimed Contribution: </span>
                                                     <span class="badge background-color-white color_neutral">N/A</span>
                                                 </div>
                                             </td>

--- a/src/test/resources/pages/instructorStudentRecordsAjaxLoading.html
+++ b/src/test/resources/pages/instructorStudentRecordsAjaxLoading.html
@@ -912,7 +912,7 @@ ul #nav {
                                             <td class="col-sm-4">Reviewee: <strong>Benny Charlés</strong>
                                             </td>
                                             <td class="col-sm-4">
-                                                <div class="pull-right"><span title="" data-placement="top" data-toggle="tooltip" data-original-title="This is the students own estimation of his/her contributions">Claimed Contribution: </span>
+                                                <div class="pull-right"><span title="" data-placement="top" data-toggle="tooltip" data-original-title="This is the student's own estimation of his/her contributions">Claimed Contribution: </span>
                                                     <span class="badge background-color-white color-negative">N/A</span>
                                                 </div>
                                             </td>
@@ -981,7 +981,7 @@ ul #nav {
                                             <td class="col-sm-4">Reviewer: <strong>Benny Charlés</strong>
                                             </td>
                                             <td class="col-sm-4">
-                                                <div class="pull-right"><span title="" data-placement="top" data-toggle="tooltip" data-original-title="This is the students own estimation of his/her contributions">Claimed Contribution: </span>
+                                                <div class="pull-right"><span title="" data-placement="top" data-toggle="tooltip" data-original-title="This is the student's own estimation of his/her contributions">Claimed Contribution: </span>
                                                     <span class="badge background-color-white color-negative">N/A</span>
                                                 </div>
                                             </td>
@@ -1061,7 +1061,7 @@ ul #nav {
                                             <td class="col-sm-4">Reviewee: <strong>Benny Charlés</strong>
                                             </td>
                                             <td class="col-sm-4">
-                                                <div class="pull-right"><span title="" data-placement="top" data-toggle="tooltip" data-original-title="This is the students own estimation of his/her contributions">Claimed Contribution: </span>
+                                                <div class="pull-right"><span title="" data-placement="top" data-toggle="tooltip" data-original-title="This is the student's own estimation of his/her contributions">Claimed Contribution: </span>
                                                     <span class="badge background-color-white color-negative">N/A</span>
                                                 </div>
                                             </td>
@@ -1130,7 +1130,7 @@ ul #nav {
                                             <td class="col-sm-4">Reviewer: <strong>Benny Charlés</strong>
                                             </td>
                                             <td class="col-sm-4">
-                                                <div class="pull-right"><span title="" data-placement="top" data-toggle="tooltip" data-original-title="This is the students own estimation of his/her contributions">Claimed Contribution: </span>
+                                                <div class="pull-right"><span title="" data-placement="top" data-toggle="tooltip" data-original-title="This is the student's own estimation of his/her contributions">Claimed Contribution: </span>
                                                     <span class="badge background-color-white color-negative">N/A</span>
                                                 </div>
                                             </td>

--- a/src/test/resources/pages/instructorStudentRecordsPageWithPrivateFeedback.html
+++ b/src/test/resources/pages/instructorStudentRecordsPageWithPrivateFeedback.html
@@ -297,7 +297,7 @@
                                             <td class="col-sm-4">Reviewee: <strong>Teammates Test</strong>
                                             </td>
                                             <td class="col-sm-4">
-                                                <div class="pull-right"><span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" title="">Claimed Contribution: </span>
+                                                <div class="pull-right"><span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" title="">Claimed Contribution: </span>
                                                     <span class="badge background-color-white color_neutral">N/A</span>
                                                 </div>
                                             </td>
@@ -358,7 +358,7 @@
                                             <td class="col-sm-4">Reviewer: <strong>Teammates Test</strong>
                                             </td>
                                             <td class="col-sm-4">
-                                                <div class="pull-right"><span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" title="">Claimed Contribution: </span>
+                                                <div class="pull-right"><span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" title="">Claimed Contribution: </span>
                                                     <span class="badge background-color-white color_neutral">N/A</span>
                                                 </div>
                                             </td>
@@ -430,7 +430,7 @@
                                             <td class="col-sm-4">Reviewee: <strong>Teammates Test</strong>
                                             </td>
                                             <td class="col-sm-4">
-                                                <div class="pull-right"><span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" title="">Claimed Contribution: </span>
+                                                <div class="pull-right"><span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" title="">Claimed Contribution: </span>
                                                     <span class="badge background-color-white color_neutral">N/A</span>
                                                 </div>
                                             </td>
@@ -491,7 +491,7 @@
                                             <td class="col-sm-4">Reviewer: <strong>Teammates Test</strong>
                                             </td>
                                             <td class="col-sm-4">
-                                                <div class="pull-right"><span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" title="">Claimed Contribution: </span>
+                                                <div class="pull-right"><span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" title="">Claimed Contribution: </span>
                                                     <span class="badge background-color-white color_neutral">N/A</span>
                                                 </div>
                                             </td>
@@ -563,7 +563,7 @@
                                             <td class="col-sm-4">Reviewee: <strong>Teammates Test</strong>
                                             </td>
                                             <td class="col-sm-4">
-                                                <div class="pull-right"><span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" title="">Claimed Contribution: </span>
+                                                <div class="pull-right"><span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" title="">Claimed Contribution: </span>
                                                     <span class="badge background-color-white color_neutral">N/A</span>
                                                 </div>
                                             </td>
@@ -624,7 +624,7 @@
                                             <td class="col-sm-4">Reviewer: <strong>Teammates Test</strong>
                                             </td>
                                             <td class="col-sm-4">
-                                                <div class="pull-right"><span data-original-title="This is the students own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" title="">Claimed Contribution: </span>
+                                                <div class="pull-right"><span data-original-title="This is the student's own estimation of his/her contributions" data-toggle="tooltip" data-placement="top" title="">Claimed Contribution: </span>
                                                     <span class="badge background-color-white color_neutral">N/A</span>
                                                 </div>
                                             </td>


### PR DESCRIPTION
Fixes #3255 

Dev green.
Currently uses a HTML escape character in the constant.
Would it be preferable to sanitise it further down the chain?

Also, I changed the string in instructorHelp.html to maintain consistency.