### PR TITLE
Update DataMigrationEvaluationsToFeedbackSessions to delete evaluations #3365

### DIFF
--- a/src/main/java/teammates/client/scripts/DataMigrationEvaluationsToFeedbackSessions.java
+++ b/src/main/java/teammates/client/scripts/DataMigrationEvaluationsToFeedbackSessions.java
@@ -35,6 +35,9 @@ import com.google.appengine.api.datastore.Text;
 /**
  * Migrates Evaluations and Submissions to FeedbackSessions and Responses.
  * Feedback session/question creator will be any instructor from the course.
+ * 
+ * The response rate will not be updated in this script. The script DataMigrationForResponseRate
+ * can be ran after this to update it.
  */
 public class DataMigrationEvaluationsToFeedbackSessions extends RemoteApiClient {
     

--- a/src/main/java/teammates/client/scripts/DataMigrationEvaluationsToFeedbackSessions.java
+++ b/src/main/java/teammates/client/scripts/DataMigrationEvaluationsToFeedbackSessions.java
@@ -6,6 +6,7 @@ import java.util.Date;
 import java.util.List;
 
 import teammates.client.remoteapi.RemoteApiClient;
+import teammates.common.datatransfer.CourseAttributes;
 import teammates.common.datatransfer.EvaluationAttributes;
 import teammates.common.datatransfer.FeedbackResponseDetails;
 import teammates.common.datatransfer.FeedbackContributionQuestionDetails;
@@ -55,18 +56,16 @@ public class DataMigrationEvaluationsToFeedbackSessions extends RemoteApiClient 
         Datastore.initialize();
         
         /**
-         * Specify courseId, evaluationName, and new feedback session name here.
-         * If new feedbackSessionName already exists, a number in brackets will be appended.
+         * Specify courseId. Feedback sessions will be made for all evaluations in the course, 
+         * the evaluations will be deleted.
          */
         String courseId = "example.gma-demo";
-        String evaluationName = "First Evaluation";
-        String newFeedbackSessionName = "Migrated FeedbackSession";
         
-        EvaluationAttributes evalAttribute = logic.getEvaluation(courseId, evaluationName);
-        if(evalAttribute != null){
-            convertOneEvaluationToFeedbackSession(evalAttribute , newFeedbackSessionName);
-        } else {
-            System.out.println("Specified evaluation not found." + courseId + " : " + evaluationName);
+        List<EvaluationAttributes> evalList = logic.getEvaluationsForCourse(courseId);
+        
+        for (EvaluationAttributes evalAttribute : evalList) {
+            convertOneEvaluationToFeedbackSession(evalAttribute , evalAttribute.name);
+            //logic.deleteEvaluation(courseId, evalAttribute.name);
         }
         
         //Converts all evaluations to feedback sessions
@@ -124,6 +123,10 @@ public class DataMigrationEvaluationsToFeedbackSessions extends RemoteApiClient 
         while(true){ //Loop to retry with a different name if entity already exists.
             
             feedbackSessionName = newFeedbackSessionName + (num==0 ? "" : ("("+num+")"));//Use same name, or if exists, use "<name>(<num>)"
+        
+            if (logic.getFeedbackSession(feedbackSessionName, courseId) != null ) {
+                System.out.println(String.format("Feedback session with the name %s already exists", feedbackSessionName));  
+            }
             
             FeedbackSessionAttributes fsa = new FeedbackSessionAttributes(feedbackSessionName,
                     courseId, creatorEmail, instructions,
@@ -141,13 +144,12 @@ public class DataMigrationEvaluationsToFeedbackSessions extends RemoteApiClient 
                 e.printStackTrace();
                 break;
             } catch (EntityAlreadyExistsException e) {
-                System.out.println("Entity already exists, retrying with a different name.");
+                System.out.println(String.format("Feedback session with the name %s already exists, retrying with a different name.", feedbackSessionName));
                 e.printStackTrace();
             }
             
             num++;
         }
-        
 
         boolean peerFeedback = eval.p2pEnabled;
         
@@ -356,7 +358,7 @@ public class DataMigrationEvaluationsToFeedbackSessions extends RemoteApiClient 
         feedbackQuestion.setQuestionDetails(questionDetails);
         
         try {
-            logic.createFeedbackQuestion(feedbackQuestion);
+            logic.createFeedbackQuestionForTemplate(feedbackQuestion, feedbackQuestion.questionNumber);
         } catch (InvalidParametersException e) {
             System.out.println("Failed to create Feedback Question 5 =(");
             e.printStackTrace();
@@ -393,7 +395,7 @@ public class DataMigrationEvaluationsToFeedbackSessions extends RemoteApiClient 
         feedbackQuestion.setQuestionDetails(questionDetails);
         
         try {
-            logic.createFeedbackQuestion(feedbackQuestion);
+            logic.createFeedbackQuestionForTemplate(feedbackQuestion, feedbackQuestion.questionNumber);
         } catch (InvalidParametersException e) {
             System.out.println("Failed to create Feedback Question 4 =(");
             e.printStackTrace();
@@ -430,7 +432,7 @@ public class DataMigrationEvaluationsToFeedbackSessions extends RemoteApiClient 
         feedbackQuestion.setQuestionDetails(questionDetails);
         
         try {
-            logic.createFeedbackQuestion(feedbackQuestion);
+            logic.createFeedbackQuestionForTemplate(feedbackQuestion, feedbackQuestion.questionNumber);
         } catch (InvalidParametersException e) {
             System.out.println("Failed to create Feedback Question 3 =(");
             e.printStackTrace();
@@ -476,7 +478,7 @@ public class DataMigrationEvaluationsToFeedbackSessions extends RemoteApiClient 
         feedbackQuestion.setQuestionDetails(questionDetails);
         
         try {
-            logic.createFeedbackQuestion(feedbackQuestion);
+            logic.createFeedbackQuestionForTemplate(feedbackQuestion, feedbackQuestion.questionNumber);
         } catch (InvalidParametersException e) {
             System.out.println("Failed to create Feedback Question 2 =(");
             e.printStackTrace();
@@ -517,7 +519,7 @@ public class DataMigrationEvaluationsToFeedbackSessions extends RemoteApiClient 
         feedbackQuestion.setQuestionDetails(questionDetails);
         
         try {
-            logic.createFeedbackQuestion(feedbackQuestion);
+            logic.createFeedbackQuestionForTemplate(feedbackQuestion, feedbackQuestion.questionNumber);
         } catch (InvalidParametersException e) {
             System.out.println("Failed to create Feedback Question 1 =(");
             e.printStackTrace();

--- a/src/main/java/teammates/client/scripts/DataMigrationEvaluationsToFeedbackSessions.java
+++ b/src/main/java/teammates/client/scripts/DataMigrationEvaluationsToFeedbackSessions.java
@@ -8,7 +8,6 @@ import java.util.List;
 import java.util.Set;
 
 import teammates.client.remoteapi.RemoteApiClient;
-import teammates.common.datatransfer.CourseAttributes;
 import teammates.common.datatransfer.EvaluationAttributes;
 import teammates.common.datatransfer.FeedbackResponseDetails;
 import teammates.common.datatransfer.FeedbackContributionQuestionDetails;
@@ -125,8 +124,8 @@ public class DataMigrationEvaluationsToFeedbackSessions extends RemoteApiClient 
     }
     
     protected void deleteEvaluation(String courseId, String evalName) {
-        // first, check if a feedback session have been created for the evaluation
-        // do not delete if the feedback session was not created
+        // first, check if a feedback session have been created for the evaluation.
+        // do not delete the evaluation if the feedback session was not created
         if (logic.getFeedbackSession(evalName, courseId) == null) {
             System.out.println("deleteEvaluation: a feedback session was not created for the evaluation " + evalName);
             return;
@@ -188,7 +187,7 @@ public class DataMigrationEvaluationsToFeedbackSessions extends RemoteApiClient 
             } catch (InvalidParametersException e) {
                 System.out.println("Something went wrong.");
                 e.printStackTrace();
-                return;
+                return;  // do not continue to create the questions and responses if fail to create the feedback session
             } catch (EntityAlreadyExistsException e) {
                 System.out.println(String.format("Feedback session with the name %s already exists, retrying with a different name.", feedbackSessionName));
                 e.printStackTrace();

--- a/src/main/java/teammates/client/scripts/DataMigrationEvaluationsToFeedbackSessions.java
+++ b/src/main/java/teammates/client/scripts/DataMigrationEvaluationsToFeedbackSessions.java
@@ -367,38 +367,23 @@ public class DataMigrationEvaluationsToFeedbackSessions extends RemoteApiClient 
         
         //Save responses
         List<FeedbackResponseAttributes> allResponses = new ArrayList<FeedbackResponseAttributes>();
-        if (q1Response != null) {
-            if(!(q1Response.responseMetaData.getValue().isEmpty() || 
-                    q1Response.recipientEmail.isEmpty())){
-                allResponses.add(q1Response);
-            }
-        }
-        if (q2Response != null) {
-            if(!(q2Response.responseMetaData.getValue().isEmpty() || 
-                    q2Response.recipientEmail.isEmpty())){
-                allResponses.add(q2Response);
-            }
-        } 
-        if (q3Response != null) {
-            if(!(q3Response.responseMetaData.getValue().isEmpty() || 
-                    q3Response.recipientEmail.isEmpty())){
-                allResponses.add(q3Response);
-            }
-        }
-        if (q4Response != null) {
-            if(!(q4Response.responseMetaData.getValue().isEmpty() || 
-                    q4Response.recipientEmail.isEmpty())){
-                allResponses.add(q4Response);
-            }
-        }
-        if (q5Response != null) {
-            if(!(q5Response.responseMetaData.getValue().isEmpty() || 
-                    q5Response.recipientEmail.isEmpty())){
-                allResponses.add(q5Response);
-            }
-        }
+        List<FeedbackResponseAttributes> validResponses = new ArrayList<FeedbackResponseAttributes>();
+        allResponses.add(q1Response);
+        allResponses.add(q2Response);
+        allResponses.add(q3Response);
+        allResponses.add(q4Response);
+        allResponses.add(q5Response);
         
-        return allResponses;
+        for (FeedbackResponseAttributes response : allResponses) {
+            if (response != null) {
+                if(!(response.responseMetaData.getValue().isEmpty() || 
+                        response.recipientEmail.isEmpty())){
+                    validResponses.add(response);
+                }
+            }   
+        }
+           
+        return validResponses;
     }
 
     private List<FeedbackQuestionAttributes> createFeedbackQuestions(EvaluationAttributes eval,

--- a/src/main/java/teammates/client/scripts/DataMigrationEvaluationsToFeedbackSessions.java
+++ b/src/main/java/teammates/client/scripts/DataMigrationEvaluationsToFeedbackSessions.java
@@ -164,7 +164,7 @@ public class DataMigrationEvaluationsToFeedbackSessions extends RemoteApiClient 
         Date startTime = eval.startTime;
         Date endTime = eval.endTime;
         Date sessionVisibleFromTime = eval.startTime;
-        Date resultsVisibleFromTime = eval.endTime;
+        Date resultsVisibleFromTime = eval.published ? eval.endTime : Const.TIME_REPRESENTS_LATER;
         double timeZone = eval.timeZone;
         int gracePeriod = eval.gracePeriod;
         FeedbackSessionType feedbackSessionType = FeedbackSessionType.STANDARD;

--- a/src/main/java/teammates/client/scripts/DataMigrationEvaluationsToFeedbackSessions.java
+++ b/src/main/java/teammates/client/scripts/DataMigrationEvaluationsToFeedbackSessions.java
@@ -254,7 +254,7 @@ public class DataMigrationEvaluationsToFeedbackSessions extends RemoteApiClient 
                 q4Response.courseId = courseId;
                 q4Response.giverEmail = giver;
                 q4Response.giverSection = giverSection;
-                q4Response.recipientEmail = recipient;
+                q4Response.recipientEmail = studentRecipient.team;
                 q4Response.recipientSection = recipientSection;
                 
                 q4Response.feedbackQuestionType = FeedbackQuestionType.TEXT;

--- a/src/main/java/teammates/client/scripts/DataMigrationEvaluationsToFeedbackSessions.java
+++ b/src/main/java/teammates/client/scripts/DataMigrationEvaluationsToFeedbackSessions.java
@@ -61,7 +61,7 @@ public class DataMigrationEvaluationsToFeedbackSessions extends RemoteApiClient 
         Datastore.initialize();
         
         // modify this value to migrate evaluations for all courses, or for a specific course
-        boolean isForAllCourses = true;
+        boolean isForAllCourses = false;
         
         if (isForAllCourses) {
             Set<String> coursesId = getCourses();
@@ -207,14 +207,8 @@ public class DataMigrationEvaluationsToFeedbackSessions extends RemoteApiClient 
         boolean peerFeedback = eval.p2pEnabled;
         
         //Create feedback questions
-        createFeedbackQuestions(eval, feedbackSessionName, courseId, creatorEmail, peerFeedback);
+        List<String> fqIds = createFeedbackQuestions(eval, feedbackSessionName, courseId, creatorEmail, peerFeedback);
         
-        
-        //Get feedbackQuestionIds
-        List<String> fqIds = new ArrayList<String>();
-        for(int i=1 ; i<=(peerFeedback?5:3) ; i++){
-            fqIds.add(logic.getFeedbackQuestion(feedbackSessionName, courseId, i).getId());
-        }
         
         //Create feedback Responses
         List<SubmissionAttributes> allSubmissions = subDb.getSubmissionsForEvaluation(courseId, eval.name);
@@ -358,29 +352,39 @@ public class DataMigrationEvaluationsToFeedbackSessions extends RemoteApiClient 
         }
     }
 
-    private void createFeedbackQuestions(EvaluationAttributes eval,
-            String feedbackSessionName, String courseId, String creatorEmail, boolean peerFeedback) {
+    private List<String> createFeedbackQuestions(EvaluationAttributes eval,
+            String feedbackSessionName, String courseId, String creatorEmail, boolean peerFeedback) throws InvalidParametersException {
+        List<String> result = new ArrayList<String>();
+        
         //Question 1: Contribution Question
-        createQuestion1(feedbackSessionName, courseId, creatorEmail);
+        FeedbackQuestionAttributes q1 = createQuestion1(feedbackSessionName, courseId, creatorEmail);
+        
+        result.add(q1.getId());
         
         //Question 2: Essay Question "Comments about my contribution(shown to other teammates)"
-        createQuestion2(feedbackSessionName, courseId, creatorEmail);
+        FeedbackQuestionAttributes q2 = createQuestion2(feedbackSessionName, courseId, creatorEmail);
+        result.add(q2.getId());
         
         //Question3: Essay Question "My comments about this teammate(confidential and only shown to instructor)"
-        createQuestion3(feedbackSessionName, courseId, creatorEmail);
+        FeedbackQuestionAttributes q3 = createQuestion3(feedbackSessionName, courseId, creatorEmail);
+        result.add(q3.getId());
         
         //Questions below are only enabled if peer to peer feedback is enabled.
         if(peerFeedback){
             //Question 4: Essay Question "Comments about team dynamics(confidential and only shown to instructor)"
-            createQuestion4(feedbackSessionName, courseId, creatorEmail);
+            FeedbackQuestionAttributes q4 = createQuestion4(feedbackSessionName, courseId, creatorEmail);
+            result.add(q4.getId());
             
             //Question 5: Essay Question "My feedback to this teammate(shown anonymously to the teammate)"
-            createQuestion5(feedbackSessionName, courseId, creatorEmail);
+            FeedbackQuestionAttributes q5 = createQuestion5(feedbackSessionName, courseId, creatorEmail);
+            result.add(q5.getId());
         }
+        
+        return result;
     }
 
-    private void createQuestion5(String feedbackSessionName, String courseId,
-            String creatorEmail) {
+    private FeedbackQuestionAttributes createQuestion5(String feedbackSessionName, String courseId,
+            String creatorEmail) throws InvalidParametersException {
         FeedbackQuestionAttributes feedbackQuestion = new FeedbackQuestionAttributes();
         feedbackQuestion.creatorEmail = creatorEmail;
         feedbackQuestion.courseId = courseId;
@@ -410,16 +414,13 @@ public class DataMigrationEvaluationsToFeedbackSessions extends RemoteApiClient 
         FeedbackTextQuestionDetails questionDetails = new FeedbackTextQuestionDetails(questionText );
         feedbackQuestion.setQuestionDetails(questionDetails);
         
-        try {
-            logic.createFeedbackQuestionForTemplate(feedbackQuestion, feedbackQuestion.questionNumber);
-        } catch (InvalidParametersException e) {
-            System.out.println("Failed to create Feedback Question 5 =(");
-            e.printStackTrace();
-        }
+        FeedbackQuestionAttributes fqa = logic.createFeedbackQuestionForTemplate(feedbackQuestion, feedbackQuestion.questionNumber);
+        return fqa;
+        
     }
 
-    private void createQuestion4(String feedbackSessionName, String courseId,
-            String creatorEmail) {
+    private FeedbackQuestionAttributes createQuestion4(String feedbackSessionName, String courseId,
+            String creatorEmail) throws InvalidParametersException {
         FeedbackQuestionAttributes feedbackQuestion = new FeedbackQuestionAttributes();
         feedbackQuestion.creatorEmail = creatorEmail;
         feedbackQuestion.courseId = courseId;
@@ -447,16 +448,12 @@ public class DataMigrationEvaluationsToFeedbackSessions extends RemoteApiClient 
         FeedbackTextQuestionDetails questionDetails = new FeedbackTextQuestionDetails(questionText );
         feedbackQuestion.setQuestionDetails(questionDetails);
         
-        try {
-            logic.createFeedbackQuestionForTemplate(feedbackQuestion, feedbackQuestion.questionNumber);
-        } catch (InvalidParametersException e) {
-            System.out.println("Failed to create Feedback Question 4 =(");
-            e.printStackTrace();
-        }
+        FeedbackQuestionAttributes fqa = logic.createFeedbackQuestionForTemplate(feedbackQuestion, feedbackQuestion.questionNumber);
+        return fqa;
     }
 
-    private void createQuestion3(String feedbackSessionName, String courseId,
-            String creatorEmail) {
+    private FeedbackQuestionAttributes createQuestion3(String feedbackSessionName, String courseId,
+            String creatorEmail) throws InvalidParametersException {
         FeedbackQuestionAttributes feedbackQuestion = new FeedbackQuestionAttributes();
         feedbackQuestion.creatorEmail = creatorEmail;
         feedbackQuestion.courseId = courseId;
@@ -484,16 +481,13 @@ public class DataMigrationEvaluationsToFeedbackSessions extends RemoteApiClient 
         FeedbackTextQuestionDetails questionDetails = new FeedbackTextQuestionDetails(questionText );
         feedbackQuestion.setQuestionDetails(questionDetails);
         
-        try {
-            logic.createFeedbackQuestionForTemplate(feedbackQuestion, feedbackQuestion.questionNumber);
-        } catch (InvalidParametersException e) {
-            System.out.println("Failed to create Feedback Question 3 =(");
-            e.printStackTrace();
-        }
+        FeedbackQuestionAttributes fqa = logic.createFeedbackQuestionForTemplate(feedbackQuestion, feedbackQuestion.questionNumber);
+        return fqa;
+        
     }
 
-    private void createQuestion2(String feedbackSessionName, String courseId,
-            String creatorEmail) {
+    private FeedbackQuestionAttributes createQuestion2(String feedbackSessionName, String courseId,
+            String creatorEmail) throws InvalidParametersException {
         FeedbackQuestionAttributes feedbackQuestion = new FeedbackQuestionAttributes();
         feedbackQuestion.creatorEmail = creatorEmail;
         feedbackQuestion.courseId = courseId;
@@ -530,16 +524,13 @@ public class DataMigrationEvaluationsToFeedbackSessions extends RemoteApiClient 
         FeedbackTextQuestionDetails questionDetails = new FeedbackTextQuestionDetails(questionText );
         feedbackQuestion.setQuestionDetails(questionDetails);
         
-        try {
-            logic.createFeedbackQuestionForTemplate(feedbackQuestion, feedbackQuestion.questionNumber);
-        } catch (InvalidParametersException e) {
-            System.out.println("Failed to create Feedback Question 2 =(");
-            e.printStackTrace();
-        }
+        FeedbackQuestionAttributes fqa = logic.createFeedbackQuestionForTemplate(feedbackQuestion, feedbackQuestion.questionNumber);
+        return fqa;
+       
     }
 
-    private void createQuestion1(String feedbackSessionName, String courseId,
-            String creatorEmail) {
+    private FeedbackQuestionAttributes createQuestion1(String feedbackSessionName, String courseId,
+            String creatorEmail) throws InvalidParametersException {
         FeedbackQuestionAttributes feedbackQuestion = new FeedbackQuestionAttributes();
         feedbackQuestion.creatorEmail = creatorEmail;
         feedbackQuestion.courseId = courseId;
@@ -571,11 +562,8 @@ public class DataMigrationEvaluationsToFeedbackSessions extends RemoteApiClient 
         FeedbackContributionQuestionDetails questionDetails = new FeedbackContributionQuestionDetails(questionText );
         feedbackQuestion.setQuestionDetails(questionDetails);
         
-        try {
-            logic.createFeedbackQuestionForTemplate(feedbackQuestion, feedbackQuestion.questionNumber);
-        } catch (InvalidParametersException e) {
-            System.out.println("Failed to create Feedback Question 1 =(");
-            e.printStackTrace();
-        }
+        FeedbackQuestionAttributes fqa = logic.createFeedbackQuestionForTemplate(feedbackQuestion, feedbackQuestion.questionNumber);
+        return fqa;
+        
     }
 }

--- a/src/main/java/teammates/client/scripts/DataMigrationEvaluationsToFeedbackSessions.java
+++ b/src/main/java/teammates/client/scripts/DataMigrationEvaluationsToFeedbackSessions.java
@@ -60,6 +60,8 @@ public class DataMigrationEvaluationsToFeedbackSessions extends RemoteApiClient 
     private boolean isForAllCourses = false;
     //modify this to delete the evaluation after migrating
     private boolean isDeletingEvaluations = false;
+    //modify this to make changes to the database
+    private boolean isPreview = false;
 
     @Override
     protected void doOperation() {
@@ -122,6 +124,10 @@ public class DataMigrationEvaluationsToFeedbackSessions extends RemoteApiClient 
     }
     
     protected void deleteEvaluation(String courseId, String evalName) {
+        if (isPreview) {
+            return;
+        }
+        
         // first, check if a feedback session have been created for the evaluation.
         // do not delete the evaluation if the feedback session was not created
         if (logic.getFeedbackSession(evalName, courseId) == null) {
@@ -171,6 +177,11 @@ public class DataMigrationEvaluationsToFeedbackSessions extends RemoteApiClient 
                 System.out.println(String.format("Feedback session with the name %s already exists", feedbackSessionName));  
             }
             
+            if (isPreview) {
+                return;
+            }
+            
+            
             FeedbackSessionAttributes fsa = new FeedbackSessionAttributes(feedbackSessionName,
                     courseId, creatorEmail, instructions,
                     createdTime, startTime, endTime,
@@ -213,6 +224,10 @@ public class DataMigrationEvaluationsToFeedbackSessions extends RemoteApiClient 
     private void createFeedbackResponsesFromSubmission(
             String feedbackSessionName, String courseId, boolean peerFeedback,
             List<String> fqIds, SubmissionAttributes sub) {
+        if (isPreview) {
+            return;
+        }
+        
         String giver = sub.reviewer;
         String recipient = sub.reviewee;
         String giverSection = "";
@@ -340,6 +355,9 @@ public class DataMigrationEvaluationsToFeedbackSessions extends RemoteApiClient 
 
     private List<String> createFeedbackQuestions(EvaluationAttributes eval,
             String feedbackSessionName, String courseId, String creatorEmail, boolean peerFeedback) throws InvalidParametersException {
+        if (isPreview) {
+            return null;
+        }
         List<String> result = new ArrayList<String>();
         
         //Question 1: Contribution Question

--- a/src/main/java/teammates/client/scripts/DataMigrationEvaluationsToFeedbackSessions.java
+++ b/src/main/java/teammates/client/scripts/DataMigrationEvaluationsToFeedbackSessions.java
@@ -56,12 +56,17 @@ public class DataMigrationEvaluationsToFeedbackSessions extends RemoteApiClient 
         System.out.println("Total execution time: " + (endTime - startTime) + "ms" );
     }
 
+    // modify this value to migrate evaluations for all courses, or for a specific course
+    private boolean isForAllCourses = false;
+    //modify this to delete the evaluation after migrating
+    private boolean isDeletingEvaluations = false;
+
     @Override
     protected void doOperation() {
         Datastore.initialize();
         
-        // modify this value to migrate evaluations for all courses, or for a specific course
-        boolean isForAllCourses = false;
+        
+        
         
         if (isForAllCourses) {
             Set<String> coursesId = getCourses();
@@ -82,27 +87,6 @@ public class DataMigrationEvaluationsToFeedbackSessions extends RemoteApiClient 
         //convertEvaluationsToFeedbackSessions();
     }
     
-    @SuppressWarnings("deprecation")
-    protected void convertEvaluationsToFeedbackSessions(){
-        List<EvaluationAttributes> allEvaluations = evalsDb.getAllEvaluations();
-        
-        System.out.println(allEvaluations.size() + " evaluations found.");
-        
-        int fsNum = fsDb.getAllFeedbackSessions().size();
-        
-        for(EvaluationAttributes evalAttribute : allEvaluations){
-            try {
-                convertOneEvaluationToFeedbackSession(evalAttribute, "");
-            } catch (InvalidParametersException e) {
-                System.out.println("Something went wrong");
-                e.printStackTrace();
-            }
-        }
-
-        System.out.println(allEvaluations.size() + " evaluations found and migrated.");
-        System.out.println("Original number of FS: " + fsNum);
-        System.out.println("After migration number of FS: " + fsDb.getAllFeedbackSessions().size());
-    }
     
     @SuppressWarnings("unchecked")
     private Set<String> getCourses() {
@@ -126,7 +110,9 @@ public class DataMigrationEvaluationsToFeedbackSessions extends RemoteApiClient 
             try {
                 convertOneEvaluationToFeedbackSession(evalAttribute , evalAttribute.name);
                 
-                deleteEvaluation(courseId, evalAttribute.name);
+                if(isDeletingEvaluations) {
+                    deleteEvaluation(courseId, evalAttribute.name);
+                }
                 
             } catch (InvalidParametersException ipe) {
                 System.out.println("Something went wrong");

--- a/src/main/java/teammates/logic/api/Logic.java
+++ b/src/main/java/teammates/logic/api/Logic.java
@@ -2117,12 +2117,12 @@ public class Logic {
      * * All parameters are non-null.
      * * questionNumber is > 0
      */
-    public void createFeedbackQuestionForTemplate(
+    public FeedbackQuestionAttributes createFeedbackQuestionForTemplate(
             FeedbackQuestionAttributes feedbackQuestion, int questionNumber) throws InvalidParametersException {
 
         Assumption.assertNotNull(ERROR_NULL_PARAMETER, feedbackQuestion);
         Assumption.assertTrue(questionNumber > 0);
-        feedbackQuestionsLogic.createFeedbackQuestionNoIntegrityCheck(feedbackQuestion, questionNumber);
+        return feedbackQuestionsLogic.createFeedbackQuestionNoIntegrityCheck(feedbackQuestion, questionNumber);
     }
     
     /**

--- a/src/main/java/teammates/logic/core/FeedbackQuestionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackQuestionsLogic.java
@@ -30,6 +30,7 @@ import teammates.common.util.Assumption;
 import teammates.common.util.Const;
 import teammates.common.util.Utils;
 import teammates.storage.api.FeedbackQuestionsDb;
+import teammates.storage.entity.FeedbackQuestion;
 
 public class FeedbackQuestionsLogic {
     
@@ -78,11 +79,12 @@ public class FeedbackQuestionsLogic {
      * @param questionNumber
      * @throws InvalidParametersException
      */
-    public void createFeedbackQuestionNoIntegrityCheck(FeedbackQuestionAttributes fqa, int questionNumber)
+    public FeedbackQuestionAttributes createFeedbackQuestionNoIntegrityCheck(FeedbackQuestionAttributes fqa, int questionNumber)
             throws InvalidParametersException {
         fqa.questionNumber = questionNumber;
         fqa.removeIrrelevantVisibilityOptions();
-        fqDb.createEntityWithoutExistenceCheck(fqa);
+        FeedbackQuestionAttributes newFqa = fqDb.createFeedbackQuestionWithoutExistenceCheck(fqa);
+        return newFqa;
     }
     
     public FeedbackQuestionAttributes copyFeedbackQuestion(String feedbackQuestionId,

--- a/src/main/java/teammates/storage/api/EntitiesDb.java
+++ b/src/main/java/teammates/storage/api/EntitiesDb.java
@@ -135,7 +135,7 @@ public abstract class EntitiesDb {
      * Preconditions: 
      * <br> * {@code entityToAdd} is not null and has valid data.
      */
-    public void createEntityWithoutExistenceCheck(EntityAttributes entityToAdd) 
+    public Object createEntityWithoutExistenceCheck(EntityAttributes entityToAdd) 
             throws InvalidParametersException {
         
         Assumption.assertNotNull(
@@ -171,6 +171,8 @@ public abstract class EntitiesDb {
             }
         }
         log.info(entityToAdd.getBackupIdentifier());
+        
+        return entity;
     }
     
     // TODO: use this method for subclasses.

--- a/src/main/java/teammates/storage/api/EntitiesDb.java
+++ b/src/main/java/teammates/storage/api/EntitiesDb.java
@@ -23,6 +23,7 @@ import teammates.common.util.Const;
 import teammates.common.util.ThreadHelper;
 import teammates.common.util.Utils;
 import teammates.storage.datastore.Datastore;
+import teammates.storage.entity.FeedbackQuestion;
 import teammates.storage.search.SearchDocument;
 import teammates.storage.search.SearchManager;
 import teammates.storage.search.SearchQuery;
@@ -125,6 +126,37 @@ public abstract class EntitiesDb {
         getPM().flush();
  
         return entitiesToUpdate;
+
+    }
+    
+    public List<Object> createAndReturnEntities(Collection<? extends EntityAttributes> entitiesToAdd) throws InvalidParametersException {
+        
+        Assumption.assertNotNull(
+                Const.StatusCodes.DBLEVEL_NULL_INPUT, entitiesToAdd);
+        
+        List<EntityAttributes> entitiesToUpdate = new ArrayList<EntityAttributes>();
+        List<Object> entities = new ArrayList<Object>(); 
+        
+        for(EntityAttributes entityToAdd : entitiesToAdd){
+            entityToAdd.sanitizeForSaving();
+            
+            if (!entityToAdd.isValid()) {
+                throw new InvalidParametersException(entityToAdd.getInvalidityInfo());
+            }
+            
+            if(getEntity(entityToAdd) != null){
+                entitiesToUpdate.add(entityToAdd);
+            } else {
+                entities.add(entityToAdd.toEntity());
+            }
+            
+            log.info(entityToAdd.getBackupIdentifier());
+        }
+        
+        getPM().makePersistentAll(entities);
+        getPM().flush();
+ 
+        return entities;
 
     }
 

--- a/src/main/java/teammates/storage/api/FeedbackQuestionsDb.java
+++ b/src/main/java/teammates/storage/api/FeedbackQuestionsDb.java
@@ -55,6 +55,13 @@ public class FeedbackQuestionsDb extends EntitiesDb {
         return new FeedbackQuestionAttributes(fq);        
     }
     
+    
+    public FeedbackQuestionAttributes createFeedbackQuestionWithoutExistenceCheck(EntityAttributes entityToAdd) throws InvalidParametersException {
+        Object obj = this.createEntityWithoutExistenceCheck(entityToAdd);
+        
+        return new FeedbackQuestionAttributes((FeedbackQuestion)obj);
+    }
+    
     /**
      * Preconditions: <br>
      * * All parameters are non-null. 


### PR DESCRIPTION
Fixes #3365

I used createFeedbackQuestionForTemplate, which does not check for the existence of the feedback session, instead of createFeedbackQuestion in case of problems with eventual consistency.

DataMigrationForResponseRate should be run after running DataMigrationEvaluationsToFeedbackSessions should update the response rate.
