### PR TITLE
InstructorFeedbackEditCopyUiTest can sometimes fail #3485

### DIFF
--- a/src/test/java/teammates/test/pageobjects/InstructorFeedbackEditPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorFeedbackEditPage.java
@@ -379,7 +379,7 @@ public class InstructorFeedbackEditPage extends AppPage {
     }
     
     public void waitForModalToLoad() {
-        waitForElementPresence(By.id(Const.ParamsNames.COPIED_FEEDBACK_SESSION_NAME), 1);
+        waitForElementPresence(By.id(Const.ParamsNames.COPIED_FEEDBACK_SESSION_NAME), 5);
     }
     
     public void fillCopyToOtherCoursesForm(String newName) {


### PR DESCRIPTION
Fixes #3485 by giving the modal waiting time to go up to 5 seconds

It used to be allowed up to 1 second, sometimes it fails but most of the time it doesn't.

Considering that this wait can return early from Selenium if it is found, it shouldn't affect the timing by too much (most of the time it takes < 1 second anyway). On the off chance that it takes > 1 second we should let it continue finding it -> this happens most often when we run the entire test suite and it might take longer to find elements due to taking longer to load.