### PR TITLE
Inconsistent behavior of getJsonString in test #3450

### DIFF
--- a/src/test/java/teammates/test/cases/common/StudentProfileAttributesTest.java
+++ b/src/test/java/teammates/test/cases/common/StudentProfileAttributesTest.java
@@ -70,9 +70,9 @@ public class StudentProfileAttributesTest extends BaseTestCase {
                      + "\n  \"moreInfo\": \"moreInfo can have a lot more than this...\","
                      + "\n  \"pictureKey\": \"profile Pic Key\","
                      /*
-                      *  there's a strange bug here:
-                      *  if running full test suite getJsonString() returns +0000
-                      *  but if running the test alone getJsonString() returns +0800
+                      *  Be careful:
+                      *  This comparison will fail if the test is run without
+                      *  the VM argument -Duser.timezone=UTC.
                       */
                      + "\n  \"modifiedDate\": \"2015-05-21 8:34 AM +0000\"\n}",
                      spa.getJsonString());


### PR DESCRIPTION
Fixes #3450 
Not a fix per se, but rather an explanation on how to actually make the test work without fail.
Trying to figure out if the setting can be changed such that this can be forced to everyone.