### PR TITLE
Scroll to the edited question when instructors wants to moderate for one specific response #3290

### DIFF
--- a/src/main/java/teammates/ui/controller/FeedbackSubmissionEditPageData.java
+++ b/src/main/java/teammates/ui/controller/FeedbackSubmissionEditPageData.java
@@ -13,6 +13,7 @@ import teammates.common.util.StringHelper;
 public class FeedbackSubmissionEditPageData extends PageData {
 
     public FeedbackSessionQuestionsBundle bundle = null;
+    public String moderatedQuestion = null;
     public boolean isSessionOpenForSubmission;
     public boolean isPreview;
     public boolean isModeration;

--- a/src/main/java/teammates/ui/controller/InstructorEditStudentFeedbackPageAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorEditStudentFeedbackPageAction.java
@@ -22,6 +22,7 @@ public class InstructorEditStudentFeedbackPageAction extends Action {
         String courseId = getRequestParamValue(Const.ParamsNames.COURSE_ID);
         String feedbackSessionName = getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_NAME);
         String moderatedStudentEmail = getRequestParamValue(Const.ParamsNames.FEEDBACK_SESSION_MODERATED_STUDENT);
+        String moderatedQuestionNumber = getRequestParamValue("moderatedquestion");
 
         Assumption.assertNotNull(String.format(Const.StatusMessages.NULL_POST_PARAMETER_MESSAGE, 
                                                Const.ParamsNames.COURSE_ID), 
@@ -58,6 +59,11 @@ public class InstructorEditStudentFeedbackPageAction extends Action {
         data.isSessionOpenForSubmission = true;
         data.isModeration = true;
         data.studentToViewPageAs = studentUnderModeration;
+        
+        if (moderatedQuestionNumber != null) {
+          data.moderatedQuestion = moderatedQuestionNumber;
+        }
+        
         hideQuestionsWithAnonymousResponses(data.bundle);
 
         

--- a/src/main/webapp/js/feedbackSubmissionsEdit.js
+++ b/src/main/webapp/js/feedbackSubmissionsEdit.js
@@ -41,7 +41,16 @@ $(document).ready(function () {
     prepareRubricQuestions();
     
     prepareMCQQuestions();
+    
+    focusModeratedQuestion();
 });
+
+// Looks for the question to be moderated (if it exists)
+function focusModeratedQuestion() {
+  $('html, body').animate({
+    scrollTop: $(".moderated-question").offset().top - $(".navbar").outerHeight(true)
+  }, 1000);
+}
 
 // Prepare mcq questions for answering by user
 function prepareMCQQuestions() {

--- a/src/main/webapp/jsp/feedbackSubmissionEdit.jsp
+++ b/src/main/webapp/jsp/feedbackSubmissionEdit.jsp
@@ -82,7 +82,7 @@
         int numOfResponseBoxes = question.numberOfEntitiesToGiveFeedbackTo;
         int maxResponsesPossible = data.bundle.recipientList.get(question.getId()).size();
         FeedbackQuestionDetails questionDetails = question.getQuestionDetails();
-        String qnIndexString = String.valueOf(qnIndx); // Compare strings instead of ints to avoid integer conversion complications.
+        String questionNumberString = String.valueOf(question.questionNumber); // Compare strings instead of ints to avoid integer conversion complications.
         
         if (numOfResponseBoxes == Const.MAX_POSSIBLE_RECIPIENTS ||
                 numOfResponseBoxes > maxResponsesPossible) {
@@ -97,7 +97,7 @@
         <input type="hidden" name="<%=Const.ParamsNames.FEEDBACK_QUESTION_ID%>-<%=Integer.toString(qnIndx)%>" value="<%=question.getId()%>"/>
         <input type="hidden" name="<%=Const.ParamsNames.FEEDBACK_QUESTION_RESPONSETOTAL%>-<%=Integer.toString(qnIndx)%>" value="<%=numOfResponseBoxes%>"/>
         <div class="form-horizontal">
-            <div class="panel panel-primary <%= data.moderatedQuestion.equals(qnIndexString) ? "moderated-question" : "" %>">
+            <div class="panel panel-primary <%= data.moderatedQuestion.equals(questionNumberString) ? "moderated-question" : "" %>">
                 <div class="panel-heading">Question <%=qnIndx%>:<br/>
                     <span class="text-preserve-space"><%=sanitizeForHtml(questionDetails.questionText)%></div></span>
                 <div class="panel-body">

--- a/src/main/webapp/jsp/feedbackSubmissionEdit.jsp
+++ b/src/main/webapp/jsp/feedbackSubmissionEdit.jsp
@@ -76,12 +76,14 @@
     %>
 <%
 	int qnIndx = 1;
+  
     List<FeedbackQuestionAttributes> questions = data.bundle.getSortedQuestions();
     for (FeedbackQuestionAttributes question : questions) {
         int numOfResponseBoxes = question.numberOfEntitiesToGiveFeedbackTo;
         int maxResponsesPossible = data.bundle.recipientList.get(question.getId()).size();
         FeedbackQuestionDetails questionDetails = question.getQuestionDetails();
-
+        String qnIndexString = String.valueOf(qnIndx); // Compare strings instead of ints to avoid integer conversion complications.
+        
         if (numOfResponseBoxes == Const.MAX_POSSIBLE_RECIPIENTS ||
                 numOfResponseBoxes > maxResponsesPossible) {
             numOfResponseBoxes = maxResponsesPossible;
@@ -95,7 +97,7 @@
         <input type="hidden" name="<%=Const.ParamsNames.FEEDBACK_QUESTION_ID%>-<%=Integer.toString(qnIndx)%>" value="<%=question.getId()%>"/>
         <input type="hidden" name="<%=Const.ParamsNames.FEEDBACK_QUESTION_RESPONSETOTAL%>-<%=Integer.toString(qnIndx)%>" value="<%=numOfResponseBoxes%>"/>
         <div class="form-horizontal">
-            <div class="panel panel-primary">
+            <div class="panel panel-primary <%= data.moderatedQuestion.equals(qnIndexString) ? "moderated-question" : "" %>">
                 <div class="panel-heading">Question <%=qnIndx%>:<br/>
                     <span class="text-preserve-space"><%=sanitizeForHtml(questionDetails.questionText)%></div></span>
                 <div class="panel-body">

--- a/src/main/webapp/jsp/feedbackSubmissionEdit.jsp
+++ b/src/main/webapp/jsp/feedbackSubmissionEdit.jsp
@@ -97,7 +97,7 @@
         <input type="hidden" name="<%=Const.ParamsNames.FEEDBACK_QUESTION_ID%>-<%=Integer.toString(qnIndx)%>" value="<%=question.getId()%>"/>
         <input type="hidden" name="<%=Const.ParamsNames.FEEDBACK_QUESTION_RESPONSETOTAL%>-<%=Integer.toString(qnIndx)%>" value="<%=numOfResponseBoxes%>"/>
         <div class="form-horizontal">
-            <div class="panel panel-primary <%= data.moderatedQuestion.equals(questionNumberString) ? "moderated-question" : "" %>">
+            <div class="panel panel-primary<%= questionNumberString.equals(data.moderatedQuestion) ? " moderated-question" : "" %>">
                 <div class="panel-heading">Question <%=qnIndx%>:<br/>
                     <span class="text-preserve-space"><%=sanitizeForHtml(questionDetails.questionText)%></div></span>
                 <div class="panel-body">

--- a/src/main/webapp/jsp/instructorFeedbackResultsByQuestion.jsp
+++ b/src/main/webapp/jsp/instructorFeedbackResultsByQuestion.jsp
@@ -217,6 +217,7 @@
                                                                         <input type="submit" class="btn btn-default btn-xs" value="Moderate Response" <%=disabledAttribute%> data-toggle="tooltip" title="<%=Const.Tooltips.FEEDBACK_SESSION_MODERATE_FEEDBACK%>">
                                                                         <input type="hidden" name="courseid" value="<%=data.courseId %>">
                                                                         <input type="hidden" name="fsname" value="<%= data.feedbackSessionName%>">
+                                                                        <input type="hidden" name="moderatedquestion" value="<%= question.questionNumber%>">
                                                                         <% if (responseEntry.giverEmail.matches(Const.REGEXP_TEAM)) { %>
                                                                         <input type="hidden" name="moderatedstudent" value="<%= responseEntry.giverEmail.replace(Const.TEAM_OF_EMAIL_OWNER,"")%>">
                                                                         <% } else { %>
@@ -279,6 +280,7 @@
                                                         <input type="submit" class="btn btn-default btn-xs" value="Moderate Response" <%=disabledAttribute%> data-toggle="tooltip" title="<%=Const.Tooltips.FEEDBACK_SESSION_MODERATE_FEEDBACK%>">
                                                         <input type="hidden" name="courseid" value="<%=data.courseId %>">
                                                         <input type="hidden" name="fsname" value="<%= data.feedbackSessionName%>">
+                                                        <input type="hidden" name="moderatedquestion" value="<%= question.questionNumber%>">
                                                         <% if (responseEntry.giverEmail.matches(Const.REGEXP_TEAM)) { %>
                                                         <input type="hidden" name="moderatedstudent" value="<%= responseEntry.giverEmail.replace(Const.TEAM_OF_EMAIL_OWNER,"")%>">
                                                         <% } else { %>
@@ -341,6 +343,7 @@
                                                                     <input type="submit" class="btn btn-default btn-xs" value="Moderate Response" <%=disabledAttribute%> data-toggle="tooltip" title="<%=Const.Tooltips.FEEDBACK_SESSION_MODERATE_FEEDBACK%>">
                                                                     <input type="hidden" name="courseid" value="<%=data.courseId %>">
                                                                     <input type="hidden" name="fsname" value="<%= data.feedbackSessionName%>">
+                                                                    <input type="hidden" name="moderatedquestion" value="<%= question.questionNumber%>">
                                                                     <% if (prevGiver.matches(Const.REGEXP_TEAM)) { %>
                                                                     <input type="hidden" name="moderatedstudent" value="<%= prevGiver.replace(Const.TEAM_OF_EMAIL_OWNER,"")%>">
                                                                     <% } else { %>
@@ -409,6 +412,7 @@
                                                                     <input type="submit" class="btn btn-default btn-xs" value="Moderate Response" <%=disabledAttribute%> data-toggle="tooltip" title="<%=Const.Tooltips.FEEDBACK_SESSION_MODERATE_FEEDBACK%>">
                                                                     <input type="hidden" name="courseid" value="<%=data.courseId %>">
                                                                     <input type="hidden" name="fsname" value="<%= data.feedbackSessionName%>">
+                                                                    <input type="hidden" name="moderatedquestion" value="<%= question.questionNumber%>">
                                                                     <% if (possibleGiver.matches(Const.REGEXP_TEAM)) { %>
                                                                     <input type="hidden" name="moderatedstudent" value="<%= possibleGiver.replace(Const.TEAM_OF_EMAIL_OWNER,"")%>">
                                                                     <% } else { %>

--- a/src/main/webapp/jsp/instructorFeedbackResultsByRecipientQuestionGiver.jsp
+++ b/src/main/webapp/jsp/instructorFeedbackResultsByRecipientQuestionGiver.jsp
@@ -526,6 +526,7 @@
                                                         <input type="submit" class="btn btn-default btn-xs" value="Moderate Response" <%=disabledAttribute%> data-toggle="tooltip" title="<%=Const.Tooltips.FEEDBACK_SESSION_MODERATE_FEEDBACK%>">
                                                         <input type="hidden" name="courseid" value="<%=data.courseId %>">
                                                         <input type="hidden" name="fsname" value="<%= data.feedbackSessionName%>">
+                                                        <input type="hidden" name="moderatedquestion" value="<%= question.questionNumber %>">
                                                         <% if (responseEntry.giverEmail.matches(Const.REGEXP_TEAM)) { %>
                                                         <input type="hidden" name="moderatedstudent" value="<%= responseEntry.giverEmail.replace(Const.TEAM_OF_EMAIL_OWNER,"")%>">
                                                         <% } else { %>
@@ -579,6 +580,7 @@
                                                                 <input type="submit" class="btn btn-default btn-xs" value="Moderate Response" <%=disabledAttribute%> data-toggle="tooltip" title="<%=Const.Tooltips.FEEDBACK_SESSION_MODERATE_FEEDBACK%>">
                                                                 <input type="hidden" name="courseid" value="<%=data.courseId %>">
                                                                 <input type="hidden" name="fsname" value="<%= data.feedbackSessionName%>">
+                                                                <input type="hidden" name="moderatedquestion" value="<%= question.questionNumber %>">
                                                                 <% if (possibleGiverWithNoResponse.matches(Const.REGEXP_TEAM)) { %>
                                                                 <input type="hidden" name="moderatedstudent" value="<%= possibleGiverWithNoResponse.replace(Const.TEAM_OF_EMAIL_OWNER,"")%>">
                                                                 <% } else { %>

--- a/src/test/java/teammates/test/cases/ui/browsertests/InstructorFeedbackResultsPageUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/InstructorFeedbackResultsPageUiTest.java
@@ -107,7 +107,7 @@ public class InstructorFeedbackResultsPageUiTest extends BaseUiTestCase {
     
     public void testSortAction(){
         
-        ______TS("test sort types");
+        ______TS("test sort by giver > recipient > question");
         
         resultsPage = loginToInstructorFeedbackResultsPage("CFResultsUiT.instr", "Open Session");
         resultsPage.displayByGiverRecipientQuestion();
@@ -129,6 +129,8 @@ public class InstructorFeedbackResultsPageUiTest extends BaseUiTestCase {
 
         resultsPage.verifyHtmlMainContent("/instructorFeedbackResultsSortGiverRecipientQuestion.html");
         
+        ______TS("test sort by recipient > giver > question");
+        
         resultsPage.displayByRecipientGiverQuestion();
         resultsPage.verifyHtmlMainContent("/instructorFeedbackResultsSortRecipientGiverQuestion.html");
 
@@ -147,9 +149,12 @@ public class InstructorFeedbackResultsPageUiTest extends BaseUiTestCase {
         assertEquals(true, resultsPage.clickQuestionAdditionalInfoButton(12,"giver-1-recipient-1"));
         assertEquals(false, resultsPage.clickQuestionAdditionalInfoButton(12,"giver-1-recipient-1"));
         
+        ______TS("test sort by giver > question > recipient");
         
         resultsPage.displayByGiverQuestionRecipient();
         resultsPage.verifyHtmlMainContent("/instructorFeedbackResultsSortGiverQuestionRecipient.html");
+        
+        ______TS("test sort by recipient > question > giver");
         
         resultsPage.displayByRecipientQuestionGiver();
         resultsPage.verifyHtmlMainContent("/instructorFeedbackResultsSortRecipientQuestionGiver.html");
@@ -157,18 +162,27 @@ public class InstructorFeedbackResultsPageUiTest extends BaseUiTestCase {
         // Do not sort by team
         resultsPage.clickGroupByTeam();
         
+        ______TS("test order in giver > recipient > question team");
+        
         resultsPage.displayByGiverRecipientQuestion();
         resultsPage.verifyHtmlMainContent("/instructorFeedbackResultsSortGiverRecipientQuestionTeam.html");
 
+        ______TS("test order in recipient > giver > question team");
+        
         resultsPage.displayByRecipientGiverQuestion();
         resultsPage.verifyHtmlMainContent("/instructorFeedbackResultsSortRecipientGiverQuestionTeam.html");
+        
+        ______TS("test order in giver > question > recipient team");
         
         resultsPage.displayByGiverQuestionRecipient();
         resultsPage.verifyHtmlMainContent("/instructorFeedbackResultsSortGiverQuestionRecipientTeam.html");
         
+        ______TS("test order in recipient > question > giver team");
+        
         resultsPage.displayByRecipientQuestionGiver();
         resultsPage.verifyHtmlMainContent("/instructorFeedbackResultsSortRecipientQuestionGiverTeam.html");
         
+        ______TS("test sort by question");
         
         //By question
         resultsPage.displayByQuestion();

--- a/src/test/java/teammates/test/pageobjects/InstructorFeedbackResultsPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorFeedbackResultsPage.java
@@ -379,7 +379,7 @@ public class InstructorFeedbackResultsPage extends AppPage {
     }
     
     public void verifyModerateResponseButtonBelongsTo(WebElement btn, String email) {
-        assertEquals(email, btn.findElement(By.xpath("input[4]")).getAttribute("value"));
+        assertEquals(email, btn.findElement(By.xpath("input[5]")).getAttribute("value"));
     }
     
     public WebElement getModerateResponseButtonInQuestionView(int qnNo, int responseNo) {

--- a/src/test/resources/pages/InstructorEditStudentFeedbackPageModified.html
+++ b/src/test/resources/pages/InstructorEditStudentFeedbackPageModified.html
@@ -227,7 +227,7 @@ ul #nav {
 <body>
     
         <nav class="navbar navbar-default navbar-fixed-top">
-            <h3 class="text-center">Moderating Session for Student student1 In Course1 (student1InIESFPTCourse@gmail.tmt)</h3>
+            <h3 class="text-center">Moderating Responses for Student student1 In Course1 (student1InIESFPTCourse@gmail.tmt)</h3>
         </nav>    
     
     <div id="frameBody">
@@ -272,13 +272,13 @@ ul #nav {
                         <div class="form-group">
                             <label class="col-sm-2 control-label">Opening time:</label>
                             <div class="col-sm-10">
-                                <p class="form-control-static">01 Apr 2012, 23:59</p>
+                                <p class="form-control-static">Sun, 01 Apr 2012, 23:59</p>
                             </div>
                         </div>
                         <div class="form-group">
                             <label class="col-sm-2 control-label">Closing time:</label>
                             <div class="col-sm-10">
-                                <p class="form-control-static">30 Apr 2017, 23:59</p>
+                                <p class="form-control-static">Sun, 30 Apr 2017, 23:59</p>
                             </div>
                         </div>
                         <div class="form-group">
@@ -392,8 +392,8 @@ ul #nav {
             
                 	<input type="hidden" value="student1InIESFPTCourse@gmail.tmt" name="moderatedstudent" />
             
-                    <input type="submit" value="Submit Feedback" title="" data-placement="top" data-toggle="tooltip" id="response_submit_button" class="btn btn-primary" data-original-title="You can save your responses at any time and come back later to continue." />
-            
+                    <input type="submit" value="Submit Feedback" title="You can save your responses at any time and come back later to continue." data-placement="top" data-toggle="tooltip" id="response_submit_button" class="btn btn-primary"/>
+                    
             </div>
             <br /><br />
         </form>

--- a/src/test/resources/pages/InstructorEditStudentFeedbackPageOpen.html
+++ b/src/test/resources/pages/InstructorEditStudentFeedbackPageOpen.html
@@ -227,7 +227,7 @@ ul #nav {
 <body>
     
         <nav class="navbar navbar-default navbar-fixed-top">
-            <h3 class="text-center">Moderating Session for Student student1 In Course1 (student1InIESFPTCourse@gmail.tmt)</h3>
+            <h3 class="text-center">Moderating Responses for Student student1 In Course1 (student1InIESFPTCourse@gmail.tmt)</h3>
         </nav>    
     
     <div id="frameBody">
@@ -272,13 +272,13 @@ ul #nav {
                         <div class="form-group">
                             <label class="col-sm-2 control-label">Opening time:</label>
                             <div class="col-sm-10">
-                                <p class="form-control-static">01 Apr 2012, 23:59</p>
+                                <p class="form-control-static">Sun, 01 Apr 2012, 23:59</p>
                             </div>
                         </div>
                         <div class="form-group">
                             <label class="col-sm-2 control-label">Closing time:</label>
                             <div class="col-sm-10">
-                                <p class="form-control-static">30 Apr 2017, 23:59</p>
+                                <p class="form-control-static">Sun, 30 Apr 2017, 23:59</p>
                             </div>
                         </div>
                         <div class="form-group">
@@ -385,8 +385,8 @@ ul #nav {
             
                 	<input type="hidden" value="student1InIESFPTCourse@gmail.tmt" name="moderatedstudent" />
             
-                    <input type="submit" value="Submit Feedback" title="" data-placement="top" data-toggle="tooltip" id="response_submit_button" class="btn btn-primary" data-original-title="You can save your responses at any time and come back later to continue." />
-            
+                    <input type="submit" value="Submit Feedback" title="You can save your responses at any time and come back later to continue." data-placement="top" data-toggle="tooltip" class="btn btn-primary" id="response_submit_button"/>
+                    
             </div>
             <br /><br />
         </form>

--- a/src/test/resources/pages/instructorFeedbackResultsAjaxByQuestion.html
+++ b/src/test/resources/pages/instructorFeedbackResultsAjaxByQuestion.html
@@ -313,6 +313,7 @@
                                                         <input class="btn btn-default btn-xs" data-toggle="tooltip" title="Edit the responses given by this student" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -331,6 +332,7 @@
                                                         <input class="btn btn-default btn-xs" data-toggle="tooltip" title="Edit the responses given by this student" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -349,6 +351,7 @@
                                                         <input class="btn btn-default btn-xs" data-toggle="tooltip" title="Edit the responses given by this student" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -367,6 +370,7 @@
                                                         <input class="btn btn-default btn-xs" data-toggle="tooltip" title="Edit the responses given by this student" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -385,6 +389,7 @@
                                                         <input class="btn btn-default btn-xs" data-toggle="tooltip" title="Edit the responses given by this student" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -403,6 +408,7 @@
                                                         <input class="btn btn-default btn-xs" data-toggle="tooltip" title="Edit the responses given by this student" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -421,6 +427,7 @@
                                                         <input class="btn btn-default btn-xs" data-toggle="tooltip" title="Edit the responses given by this student" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -439,6 +446,7 @@
                                                         <input class="btn btn-default btn-xs" data-toggle="tooltip" title="Edit the responses given by this student" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>

--- a/src/test/resources/pages/instructorFeedbackResultsAjaxByQuestionHelperView.html
+++ b/src/test/resources/pages/instructorFeedbackResultsAjaxByQuestionHelperView.html
@@ -310,6 +310,7 @@
                                                         <input class="btn btn-default btn-xs" data-toggle="tooltip" disabled="disabled" title="Edit the responses given by this student" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -328,6 +329,7 @@
                                                         <input class="btn btn-default btn-xs" data-toggle="tooltip" disabled="disabled" title="Edit the responses given by this student" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -346,6 +348,7 @@
                                                         <input class="btn btn-default btn-xs" data-toggle="tooltip" disabled="disabled" title="Edit the responses given by this student" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -364,6 +367,7 @@
                                                         <input class="btn btn-default btn-xs" data-toggle="tooltip" disabled="disabled" title="Edit the responses given by this student" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -382,6 +386,7 @@
                                                         <input class="btn btn-default btn-xs" data-toggle="tooltip" disabled="disabled" title="Edit the responses given by this student" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -400,6 +405,7 @@
                                                         <input class="btn btn-default btn-xs" data-toggle="tooltip" disabled="disabled" title="Edit the responses given by this student" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -418,6 +424,7 @@
                                                         <input class="btn btn-default btn-xs" data-toggle="tooltip" disabled="disabled" title="Edit the responses given by this student" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -436,6 +443,7 @@
                                                         <input class="btn btn-default btn-xs" data-toggle="tooltip" disabled="disabled" title="Edit the responses given by this student" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>

--- a/src/test/resources/pages/instructorFeedbackResultsAjaxByRQG.html
+++ b/src/test/resources/pages/instructorFeedbackResultsAjaxByRQG.html
@@ -349,6 +349,7 @@
                                                         <input class="btn btn-default btn-xs" data-toggle="tooltip" title="Edit the responses given by this student" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="drop.out@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -411,6 +412,7 @@
                                                         <input class="btn btn-default btn-xs" data-toggle="tooltip" title="Edit the responses given by this student" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -548,6 +550,7 @@
                                                         <input class="btn btn-default btn-xs" data-toggle="tooltip" title="Edit the responses given by this student" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -685,6 +688,7 @@
                                                         <input class="btn btn-default btn-xs" data-toggle="tooltip" title="Edit the responses given by this student" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -792,6 +796,7 @@
                                                         <input class="btn btn-default btn-xs" data-toggle="tooltip" title="Edit the responses given by this student" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -899,6 +904,7 @@
                                                         <input class="btn btn-default btn-xs" data-toggle="tooltip" title="Edit the responses given by this student" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -1006,6 +1012,7 @@
                                                         <input class="btn btn-default btn-xs" data-toggle="tooltip" title="Edit the responses given by this student" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -1123,6 +1130,7 @@
                                                         <input class="btn btn-default btn-xs" data-toggle="tooltip" title="Edit the responses given by this student" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -1227,6 +1235,7 @@
                                                         <input class="btn btn-default btn-xs" data-toggle="tooltip" title="Edit the responses given by this student" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -1341,6 +1350,7 @@
                                              <input class="btn btn-default btn-xs" data-toggle="tooltip" title="Edit the responses given by this student" type="submit" value="Moderate Response"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
+                                                                                          <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                                           <input name="moderatedstudent" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                        </form>
                                        </td>
@@ -1449,6 +1459,7 @@
                                              <input class="btn btn-default btn-xs" data-toggle="tooltip" title="Edit the responses given by this student" type="submit" value="Moderate Response"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
+                                                                                          <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                                           <input name="moderatedstudent" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                        </form>
                                        </td>
@@ -1473,6 +1484,7 @@
                                              <input class="btn btn-default btn-xs" data-toggle="tooltip" title="Edit the responses given by this student" type="submit" value="Moderate Response"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
+                                                                                          <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                                           <input name="moderatedstudent" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt"/>
                                                                                        </form>
                                        </td>
@@ -1538,6 +1550,7 @@
                                              <input class="btn btn-default btn-xs" data-toggle="tooltip" title="Edit the responses given by this student" type="submit" value="Moderate Response"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
+                                                                                          <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                                           <input name="moderatedstudent" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                        </form>
                                        </td>
@@ -1562,6 +1575,7 @@
                                              <input class="btn btn-default btn-xs" data-toggle="tooltip" title="Edit the responses given by this student" type="submit" value="Moderate Response"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
+                                                                                          <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                                           <input name="moderatedstudent" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt"/>
                                                                                        </form>
                                        </td>
@@ -1665,6 +1679,7 @@
                                              <input class="btn btn-default btn-xs" data-toggle="tooltip" title="Edit the responses given by this student" type="submit" value="Moderate Response"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
+                                                                                          <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                                           <input name="moderatedstudent" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                        </form>
                                        </td>
@@ -1689,6 +1704,7 @@
                                              <input class="btn btn-default btn-xs" data-toggle="tooltip" title="Edit the responses given by this student" type="submit" value="Moderate Response"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
+                                                                                          <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                                           <input name="moderatedstudent" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt"/>
                                                                                        </form>
                                        </td>
@@ -1779,6 +1795,7 @@
                                              <input class="btn btn-default btn-xs" data-toggle="tooltip" title="Edit the responses given by this student" type="submit" value="Moderate Response"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
+                                                                                          <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                                           <input name="moderatedstudent" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                        </form>
                                        </td>
@@ -1804,6 +1821,7 @@
                                              <input class="btn btn-default btn-xs" data-toggle="tooltip" title="Edit the responses given by this student" type="submit" value="Moderate Response"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
+                                                                                          <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                                           <input name="moderatedstudent" type="hidden" value="drop.out@gmail.tmt"/>
                                                                                        </form>
                                        </td>
@@ -1871,6 +1889,7 @@
                                              <input class="btn btn-default btn-xs" data-toggle="tooltip" title="Edit the responses given by this student" type="submit" value="Moderate Response"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
+                                                                                          <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                                           <input name="moderatedstudent" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt"/>
                                                                                        </form>
                                        </td>
@@ -1979,6 +1998,7 @@
                                              <input class="btn btn-default btn-xs" data-toggle="tooltip" title="Edit the responses given by this student" type="submit" value="Moderate Response"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
+                                                                                          <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                                           <input name="moderatedstudent" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                        </form>
                                        </td>
@@ -2003,6 +2023,7 @@
                                              <input class="btn btn-default btn-xs" data-toggle="tooltip" title="Edit the responses given by this student" type="submit" value="Moderate Response"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
+                                                                                          <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                                           <input name="moderatedstudent" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt"/>
                                                                                        </form>
                                        </td>
@@ -2068,6 +2089,7 @@
                                              <input class="btn btn-default btn-xs" data-toggle="tooltip" title="Edit the responses given by this student" type="submit" value="Moderate Response"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
+                                                                                          <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                                           <input name="moderatedstudent" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                        </form>
                                        </td>
@@ -2092,6 +2114,7 @@
                                              <input class="btn btn-default btn-xs" data-toggle="tooltip" title="Edit the responses given by this student" type="submit" value="Moderate Response"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
+                                                                                          <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                                           <input name="moderatedstudent" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt"/>
                                                                                        </form>
                                        </td>
@@ -2199,6 +2222,7 @@
                                              <input class="btn btn-default btn-xs" data-toggle="tooltip" title="Edit the responses given by this student" type="submit" value="Moderate Response"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
+                                                                                          <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                                           <input name="moderatedstudent" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                        </form>
                                        </td>
@@ -2223,6 +2247,7 @@
                                              <input class="btn btn-default btn-xs" data-toggle="tooltip" title="Edit the responses given by this student" type="submit" value="Moderate Response"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
+                                                                                          <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                                           <input name="moderatedstudent" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt"/>
                                                                                        </form>
                                        </td>
@@ -2313,6 +2338,7 @@
                                              <input class="btn btn-default btn-xs" data-toggle="tooltip" title="Edit the responses given by this student" type="submit" value="Moderate Response"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
+                                                                                          <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                                           <input name="moderatedstudent" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt"/>
                                                                                        </form>
                                        </td>
@@ -2421,6 +2447,7 @@
                                              <input class="btn btn-default btn-xs" data-toggle="tooltip" title="Edit the responses given by this student" type="submit" value="Moderate Response"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
+                                                                                          <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                                           <input name="moderatedstudent" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                        </form>
                                        </td>
@@ -2445,6 +2472,7 @@
                                              <input class="btn btn-default btn-xs" data-toggle="tooltip" title="Edit the responses given by this student" type="submit" value="Moderate Response"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
+                                                                                          <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                                           <input name="moderatedstudent" type="hidden" value="CFResultsUiT.charlie.d@gmail.tmt"/>
                                                                                        </form>
                                        </td>
@@ -2468,6 +2496,7 @@
                                              <input class="btn btn-default btn-xs" data-toggle="tooltip" title="Edit the responses given by this student" type="submit" value="Moderate Response"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
+                                                                                          <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                                           <input name="moderatedstudent" type="hidden" value="CFResultsUiT.danny.e@gmail.tmt"/>
                                                                                        </form>
                                        </td>
@@ -2491,6 +2520,7 @@
                                              <input class="btn btn-default btn-xs" data-toggle="tooltip" title="Edit the responses given by this student" type="submit" value="Moderate Response"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
+                                                                                          <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                                           <input name="moderatedstudent" type="hidden" value="drop.out@gmail.tmt"/>
                                                                                        </form>
                                        </td>
@@ -2514,6 +2544,7 @@
                                              <input class="btn btn-default btn-xs" data-toggle="tooltip" title="Edit the responses given by this student" type="submit" value="Moderate Response"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
+                                                                                          <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                                           <input name="moderatedstudent" type="hidden" value="extra.guy@gmail.tmt"/>
                                                                                        </form>
                                        </td>
@@ -2604,6 +2635,7 @@
                                              <input class="btn btn-default btn-xs" data-toggle="tooltip" title="Edit the responses given by this student" type="submit" value="Moderate Response"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
+                                                                                          <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                                           <input name="moderatedstudent" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt"/>
                                                                                        </form>
                                        </td>
@@ -2629,6 +2661,7 @@
                                              <input class="btn btn-default btn-xs" data-toggle="tooltip" title="Edit the responses given by this student" type="submit" value="Moderate Response"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
+                                                                                          <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                                           <input name="moderatedstudent" type="hidden" value="drop.out@gmail.tmt"/>
                                                                                        </form>
                                        </td>
@@ -2737,6 +2770,7 @@
                                              <input class="btn btn-default btn-xs" data-toggle="tooltip" title="Edit the responses given by this student" type="submit" value="Moderate Response"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
+                                                                                          <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                                           <input name="moderatedstudent" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                        </form>
                                        </td>
@@ -2761,6 +2795,7 @@
                                              <input class="btn btn-default btn-xs" data-toggle="tooltip" title="Edit the responses given by this student" type="submit" value="Moderate Response"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
+                                                                                          <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                                           <input name="moderatedstudent" type="hidden" value="CFResultsUiT.charlie.d@gmail.tmt"/>
                                                                                        </form>
                                        </td>
@@ -2784,6 +2819,7 @@
                                              <input class="btn btn-default btn-xs" data-toggle="tooltip" title="Edit the responses given by this student" type="submit" value="Moderate Response"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
+                                                                                          <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                                           <input name="moderatedstudent" type="hidden" value="CFResultsUiT.danny.e@gmail.tmt"/>
                                                                                        </form>
                                        </td>
@@ -2807,6 +2843,7 @@
                                              <input class="btn btn-default btn-xs" data-toggle="tooltip" title="Edit the responses given by this student" type="submit" value="Moderate Response"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
+                                                                                          <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                                           <input name="moderatedstudent" type="hidden" value="drop.out@gmail.tmt"/>
                                                                                        </form>
                                        </td>
@@ -2830,6 +2867,7 @@
                                              <input class="btn btn-default btn-xs" data-toggle="tooltip" title="Edit the responses given by this student" type="submit" value="Moderate Response"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
+                                                                                          <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                                           <input name="moderatedstudent" type="hidden" value="extra.guy@gmail.tmt"/>
                                                                                        </form>
                                        </td>
@@ -2920,6 +2958,7 @@
                                              <input class="btn btn-default btn-xs" data-toggle="tooltip" title="Edit the responses given by this student" type="submit" value="Moderate Response"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
+                                                                                          <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                                           <input name="moderatedstudent" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                        </form>
                                        </td>
@@ -3057,6 +3096,7 @@
                                              <input class="btn btn-default btn-xs" data-toggle="tooltip" title="Edit the responses given by this student" type="submit" value="Moderate Response"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
+                                                                                          <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                                           <input name="moderatedstudent" type="hidden" value="drop.out@gmail.tmt"/>
                                                                                        </form>
                                        </td>
@@ -3164,6 +3204,7 @@
                                              <input class="btn btn-default btn-xs" data-toggle="tooltip" title="Edit the responses given by this student" type="submit" value="Moderate Response"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
+                                                                                          <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                                           <input name="moderatedstudent" type="hidden" value="drop.out@gmail.tmt"/>
                                                                                        </form>
                                        </td>
@@ -3253,6 +3294,7 @@
                                              <input class="btn btn-default btn-xs" data-toggle="tooltip" title="Edit the responses given by this student" type="submit" value="Moderate Response"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
+                                                                                          <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                                           <input name="moderatedstudent" type="hidden" value="CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                        </form>
                                        </td>

--- a/src/test/resources/pages/instructorFeedbackResultsFilteredBySectionA.html
+++ b/src/test/resources/pages/instructorFeedbackResultsFilteredBySectionA.html
@@ -310,6 +310,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -328,6 +329,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -346,6 +348,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -364,6 +367,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -382,6 +386,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -400,6 +405,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -418,6 +424,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -436,6 +443,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -518,6 +526,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -534,6 +543,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -550,6 +560,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -566,6 +577,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -582,6 +594,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -598,6 +611,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -710,6 +724,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -927,6 +942,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -945,6 +961,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -961,6 +978,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -977,6 +995,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -993,6 +1012,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -1009,6 +1029,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -1166,6 +1187,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -1184,6 +1206,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -1200,6 +1223,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -1216,6 +1240,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -1232,6 +1257,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -1248,6 +1274,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -1375,6 +1402,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -1391,6 +1419,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -1407,6 +1436,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -1423,6 +1453,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -1439,6 +1470,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -1455,6 +1487,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -1592,6 +1625,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -1610,6 +1644,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -1626,6 +1661,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -1642,6 +1678,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -1658,6 +1695,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -1674,6 +1712,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -1801,6 +1840,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -1817,6 +1857,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -1833,6 +1874,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -1849,6 +1891,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -1865,6 +1908,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -1881,6 +1925,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2018,6 +2063,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -2034,6 +2080,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2050,6 +2097,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2066,6 +2114,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2082,6 +2131,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2098,6 +2148,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2229,6 +2280,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -2245,6 +2297,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2261,6 +2314,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2277,6 +2331,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2293,6 +2348,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2309,6 +2365,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2443,6 +2500,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -2459,6 +2517,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2475,6 +2534,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2491,6 +2551,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2507,6 +2568,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2523,6 +2585,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2690,6 +2753,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -2708,6 +2772,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -2726,6 +2791,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -2744,6 +2810,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -2760,6 +2827,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2776,6 +2844,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2792,6 +2861,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2808,6 +2878,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2824,6 +2895,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2840,6 +2912,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2856,6 +2929,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2872,6 +2946,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2888,6 +2963,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2904,6 +2980,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2920,6 +2997,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2936,6 +3014,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2952,6 +3031,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2968,6 +3048,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2984,6 +3065,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3000,6 +3082,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3016,6 +3099,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3032,6 +3116,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3171,6 +3256,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -3189,6 +3275,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -3205,6 +3292,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3221,6 +3309,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3237,6 +3326,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3253,6 +3343,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3269,6 +3360,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3285,6 +3377,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3301,6 +3394,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3317,6 +3411,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3333,6 +3428,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3349,6 +3445,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3365,6 +3462,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3381,6 +3479,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3397,6 +3496,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3413,6 +3513,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3429,6 +3530,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3445,6 +3547,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3461,6 +3564,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3477,6 +3581,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3612,6 +3717,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -3630,6 +3736,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -3646,6 +3753,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3662,6 +3770,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3678,6 +3787,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3694,6 +3804,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3710,6 +3821,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3726,6 +3838,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3742,6 +3855,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3758,6 +3872,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3774,6 +3889,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3790,6 +3906,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3806,6 +3923,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3822,6 +3940,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3838,6 +3957,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3854,6 +3974,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3870,6 +3991,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3886,6 +4008,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3902,6 +4025,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3918,6 +4042,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -4042,6 +4167,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>

--- a/src/test/resources/pages/instructorFeedbackResultsFilteredBySectionB.html
+++ b/src/test/resources/pages/instructorFeedbackResultsFilteredBySectionB.html
@@ -312,6 +312,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>

--- a/src/test/resources/pages/instructorFeedbackResultsPageOpen.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageOpen.html
@@ -597,6 +597,7 @@ ul #nav {
         	                                  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                     			</td>
@@ -615,6 +616,7 @@ ul #nav {
         	                                  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                     			</td>
@@ -633,6 +635,7 @@ ul #nav {
         	                                  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                     			</td>
@@ -651,6 +654,7 @@ ul #nav {
         	                                  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                     			</td>
@@ -669,6 +673,7 @@ ul #nav {
         	                                  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                     			</td>
@@ -687,6 +692,7 @@ ul #nav {
         	                                  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                     			</td>
@@ -705,6 +711,7 @@ ul #nav {
         	                                  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                     			</td>
@@ -723,6 +730,7 @@ ul #nav {
         	                                  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                     			</td>
@@ -805,6 +813,7 @@ ul #nav {
         	                                  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                     			</td>
@@ -821,6 +830,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -837,6 +847,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -853,6 +864,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -869,6 +881,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -885,6 +898,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -901,6 +915,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -983,6 +998,7 @@ ul #nav {
         	                                  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                     			</td>
@@ -1065,6 +1081,7 @@ ul #nav {
         	                                  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                     			</td>
@@ -1282,6 +1299,7 @@ ul #nav {
         	                                  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                     			</td>
@@ -1300,6 +1318,7 @@ ul #nav {
         	                                  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                     			</td>
@@ -1316,6 +1335,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -1332,6 +1352,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -1348,6 +1369,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -1364,6 +1386,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -1380,6 +1403,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -1537,6 +1561,7 @@ ul #nav {
         	                                  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                     			</td>
@@ -1555,6 +1580,7 @@ ul #nav {
         	                                  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                     			</td>
@@ -1571,6 +1597,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -1587,6 +1614,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -1603,6 +1631,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -1619,6 +1648,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -1635,6 +1665,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -1762,6 +1793,7 @@ ul #nav {
         	                                  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                     			</td>
@@ -1778,6 +1810,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -1794,6 +1827,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -1810,6 +1844,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -1826,6 +1861,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -1842,6 +1878,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -1858,6 +1895,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -1995,6 +2033,7 @@ ul #nav {
         	                                  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                     			</td>
@@ -2013,6 +2052,7 @@ ul #nav {
         	                                  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                     			</td>
@@ -2029,6 +2069,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -2045,6 +2086,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -2061,6 +2103,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -2077,6 +2120,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -2093,6 +2137,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -2220,6 +2265,7 @@ ul #nav {
         	                                  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                     			</td>
@@ -2236,6 +2282,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -2252,6 +2299,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -2268,6 +2316,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -2284,6 +2333,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -2300,6 +2350,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -2316,6 +2367,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -2453,6 +2505,7 @@ ul #nav {
         	                                  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                     			</td>
@@ -2469,6 +2522,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -2485,6 +2539,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -2501,6 +2556,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -2517,6 +2573,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -2533,6 +2590,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -2549,6 +2607,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -2673,6 +2732,7 @@ ul #nav {
         	                                  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                     			</td>
@@ -2689,6 +2749,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -2705,6 +2766,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -2721,6 +2783,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -2737,6 +2800,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -2753,6 +2817,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -2769,6 +2834,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -2903,6 +2969,7 @@ ul #nav {
         	                                  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                     			</td>
@@ -2919,6 +2986,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -2935,6 +3003,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -2951,6 +3020,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -2967,6 +3037,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -2983,6 +3054,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -2999,6 +3071,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -3166,6 +3239,7 @@ ul #nav {
         	                                  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                     			</td>
@@ -3184,6 +3258,7 @@ ul #nav {
         	                                  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                     			</td>
@@ -3202,6 +3277,7 @@ ul #nav {
         	                                  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                     			</td>
@@ -3220,6 +3296,7 @@ ul #nav {
         	                                  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                     			</td>
@@ -3236,6 +3313,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -3252,6 +3330,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -3268,6 +3347,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -3284,6 +3364,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -3300,6 +3381,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -3316,6 +3398,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -3332,6 +3415,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -3348,6 +3432,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -3364,6 +3449,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -3380,6 +3466,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -3396,6 +3483,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -3412,6 +3500,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -3428,6 +3517,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -3444,6 +3534,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -3460,6 +3551,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -3476,6 +3568,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -3492,6 +3585,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -3508,6 +3602,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -3524,6 +3619,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -3663,6 +3759,7 @@ ul #nav {
         	                                  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                     			</td>
@@ -3681,6 +3778,7 @@ ul #nav {
         	                                  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                     			</td>
@@ -3697,6 +3795,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -3713,6 +3812,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -3729,6 +3829,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -3745,6 +3846,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -3761,6 +3863,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -3777,6 +3880,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -3793,6 +3897,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -3809,6 +3914,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -3825,6 +3931,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -3841,6 +3948,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -3857,6 +3965,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -3873,6 +3982,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -3889,6 +3999,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -3905,6 +4016,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -3921,6 +4033,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -3937,6 +4050,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -3953,6 +4067,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -3969,6 +4084,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -3985,6 +4101,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -4120,6 +4237,7 @@ ul #nav {
         	                                  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                     			</td>
@@ -4138,6 +4256,7 @@ ul #nav {
         	                                  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                     			</td>
@@ -4154,6 +4273,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -4170,6 +4290,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -4186,6 +4307,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -4202,6 +4324,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -4218,6 +4341,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -4234,6 +4358,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -4250,6 +4375,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -4266,6 +4392,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -4282,6 +4409,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -4298,6 +4426,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -4314,6 +4443,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -4330,6 +4460,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -4346,6 +4477,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -4362,6 +4494,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -4378,6 +4511,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -4394,6 +4528,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -4410,6 +4545,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -4426,6 +4562,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -4442,6 +4579,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -4566,6 +4704,7 @@ ul #nav {
         	                                  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                     			</td>
@@ -4582,6 +4721,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -4598,6 +4738,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -4614,6 +4755,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -4630,6 +4772,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -4646,6 +4789,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>
@@ -4662,6 +4806,7 @@ ul #nav {
         	                                			  			<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
 			                                                        <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                         			                                <input name="fsname" type="hidden" value="First Session"/>
+                                                              <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                 			        <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
 			                                                    </form>
                         			            			</td>

--- a/src/test/resources/pages/instructorFeedbackResultsPageOpenWithHelperView1.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageOpenWithHelperView1.html
@@ -307,6 +307,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" disabled="disabled" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -325,6 +326,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" disabled="disabled" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -343,6 +345,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" disabled="disabled" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -361,6 +364,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" disabled="disabled" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -379,6 +383,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" disabled="disabled" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -397,6 +402,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" disabled="disabled" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -415,6 +421,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" disabled="disabled" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -433,6 +440,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" disabled="disabled" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -1088,6 +1096,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" disabled="disabled" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -1104,6 +1113,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" disabled="disabled" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -1120,6 +1130,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" disabled="disabled" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -1136,6 +1147,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" disabled="disabled" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -1152,6 +1164,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" disabled="disabled" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -1168,6 +1181,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" disabled="disabled" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -1184,6 +1198,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>

--- a/src/test/resources/pages/instructorFeedbackResultsPageOpenWithHelperView2.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageOpenWithHelperView2.html
@@ -307,6 +307,7 @@
                                  						<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    </form>
                            						</td>
@@ -325,6 +326,7 @@
                                  						<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    </form>
                            						</td>
@@ -343,6 +345,7 @@
                                  						<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    </form>
                            						</td>
@@ -361,6 +364,7 @@
                                  						<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    </form>
                            						</td>
@@ -379,6 +383,7 @@
                                  						<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    </form>
                            						</td>
@@ -397,6 +402,7 @@
                                  						<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    </form>
                            						</td>
@@ -415,6 +421,7 @@
                                  						<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    </form>
                            						</td>
@@ -433,6 +440,7 @@
                                  						<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    </form>
                            						</td>
@@ -515,6 +523,7 @@
                                  						<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    </form>
                            						</td>
@@ -531,6 +540,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -547,6 +557,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -563,6 +574,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -579,6 +591,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -595,6 +608,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -611,6 +625,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" disabled="disabled" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -723,6 +738,7 @@
                                  						<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" disabled="disabled" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    </form>
                            						</td>
@@ -940,6 +956,7 @@
                                  						<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    </form>
                            						</td>
@@ -958,6 +975,7 @@
                                  						<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    </form>
                            						</td>
@@ -974,6 +992,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -990,6 +1009,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -1006,6 +1026,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -1022,6 +1043,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -1038,6 +1060,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" disabled="disabled" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -1195,6 +1218,7 @@
                                  						<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    </form>
                            						</td>
@@ -1211,6 +1235,7 @@
                                                             <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                             <input name="fsname" type="hidden" value="First Session"/>
+                                                            <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                             <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -1227,6 +1252,7 @@
                                                             <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                             <input name="fsname" type="hidden" value="First Session"/>
+                                                            <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                             <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -1243,6 +1269,7 @@
                                                             <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                             <input name="fsname" type="hidden" value="First Session"/>
+                                                            <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                             <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -1259,6 +1286,7 @@
                                                             <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                             <input name="fsname" type="hidden" value="First Session"/>
+                                                            <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                             <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -1275,6 +1303,7 @@
                                                             <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                             <input name="fsname" type="hidden" value="First Session"/>
+                                                            <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                             <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -1291,6 +1320,7 @@
                                                             <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" disabled="disabled" title="" type="submit" value="Moderate Response"/>
                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                             <input name="fsname" type="hidden" value="First Session"/>
+                                                            <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                             <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -1418,6 +1448,7 @@
                                  						<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    </form>
                            						</td>
@@ -1434,6 +1465,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -1450,6 +1482,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -1466,6 +1499,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -1482,6 +1516,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -1498,6 +1533,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -1514,6 +1550,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" disabled="disabled" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -1651,6 +1688,7 @@
                                  						<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    </form>
                            						</td>
@@ -1669,6 +1707,7 @@
                                  						<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    </form>
                            						</td>
@@ -1685,6 +1724,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -1701,6 +1741,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -1717,6 +1758,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -1733,6 +1775,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -1749,6 +1792,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" disabled="disabled" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -1876,6 +1920,7 @@
                                  						<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    </form>
                            						</td>
@@ -1892,6 +1937,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -1908,6 +1954,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -1924,6 +1971,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -1940,6 +1988,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -1956,6 +2005,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -1972,6 +2022,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" disabled="disabled" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -2109,6 +2160,7 @@
                                  						<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    </form>
                            						</td>
@@ -2125,6 +2177,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -2141,6 +2194,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -2157,6 +2211,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -2173,6 +2228,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -2189,6 +2245,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -2205,6 +2262,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" disabled="disabled" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -2329,6 +2387,7 @@
                                  						<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    </form>
                            						</td>
@@ -2345,6 +2404,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -2361,6 +2421,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -2377,6 +2438,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -2393,6 +2455,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -2409,6 +2472,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -2425,6 +2489,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" disabled="disabled" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -2559,6 +2624,7 @@
                                  						<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    </form>
                            						</td>
@@ -2575,6 +2641,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -2591,6 +2658,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -2607,6 +2675,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -2623,6 +2692,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -2639,6 +2709,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -2655,6 +2726,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" disabled="disabled" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -2822,6 +2894,7 @@
                                  						<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    </form>
                            						</td>
@@ -2840,6 +2913,7 @@
                                  						<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    </form>
                            						</td>
@@ -2858,6 +2932,7 @@
                                  						<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    </form>
                            						</td>
@@ -2876,6 +2951,7 @@
                                  						<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    </form>
                            						</td>
@@ -2892,6 +2968,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -2908,6 +2985,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -2924,6 +3002,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -2940,6 +3019,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -2956,6 +3036,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -2972,6 +3053,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -2988,6 +3070,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -3004,6 +3087,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -3020,6 +3104,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -3036,6 +3121,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -3052,6 +3138,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -3068,6 +3155,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -3084,6 +3172,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -3100,6 +3189,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -3116,6 +3206,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -3132,6 +3223,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -3148,6 +3240,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -3164,6 +3257,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -3180,6 +3274,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" disabled="disabled" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -3319,6 +3414,7 @@
                                  						<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    </form>
                            						</td>
@@ -3337,6 +3433,7 @@
                                  						<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    </form>
                            						</td>
@@ -3353,6 +3450,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -3369,6 +3467,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -3385,6 +3484,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -3401,6 +3501,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -3417,6 +3518,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -3433,6 +3535,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -3449,6 +3552,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -3465,6 +3569,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -3481,6 +3586,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -3497,6 +3603,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -3513,6 +3620,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -3529,6 +3637,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -3545,6 +3654,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -3561,6 +3671,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -3577,6 +3688,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -3593,6 +3705,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -3609,6 +3722,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -3625,6 +3739,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -3641,6 +3756,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" disabled="disabled" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -3776,6 +3892,7 @@
                                  						<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    </form>
                            						</td>
@@ -3794,6 +3911,7 @@
                                  						<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    </form>
                            						</td>
@@ -3810,6 +3928,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -3826,6 +3945,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -3842,6 +3962,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -3858,6 +3979,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -3874,6 +3996,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -3890,6 +4013,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -3906,6 +4030,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -3922,6 +4047,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -3938,6 +4064,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -3954,6 +4081,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -3970,6 +4098,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -3986,6 +4115,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -4002,6 +4132,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -4018,6 +4149,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -4034,6 +4166,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -4050,6 +4183,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -4066,6 +4200,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -4082,6 +4217,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -4098,6 +4234,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" disabled="disabled" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -4222,6 +4359,7 @@
                                  						<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    </form>
                            						</td>
@@ -4238,6 +4376,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -4254,6 +4393,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -4270,6 +4410,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -4286,6 +4427,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -4302,6 +4444,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>
@@ -4318,6 +4461,7 @@
                                  										<input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" disabled="disabled" title="" type="submit" value="Moderate Response"/>
                                                         				<input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         				<input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         				<input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                    				</form>
                            										</td>

--- a/src/test/resources/pages/instructorFeedbackResultsSortQuestion.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortQuestion.html
@@ -310,6 +310,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -328,6 +329,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -346,6 +348,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -364,6 +367,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -382,6 +386,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -400,6 +405,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -418,6 +424,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -436,6 +443,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -518,6 +526,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -534,6 +543,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -550,6 +560,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -566,6 +577,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -582,6 +594,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -598,6 +611,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -614,6 +628,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -696,6 +711,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -778,6 +794,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -995,6 +1012,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -1013,6 +1031,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -1029,6 +1048,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -1045,6 +1065,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -1061,6 +1082,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -1077,6 +1099,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -1093,6 +1116,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -1250,6 +1274,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -1268,6 +1293,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -1284,6 +1310,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -1300,6 +1327,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -1316,6 +1344,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -1332,6 +1361,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -1348,6 +1378,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -1475,6 +1506,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -1491,6 +1523,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -1507,6 +1540,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -1523,6 +1557,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -1539,6 +1574,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -1555,6 +1591,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -1571,6 +1608,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -1708,6 +1746,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -1726,6 +1765,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -1742,6 +1782,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -1758,6 +1799,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -1774,6 +1816,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -1790,6 +1833,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -1806,6 +1850,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -1933,6 +1978,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -1949,6 +1995,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -1965,6 +2012,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -1981,6 +2029,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -1997,6 +2046,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2013,6 +2063,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2029,6 +2080,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2166,6 +2218,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -2182,6 +2235,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2198,6 +2252,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2214,6 +2269,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2230,6 +2286,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2246,6 +2303,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2262,6 +2320,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2386,6 +2445,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -2402,6 +2462,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2418,6 +2479,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2434,6 +2496,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2450,6 +2513,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2466,6 +2530,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2482,6 +2547,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2616,6 +2682,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -2632,6 +2699,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2648,6 +2716,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2664,6 +2733,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2680,6 +2750,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2696,6 +2767,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2712,6 +2784,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2879,6 +2952,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -2897,6 +2971,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -2915,6 +2990,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -2933,6 +3009,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -2949,6 +3026,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2965,6 +3043,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2981,6 +3060,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2997,6 +3077,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3013,6 +3094,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3029,6 +3111,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3045,6 +3128,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3061,6 +3145,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3077,6 +3162,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3093,6 +3179,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3109,6 +3196,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3125,6 +3213,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3141,6 +3230,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3157,6 +3247,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3173,6 +3264,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3189,6 +3281,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3205,6 +3298,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3221,6 +3315,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3237,6 +3332,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3376,6 +3472,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -3394,6 +3491,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -3410,6 +3508,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3426,6 +3525,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3442,6 +3542,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3458,6 +3559,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3474,6 +3576,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3490,6 +3593,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3506,6 +3610,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3522,6 +3627,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3538,6 +3644,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3554,6 +3661,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3570,6 +3678,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3586,6 +3695,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3602,6 +3712,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3618,6 +3729,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3634,6 +3746,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3650,6 +3763,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3666,6 +3780,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3682,6 +3797,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3698,6 +3814,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3833,6 +3950,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -3851,6 +3969,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -3867,6 +3986,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3883,6 +4003,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3899,6 +4020,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3915,6 +4037,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3931,6 +4054,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3947,6 +4071,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3963,6 +4088,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3979,6 +4105,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3995,6 +4122,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -4011,6 +4139,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -4027,6 +4156,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -4043,6 +4173,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -4059,6 +4190,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -4075,6 +4207,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -4091,6 +4224,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -4107,6 +4241,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -4123,6 +4258,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -4139,6 +4275,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -4155,6 +4292,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -4279,6 +4417,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -4295,6 +4434,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -4311,6 +4451,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -4327,6 +4468,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -4343,6 +4485,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -4359,6 +4502,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -4375,6 +4519,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>

--- a/src/test/resources/pages/instructorFeedbackResultsSortQuestionSearch.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortQuestionSearch.html
@@ -310,6 +310,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -328,6 +329,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -346,6 +348,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -364,6 +367,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -382,6 +386,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -400,6 +405,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -418,6 +424,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -436,6 +443,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -518,6 +526,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -534,6 +543,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -550,6 +560,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -566,6 +577,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -582,6 +594,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -598,6 +611,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -614,6 +628,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -696,6 +711,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -778,6 +794,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -995,6 +1012,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -1013,6 +1031,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -1029,6 +1048,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -1045,6 +1065,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -1061,6 +1082,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -1077,6 +1099,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -1093,6 +1116,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -1250,6 +1274,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -1268,6 +1293,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -1284,6 +1310,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -1300,6 +1327,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -1316,6 +1344,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -1332,6 +1361,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -1348,6 +1378,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -1475,6 +1506,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -1491,6 +1523,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -1507,6 +1540,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -1523,6 +1557,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -1539,6 +1574,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -1555,6 +1591,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -1571,6 +1608,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -1708,6 +1746,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -1726,6 +1765,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -1742,6 +1782,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -1758,6 +1799,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -1774,6 +1816,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -1790,6 +1833,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -1806,6 +1850,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -1933,6 +1978,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -1949,6 +1995,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -1965,6 +2012,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -1981,6 +2029,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -1997,6 +2046,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2013,6 +2063,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2029,6 +2080,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2166,6 +2218,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -2182,6 +2235,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2198,6 +2252,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2214,6 +2269,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2230,6 +2286,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2246,6 +2303,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2262,6 +2320,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2386,6 +2445,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -2402,6 +2462,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2418,6 +2479,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2434,6 +2496,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2450,6 +2513,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2466,6 +2530,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2482,6 +2547,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2616,6 +2682,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -2632,6 +2699,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2648,6 +2716,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2664,6 +2733,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2680,6 +2750,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2696,6 +2767,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2712,6 +2784,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2879,6 +2952,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -2897,6 +2971,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -2915,6 +2990,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -2933,6 +3009,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -2949,6 +3026,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2965,6 +3043,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2981,6 +3060,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -2997,6 +3077,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3013,6 +3094,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3029,6 +3111,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3045,6 +3128,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3061,6 +3145,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3077,6 +3162,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3093,6 +3179,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3109,6 +3196,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3125,6 +3213,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3141,6 +3230,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3157,6 +3247,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3173,6 +3264,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3189,6 +3281,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3205,6 +3298,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3221,6 +3315,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3237,6 +3332,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3376,6 +3472,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -3394,6 +3491,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -3410,6 +3508,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3426,6 +3525,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3442,6 +3542,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3458,6 +3559,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3474,6 +3576,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3490,6 +3593,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3506,6 +3610,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3522,6 +3627,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3538,6 +3644,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3554,6 +3661,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3570,6 +3678,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3586,6 +3695,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3602,6 +3712,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3618,6 +3729,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3634,6 +3746,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3650,6 +3763,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3666,6 +3780,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3682,6 +3797,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3698,6 +3814,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3833,6 +3950,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -3851,6 +3969,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -3867,6 +3986,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3883,6 +4003,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3899,6 +4020,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3915,6 +4037,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3931,6 +4054,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3947,6 +4071,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3963,6 +4088,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3979,6 +4105,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -3995,6 +4122,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -4011,6 +4139,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -4027,6 +4156,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -4043,6 +4173,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -4059,6 +4190,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -4075,6 +4207,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -4091,6 +4224,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -4107,6 +4241,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -4123,6 +4258,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -4139,6 +4275,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -4155,6 +4292,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -4279,6 +4417,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -4295,6 +4434,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -4311,6 +4451,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -4327,6 +4468,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -4343,6 +4485,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -4359,6 +4502,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>
@@ -4375,6 +4519,7 @@
                                                                     <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                     <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                     <input name="fsname" type="hidden" value="First Session"/>
+                                                                    <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                     <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                                 </form>
                                                             </td>

--- a/src/test/resources/pages/instructorFeedbackResultsSortRecipientQuestionGiver.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortRecipientQuestionGiver.html
@@ -423,6 +423,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -527,6 +528,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -551,6 +553,7 @@
                                                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                 <input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                 <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                             </form>
                                                         </td>
@@ -574,6 +577,7 @@
                                                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                 <input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                 <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                             </form>
                                                         </td>
@@ -597,6 +601,7 @@
                                                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                 <input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                 <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                             </form>
                                                         </td>
@@ -620,6 +625,7 @@
                                                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                 <input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                 <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                             </form>
                                                         </td>
@@ -643,6 +649,7 @@
                                                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                 <input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                 <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                             </form>
                                                         </td>
@@ -666,6 +673,7 @@
                                                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                 <input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                 <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                             </form>
                                                         </td>
@@ -1470,6 +1478,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -1532,6 +1541,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -1669,6 +1679,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -1806,6 +1817,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -1913,6 +1925,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -2020,6 +2033,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -2127,6 +2141,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -2244,6 +2259,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -2348,6 +2364,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -2462,6 +2479,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -2570,6 +2588,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -2594,6 +2613,7 @@
                                                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                 <input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                 <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                             </form>
                                                         </td>
@@ -2659,6 +2679,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -2683,6 +2704,7 @@
                                                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                 <input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                 <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                             </form>
                                                         </td>
@@ -2786,6 +2808,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -2810,6 +2833,7 @@
                                                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                 <input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                 <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                             </form>
                                                         </td>
@@ -2900,6 +2924,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -2925,6 +2950,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -2992,6 +3018,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -3100,6 +3127,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -3124,6 +3152,7 @@
                                                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                 <input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                 <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                             </form>
                                                         </td>
@@ -3189,6 +3218,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -3213,6 +3243,7 @@
                                                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                 <input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                 <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                             </form>
                                                         </td>
@@ -3320,6 +3351,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -3344,6 +3376,7 @@
                                                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                 <input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                 <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                             </form>
                                                         </td>
@@ -3679,6 +3712,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -3787,6 +3821,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -3811,6 +3846,7 @@
                                                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                 <input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                 <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                             </form>
                                                         </td>
@@ -3834,6 +3870,7 @@
                                                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                 <input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                 <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                             </form>
                                                         </td>
@@ -3857,6 +3894,7 @@
                                                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                 <input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                 <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                             </form>
                                                         </td>
@@ -3880,6 +3918,7 @@
                                                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                 <input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                 <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                             </form>
                                                         </td>
@@ -3970,6 +4009,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -3995,6 +4035,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -4103,6 +4144,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -4127,6 +4169,7 @@
                                                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                 <input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                 <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                             </form>
                                                         </td>
@@ -4150,6 +4193,7 @@
                                                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                 <input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                 <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                             </form>
                                                         </td>
@@ -4173,6 +4217,7 @@
                                                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                 <input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                 <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                             </form>
                                                         </td>
@@ -4196,6 +4241,7 @@
                                                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                 <input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                 <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                             </form>
                                                         </td>
@@ -4286,6 +4332,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -4423,6 +4470,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -4530,6 +4578,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -4619,6 +4668,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -4788,6 +4838,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>

--- a/src/test/resources/pages/instructorFeedbackResultsSortRecipientQuestionGiverTeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortRecipientQuestionGiverTeam.html
@@ -341,6 +341,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -445,6 +446,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -469,6 +471,7 @@
                                                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                 <input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                 <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                             </form>
                                                         </td>
@@ -492,6 +495,7 @@
                                                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                 <input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                 <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                             </form>
                                                         </td>
@@ -515,6 +519,7 @@
                                                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                 <input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                 <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                             </form>
                                                         </td>
@@ -538,6 +543,7 @@
                                                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                 <input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                 <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                             </form>
                                                         </td>
@@ -561,6 +567,7 @@
                                                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                 <input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                 <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                             </form>
                                                         </td>
@@ -584,6 +591,7 @@
                                                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                 <input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                 <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                             </form>
                                                         </td>
@@ -699,6 +707,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -761,6 +770,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -898,6 +908,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -1035,6 +1046,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -1142,6 +1154,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -1249,6 +1262,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -1356,6 +1370,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -1473,6 +1488,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -1577,6 +1593,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -1691,6 +1708,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -1799,6 +1817,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -1823,6 +1842,7 @@
                                                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                 <input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                 <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                             </form>
                                                         </td>
@@ -1888,6 +1908,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -1912,6 +1933,7 @@
                                                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                 <input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                 <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                             </form>
                                                         </td>
@@ -2015,6 +2037,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -2039,6 +2062,7 @@
                                                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                 <input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                 <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                             </form>
                                                         </td>
@@ -2129,6 +2153,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -2154,6 +2179,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -2221,6 +2247,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -2329,6 +2356,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -2353,6 +2381,7 @@
                                                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                 <input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                 <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                             </form>
                                                         </td>
@@ -2418,6 +2447,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -2442,6 +2472,7 @@
                                                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                 <input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                 <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                             </form>
                                                         </td>
@@ -2549,6 +2580,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -2573,6 +2605,7 @@
                                                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                 <input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                 <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                             </form>
                                                         </td>
@@ -2663,6 +2696,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -2771,6 +2805,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -2795,6 +2830,7 @@
                                                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                 <input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                 <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                             </form>
                                                         </td>
@@ -2818,6 +2854,7 @@
                                                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                 <input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                 <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                             </form>
                                                         </td>
@@ -2841,6 +2878,7 @@
                                                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                 <input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                 <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                             </form>
                                                         </td>
@@ -2864,6 +2902,7 @@
                                                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                 <input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                 <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                             </form>
                                                         </td>
@@ -2954,6 +2993,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -2979,6 +3019,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -3087,6 +3128,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -3111,6 +3153,7 @@
                                                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                 <input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                 <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                             </form>
                                                         </td>
@@ -3134,6 +3177,7 @@
                                                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                 <input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                 <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                             </form>
                                                         </td>
@@ -3157,6 +3201,7 @@
                                                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                 <input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                 <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                             </form>
                                                         </td>
@@ -3180,6 +3225,7 @@
                                                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                 <input name="fsname" type="hidden" value="First Session"/>
+                                                                <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                                 <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                             </form>
                                                         </td>
@@ -3270,6 +3316,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -3407,6 +3454,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -3514,6 +3562,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -3603,6 +3652,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>
@@ -3737,6 +3787,7 @@
                                                         <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
                                                         <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                         <input name="fsname" type="hidden" value="First Session"/>
+                                                        <input name="moderatedquestion" type="hidden" value="{*}"/>
                                                         <input name="moderatedstudent" type="hidden" value="{*}@gmail.tmt"/>
                                                     </form>
                                                 </td>


### PR DESCRIPTION
Fixes #3290 

The initial commits are for program logic, but the bulk of the lines changed are from updating test cases.

For testing, out of 23 HTML files used in InstructorFeedbackResultsPageUiTest, 12 files were updated. The only change to these files were the addition of an `<input name="moderatedquestion" type="hidden" value="{*}"/>` element for every `Moderate Response` button that originates from a specific question. (hence only the Questions and Recipient > Question > Giver views were affected)

Generating the updated files was done through a separate script which can be found [here](https://github.com/acruis/samples/blob/master/TestAppend.java). For the code reviewer, instead of checking the diff in every test file, you can simply check the logic of the generator script and then run the script on the original HTML files to check that the outcome matches the new files in this PR.