### PR TITLE
New contribution question: Null recipient type #2536

### DIFF
--- a/src/main/webapp/js/instructorFeedbackEdit.js
+++ b/src/main/webapp/js/instructorFeedbackEdit.js
@@ -1218,8 +1218,8 @@ function fixContribQnGiverRecipient(questionNumber){
     $('#givertype'+idSuffix).find('option').not('[value="STUDENTS"]').prop('disabled', true);
     $('#recipienttype'+idSuffix).find('option').not('[value="OWN_TEAM_MEMBERS_INCLUDING_SELF"]').prop('disabled', true);
 
-    $('#givertype'+idSuffix).find('option').filter('[value="STUDENTS"]').attr('selected','selected');
-    $('#recipienttype'+idSuffix).find('option').filter('[value="OWN_TEAM_MEMBERS_INCLUDING_SELF"]').attr('selected','selected');
+    $('#givertype'+idSuffix).find('option').filter('[value="STUDENTS"]').prop('selected','selected');
+    $('#recipienttype'+idSuffix).find('option').filter('[value="OWN_TEAM_MEMBERS_INCLUDING_SELF"]').prop('selected','selected');
 }
 
 /**


### PR DESCRIPTION
Fixes #2536 
Tracing down, I found out that the source of the problem is here:
![2536](https://cloud.githubusercontent.com/assets/7261051/7218582/5c9376a4-e6aa-11e4-92cf-dd421d24f944.png)
Somehow, this dropdown value is not updated to Giver's team members and Giver. It looks trivial, 
however the effect snowballed down like this:
1. Remember that options other than Giver's team members and Giver are disabled.
2. Because it is disabled _and_ "selected", it will be passed as null, and there goes our NPE.

I fixed it by changing .attr in the js file to .prop. However I'm really at a loss of explanation why.
1. Not because of .attr. If it was, the other dropdown (givertype) should've given problems as well but it didn't.
2. Not because of too many options. I tried reducing the # of options to 4 (same as givertype), still happened.
3. Even more confusing: when I looked at the HTML source of the erroneous page above, the option denoted as selected is actually the correct one. But it's NOT rendered correctly.

Good thing is that this error is not poisonous. After the question is saved, the recipient type will be correctly displayed.