### PR TITLE
Assertion failure in FeedbackQuestionSubmissionEditPageAction #3357

### DIFF
--- a/src/main/webapp/js/instructorFeedbackEdit.js
+++ b/src/main/webapp/js/instructorFeedbackEdit.js
@@ -607,7 +607,7 @@ function formatQuestionNumbers(){
 
 function getQuestionLink(qnNumber) {
     var courseid = $("input[name='courseid']").val();
-    var fsname = toParameterFormat($("input[name='fsname']").val());
+    var fsname = encodeURIComponent($("input[name='fsname']").val());
     
     var questionId = $("#form_editquestion-" + qnNumber)
                         .find("input[name='questionid']").val();
@@ -621,7 +621,7 @@ function getQuestionLink(qnNumber) {
     var questionLink =  window.location.protocol + "//" 
                         + window.location.host + actionUrl
                         + "?courseid=" + courseid 
-                        + "&fsname=" + replaceAll(fsname, "#", "%23")
+                        + "&fsname=" + fsname
                         + "&questionid=" + questionId;
     
     setStatusMessage("Link for question " + qnNumber + ": " + questionLink, false);

--- a/src/main/webapp/js/instructorFeedbackEdit.js
+++ b/src/main/webapp/js/instructorFeedbackEdit.js
@@ -621,7 +621,7 @@ function getQuestionLink(qnNumber) {
     var questionLink =  window.location.protocol + "//" 
                         + window.location.host + actionUrl
                         + "?courseid=" + courseid 
-                        + "&fsname=" + fsname
+                        + "&fsname=" + fsname 
                         + "&questionid=" + questionId;
     
     setStatusMessage("Link for question " + qnNumber + ": " + questionLink, false);

--- a/src/main/webapp/js/instructorFeedbackEdit.js
+++ b/src/main/webapp/js/instructorFeedbackEdit.js
@@ -621,7 +621,7 @@ function getQuestionLink(qnNumber) {
     var questionLink =  window.location.protocol + "//" 
                         + window.location.host + actionUrl
                         + "?courseid=" + courseid 
-                        + "&fsname=" + fsname 
+                        + "&fsname=" + replaceAll(fsname, "#", "%23")
                         + "&questionid=" + questionId;
     
     setStatusMessage("Link for question " + qnNumber + ": " + questionLink, false);

--- a/src/test/java/teammates/test/cases/ui/browsertests/InstructorFeedbackEditPageUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/InstructorFeedbackEditPageUiTest.java
@@ -245,7 +245,7 @@ public class InstructorFeedbackEditPageUiTest extends BaseUiTestCase {
         String expectedUrl = TestProperties.inst().TEAMMATES_URL
                 + Const.ActionURIs.INSTRUCTOR_FEEDBACK_QUESTION_SUBMISSION_EDIT_PAGE
                 + "?courseid=" + courseId
-                + "&fsname=First+Session"
+                + "&fsname=First%20Session"
                 + "&questionid=" + questionId;
 
         assertTrue(feedbackEditPage.isElementVisible("statusMessage"));


### PR DESCRIPTION
Fixes #3357
This issue is very reminiscent of #3184 in the sense that the cause is exactly the same: # in session name. As such the remedy is also the same.
I can't use `encodeURIComponent` because it will also encode the + used in the URL in place of space, and that will cause problems.
Also, I'm two tests away from dev green, but they're failing in master anyway (#3371 and #3374) so I guess I won't be fixing them here.
(edit: I stand corrected: `encodeURIComponent` is the better solution as it also fixes #3376 )