### PR TITLE
InstructorFeedbackResultsPageUiTest test waiting excessively long around line 456-458 #3445

### DIFF
--- a/src/test/java/teammates/test/cases/ui/browsertests/InstructorFeedbackResultsPageUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/InstructorFeedbackResultsPageUiTest.java
@@ -454,7 +454,7 @@ public class InstructorFeedbackResultsPageUiTest extends BaseUiTestCase {
         
         resultsPage.displayByRecipientGiverQuestion();
         resultsPage.addFeedbackResponseComment("showResponseCommentAddForm-0-1-1", "successive action comment");
-        resultsPage.verifyCommentRowContent("-0",
+        resultsPage.verifyCommentRowContent("-0-1-1-2",
                 "successive action comment", "CFResultsUiT.instr@gmail.tmt");
         
         resultsPage.editFeedbackResponseComment("-0-1-1-2",


### PR DESCRIPTION
Fixes #3445 
We look back back to commit 9a74903205eb66407024433ea29d3f14c7e1c422, where the comment row ID suffixes are changed (possibly due to change in implementation).
_Notice that there's a line that's missed._
And that's it. We're forced to wait for 30 seconds for a non-existent element.