### PR TITLE
FeedbackSessionsLogicTest occasionally fails at line 184 #3417

### DIFF
--- a/src/test/java/teammates/test/cases/logic/FeedbackSessionsLogicTest.java
+++ b/src/test/java/teammates/test/cases/logic/FeedbackSessionsLogicTest.java
@@ -40,6 +40,7 @@ import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
 import teammates.common.util.Const;
 import teammates.common.util.HttpRequestHelper;
+import teammates.common.util.ThreadHelper;
 import teammates.common.util.TimeHelper;
 import teammates.logic.api.Logic;
 import teammates.logic.automated.EmailAction;
@@ -176,6 +177,7 @@ public class FeedbackSessionsLogicTest extends BaseComponentUsingTaskQueueTestCa
         session.sessionVisibleFromTime = TimeHelper.getDateOffsetToCurrentTime(-1);
         session.startTime = TimeHelper.getDateOffsetToCurrentTime(-1);
         session.endTime = TimeHelper.getDateOffsetToCurrentTime(1);
+        ThreadHelper.waitBriefly(); // this one is correctly used
         fsLogic.createFeedbackSession(session);
         
         sessionList = fsLogic


### PR DESCRIPTION
Fixes #3417 
The problem lies in this code block:
![newtestimprovements2](https://cloud.githubusercontent.com/assets/7261051/7674073/3e7dc854-fd52-11e4-8c52-2ec21b007e17.png)
For the assertion in line 184 to pass, `sessionList` must contain `session` which is defined above. `getFeedbackSessionsClosingWithinTimeLimit` will return feedback sessions that are _strictly before_ the time limit, accurate to the milliseconds.
Failure occurs if between lines 178 and 179 the time elapsed is less than one millisecond (apparently it's possible). That is why adding waitBriefly (10 ms) solves the problem.