### PR TITLE
FeedbackNumScaleQuestionUiTest test fail randomly on line 113-114 #3444

### DIFF
--- a/src/test/java/teammates/test/pageobjects/InstructorFeedbackEditPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorFeedbackEditPage.java
@@ -192,6 +192,8 @@ public class InstructorFeedbackEditPage extends AppPage {
         }
         WebElement minScaleBox = browser.driver.findElement(By.id("minScaleBox" + idSuffix));
         fillTextBox(minScaleBox, Integer.toString(minScale));
+        JavascriptExecutor jsExecutor = (JavascriptExecutor) browser.driver;
+        jsExecutor.executeScript("$(arguments[0]).change();", minScaleBox);
     }
     
     public void fillMaxNumScaleBox(int maxScale, int qnNumber) {
@@ -212,6 +214,8 @@ public class InstructorFeedbackEditPage extends AppPage {
         }
         WebElement minScaleBox = browser.driver.findElement(By.id("minScaleBox" + idSuffix));
         fillTextBox(minScaleBox, minScale);
+        JavascriptExecutor jsExecutor = (JavascriptExecutor) browser.driver;
+        jsExecutor.executeScript("$(arguments[0]).change();", minScaleBox);
     }
     
     public void fillMaxNumScaleBox(String maxScale, int qnNumber) {
@@ -252,6 +256,8 @@ public class InstructorFeedbackEditPage extends AppPage {
         }
         WebElement stepBox = browser.driver.findElement(By.id("stepBox" + idSuffix));
         fillTextBox(stepBox, step);
+        JavascriptExecutor jsExecutor = (JavascriptExecutor) browser.driver;
+        jsExecutor.executeScript("$(arguments[0]).change();", stepBox);
     }
     
     public String getNumScalePossibleValuesString(int qnNumber) {


### PR DESCRIPTION
Fixes #3444 

This problem arises because of how Firefox deals with events depending on whether the webdriver browser is in focus or not.

On master, this test actually passes if the browser is running and we actively look at it and let it run because it is in focus and the onchange event will fire in that case.

However, when we allow the tests to run in the background and we go into Eclipse and start doing our own things like debugging, thinking of how we can write better code etc., Firefox is no longer in focus and sending Tab keys in the AppPage.java might not work as we intended it to.

Notice how this test seems to fail randomly and then when there are less and less tests running suddenly it passes? That's because when there are less browsers on, we have a higher chance or tendency to watch the test run or having that particular browser to be in focus hence it's like a buggy test when we don't care about it, but when we care about it and look at it it will definitely pass - heisentest much..

So the fix is to just forcibly trigger the on chance event whenever we fill in the text boxes as per what I've added in this PR. It's also consistent with some of the other fill text boxes, some of them forcibly trigger the on change event but some of them do not.

For consistency sake and also to bypass how Firefox deals with these events based on whether or not the browser is on focus and in the foreground, we should always just forcibly trigger the event to have a consistent testing result.