### PR TITLE
Main Titles(h1 tags) are covered by navigation bar for a certain page width #3293

### DIFF
--- a/src/main/webapp/stylesheets/teammatesCommon.css
+++ b/src/main/webapp/stylesheets/teammatesCommon.css
@@ -321,17 +321,26 @@ Apply to thead to make headers not bold.
 
 /* Code to morph navbar to hamburger at tablet size (992px) instead of phone size (768px) */ 
 /* Prevents content overflow in navbar*/
-@media (max-width: 991px) {
-    .navbar-header {
+@media (min-width: 768px) and (max-width: 991px) {
+    .container>.navbar-header {
         float: none;
+        /* ya test only */
+        margin-left: -15px;
+        margin-right: -15px;
+    }
+    .navbar>.container .navbar-brand {
+        margin-left: 0px;
     }
     .navbar-toggle {
         display: block;
     }
-    .navbar-collapse {
+    .container>.navbar-collapse {
         border-top: 1px solid transparent;
         box-shadow: inset 0 1px 0 rgba(255,255,255,0.1);
         max-height: 345px; /* Avoids scrollbar from showing up */
+        /* test only */
+        margin-right: -15px;
+        margin-left: -15px;
     }
     /* Since the original bootstrap code has !important,
     we need to match with !important to override */
@@ -344,6 +353,9 @@ Apply to thead to make headers not bold.
     }
     .navbar-nav>li {
         float: none;
+        /* try hor */
+        padding-left: 15px;
+        padding-right: 15px;
     }
     .navbar-nav>li>a {
         padding-top: 10px;
@@ -362,6 +374,12 @@ Apply to thead to make headers not bold.
     /* Makes container exhibit container-fluid behavior */
     .container {
       width: auto;
+    }
+}
+
+@media (max-width: 768px) {
+    .navbar-collapse {
+        max-height: 360px;
     }
 }
 

--- a/src/main/webapp/stylesheets/teammatesCommon.css
+++ b/src/main/webapp/stylesheets/teammatesCommon.css
@@ -324,7 +324,6 @@ Apply to thead to make headers not bold.
 @media (min-width: 768px) and (max-width: 991px) {
     .container>.navbar-header {
         float: none;
-        /* ya test only */
         margin-left: -15px;
         margin-right: -15px;
     }
@@ -338,7 +337,6 @@ Apply to thead to make headers not bold.
         border-top: 1px solid transparent;
         box-shadow: inset 0 1px 0 rgba(255,255,255,0.1);
         max-height: 345px; /* Avoids scrollbar from showing up */
-        /* test only */
         margin-right: -15px;
         margin-left: -15px;
     }
@@ -353,7 +351,6 @@ Apply to thead to make headers not bold.
     }
     .navbar-nav>li {
         float: none;
-        /* try hor */
         padding-left: 15px;
         padding-right: 15px;
     }

--- a/src/main/webapp/stylesheets/teammatesCommon.css
+++ b/src/main/webapp/stylesheets/teammatesCommon.css
@@ -319,6 +319,52 @@ Apply to thead to make headers not bold.
     border: 0;
 }
 
+/* Code to morph navbar to hamburger at tablet size (992px) instead of phone size (768px) */ 
+/* Prevents content overflow in navbar*/
+@media (max-width: 991px) {
+    .navbar-header {
+        float: none;
+    }
+    .navbar-toggle {
+        display: block;
+    }
+    .navbar-collapse {
+        border-top: 1px solid transparent;
+        box-shadow: inset 0 1px 0 rgba(255,255,255,0.1);
+        max-height: 345px; /* Avoids scrollbar from showing up */
+    }
+    /* Since the original bootstrap code has !important,
+    we need to match with !important to override */
+    .navbar-collapse.collapse {
+        display: none!important;
+    }
+    .navbar-nav {
+        float: none!important;
+        margin: 7.5px -15px;
+    }
+    .navbar-nav>li {
+        float: none;
+    }
+    .navbar-nav>li>a {
+        padding-top: 10px;
+        padding-bottom: 10px;
+    }
+    .navbar-text {
+        float: none;
+        margin: 15px 0;
+    }
+    .navbar-collapse.collapse.in { 
+        display: block!important;
+    }
+    .collapsing {
+        overflow: hidden!important;
+    }
+    /* Makes container exhibit container-fluid behavior */
+    .container {
+      width: auto;
+    }
+}
+
 /*////////////////////////////////////////////////////////////
 ///////////////////////// Header ////////////////////////////
 //////////////////////////////////////////////////////////*/


### PR DESCRIPTION
Fixes #3293 

As mentioned in the issue, the new CSS improves the responsiveness of the navbar by, at 992px and below, transforming it into a hamburger bar and forcing the navbar container to exhibit container-fluid behaviour (auto width, as opposed to the normal responsive-fixed-width container behaviour).