### PR TITLE
executeJsTests can sometimes fail #3477

### DIFF
--- a/src/main/webapp/js/index.js
+++ b/src/main/webapp/js/index.js
@@ -123,10 +123,15 @@ function formatNumber(number) {
     return number;
 }
 
-// looping through all the testimonials
+//looping through all the testimonials
 function loopTestimonials() {
-    var tc = document.getElementById("testimonialContainer");
+    var tc = document.getElementById('testimonialContainer');
+    
+    // intended null checking and early return, to prevent constant failures in JavaScript tests
+    if (tc === null && typeof tc === 'object') {
+        return;
+    }
+    
     tc.innerHTML = TESTIMONIALS[CURRENT_TESTIMONIAL];
     CURRENT_TESTIMONIAL = (CURRENT_TESTIMONIAL + 1) % TESTIMONIALS.length;
-
 }


### PR DESCRIPTION
Fixes #3477

In case anyone is interested

![screen shot 2015-05-25 at 11 27 15 am](https://cloud.githubusercontent.com/assets/6291947/7791349/2ad3a59c-02d1-11e5-8d1c-00e841128f84.png)

After adding for null check, no more red blobs -> 

![screen shot 2015-05-25 at 11 27 08 am](https://cloud.githubusercontent.com/assets/6291947/7791350/2b01c878-02d1-11e5-80ff-39a70618166c.png)

Once index.js is loaded, there is a set interval for looping testimonials but no check as to whether the element is there, when on our js test html it is null and every 5000 ms it will loop and result in an error, sometimes during our entire testing suite if the assert from Java comes later than that, it will find that there is a JavaScript error and that looping error is the one that is found, not an actual JavaScript testing error.