### PR TITLE
AdminActivityLogPageUiTest occasional fails due to IndexOutOfBoundException #3440

### DIFF
--- a/src/test/java/teammates/test/cases/ui/browsertests/AdminActivityLogPageUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/AdminActivityLogPageUiTest.java
@@ -52,12 +52,12 @@ public class AdminActivityLogPageUiTest extends BaseUiTestCase {
             logPage.clickViewActionsButtonOfFirstEntry();
             String actualPersonInfo = logPage.getFilterBoxString();
             assertEqualsIfQueryStringNotEmpty(expectedPersonInfo, actualPersonInfo);            
-        } catch (NoSuchElementException emptylogs) {
+        } catch (NoSuchElementException exceptionFromEmptyLogs) {
             /*
              * This can happen if this test is run right after the server is started.
              * In this case, no view actions can be done.
              */
-        } catch (IndexOutOfBoundsException invisibletmtlogs) {
+        } catch (IndexOutOfBoundsException exceptionFromInvisibleTmtLogs) {
             /*
              * This can happen if all the log entries are from test accounts
              * (i.e emails ending with .tmt) because they are invisible.

--- a/src/test/java/teammates/test/cases/ui/browsertests/AdminActivityLogPageUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/AdminActivityLogPageUiTest.java
@@ -49,7 +49,7 @@ public class AdminActivityLogPageUiTest extends BaseUiTestCase {
         
         try {
             String expectedPersonInfo = logPage.getPersonInfoOfFirstEntry();      
-            logPage.clickViewActionsButtonOfFirstEntry();
+            logPage.clickViewActionsButtonOfSecondEntry();
             String actualPersonInfo = logPage.getFilterBoxString();
             assertEqualsIfQueryStringNotEmpty(expectedPersonInfo, actualPersonInfo);            
         } catch (NoSuchElementException emptylogs) {

--- a/src/test/java/teammates/test/cases/ui/browsertests/AdminActivityLogPageUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/AdminActivityLogPageUiTest.java
@@ -57,8 +57,12 @@ public class AdminActivityLogPageUiTest extends BaseUiTestCase {
              * This can happen if this test is run right after the server is started.
              * In this case, no view actions can be done.
              */
-        } catch (IndexOutOfBoundsException e) {
-            // trying to figure out how to replicate this
+        } catch (IndexOutOfBoundsException invisibletmtlogs) {
+            /*
+             * This can happen if all the log entries are from test accounts
+             * (i.e emails ending with .tmt) because they are invisible.
+             * In this case, no view actions can be done.
+             */
         }
     }
     

--- a/src/test/java/teammates/test/cases/ui/browsertests/AdminActivityLogPageUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/AdminActivityLogPageUiTest.java
@@ -49,7 +49,7 @@ public class AdminActivityLogPageUiTest extends BaseUiTestCase {
         
         try {
             String expectedPersonInfo = logPage.getPersonInfoOfFirstEntry();      
-            logPage.clickViewActionsButtonOfSecondEntry();
+            logPage.clickViewActionsButtonOfFirstEntry();
             String actualPersonInfo = logPage.getFilterBoxString();
             assertEqualsIfQueryStringNotEmpty(expectedPersonInfo, actualPersonInfo);            
         } catch (NoSuchElementException emptylogs) {
@@ -57,6 +57,8 @@ public class AdminActivityLogPageUiTest extends BaseUiTestCase {
              * This can happen if this test is run right after the server is started.
              * In this case, no view actions can be done.
              */
+        } catch (IndexOutOfBoundsException e) {
+            // trying to figure out how to replicate this
         }
     }
     

--- a/src/test/java/teammates/test/pageobjects/AdminActivityLogPage.java
+++ b/src/test/java/teammates/test/pageobjects/AdminActivityLogPage.java
@@ -2,6 +2,8 @@ package teammates.test.pageobjects;
 
 import static org.testng.AssertJUnit.assertTrue;
 
+import java.util.List;
+
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
@@ -30,14 +32,14 @@ public class AdminActivityLogPage extends AppPage {
         return hiddenInput.getAttribute("value");
     }
     
-    public void clickViewActionsButtonOfFirstEntry(){
-        
+    public void clickViewActionsButtonOfSecondEntry() {
         WebElement table = browser.driver.findElement(By.id("logsTable"));
+        List<WebElement> tableEntries = table.findElements(By.tagName("tr"));
         WebElement tableRow;
-        try {
-            tableRow = table.findElements(By.tagName("tr")).get(1);
-        } catch (IndexOutOfBoundsException onlyoneentry) {
-            tableRow = table.findElements(By.tagName("tr")).get(0);
+        if (tableEntries.size() == 1) {
+            tableRow = tableEntries.get(0);
+        } else {
+            tableRow = tableEntries.get(1);
         }
         WebElement element = tableRow.findElement(By.tagName("button"));
         element.click();

--- a/src/test/java/teammates/test/pageobjects/AdminActivityLogPage.java
+++ b/src/test/java/teammates/test/pageobjects/AdminActivityLogPage.java
@@ -33,7 +33,12 @@ public class AdminActivityLogPage extends AppPage {
     public void clickViewActionsButtonOfFirstEntry(){
         
         WebElement table = browser.driver.findElement(By.id("logsTable"));
-        WebElement tableRow = table.findElements(By.tagName("tr")).get(1);
+        WebElement tableRow;
+        try {
+            tableRow = table.findElements(By.tagName("tr")).get(1);
+        } catch (IndexOutOfBoundsException onlyoneentry) {
+            tableRow = table.findElements(By.tagName("tr")).get(0);
+        }
         WebElement element = tableRow.findElement(By.tagName("button"));
         element.click();
     }

--- a/src/test/java/teammates/test/pageobjects/AdminActivityLogPage.java
+++ b/src/test/java/teammates/test/pageobjects/AdminActivityLogPage.java
@@ -2,8 +2,6 @@ package teammates.test.pageobjects;
 
 import static org.testng.AssertJUnit.assertTrue;
 
-import java.util.List;
-
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
@@ -32,15 +30,10 @@ public class AdminActivityLogPage extends AppPage {
         return hiddenInput.getAttribute("value");
     }
     
-    public void clickViewActionsButtonOfSecondEntry() {
+    public void clickViewActionsButtonOfFirstEntry(){
+        
         WebElement table = browser.driver.findElement(By.id("logsTable"));
-        List<WebElement> tableEntries = table.findElements(By.tagName("tr"));
-        WebElement tableRow;
-        if (tableEntries.size() == 1) {
-            tableRow = tableEntries.get(0);
-        } else {
-            tableRow = tableEntries.get(1);
-        }
+        WebElement tableRow = table.findElements(By.tagName("tr")).get(1);
         WebElement element = tableRow.findElement(By.tagName("button"));
         element.click();
     }


### PR DESCRIPTION
Fixes #3440 
(deleted the old explanation: they're totally off tangent and not addressing the issue).
The fails occur if the log entries are all from test e-mail accounts (ending with .tmt), because they will be _invisible_ in the logs table.