### PR TITLE
InstructorAttributes: findAvailableInstructorGoogleIdForCourse() doesn't return an instructor with 'Co-owner' privilege #3312

### DIFF
--- a/src/main/java/teammates/ui/controller/AdminSearchPageAction.java
+++ b/src/main/java/teammates/ui/controller/AdminSearchPageAction.java
@@ -268,7 +268,7 @@ public class AdminSearchPageAction extends Action {
           
             if(instructor.googleId != null){
                googleId = instructor.googleId;
-               if(instructor.isAllowedForPrivilege(Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_COOWNER)){            
+               if(instructor.role.equals(Const.InstructorPermissionRoleNames.INSTRUCTOR_PERMISSION_ROLE_COOWNER)){            
                    break;
                } 
             }            


### PR DESCRIPTION
Fixes #3312 