### PR TITLE
BackDoorTest.java still fails due to java.lang.StackOverflowError #3488

### DIFF
--- a/src/test/java/teammates/test/cases/testdriver/BackDoorTest.java
+++ b/src/test/java/teammates/test/cases/testdriver/BackDoorTest.java
@@ -325,7 +325,7 @@ public class BackDoorTest extends BaseTestCase {
         // Characters that are allowed in a URI but do not have a reserved
         // purpose are called unreserved. 
         // unreserved = ALPHA / DIGIT / "-" / "." / "_" / "~"
-        String pattern = "(\\w|-|~|.)*";
+        String pattern = "(\\w|-|~|\\.)*";
 
         String errorMessage = key + "[length=" + key.length() + "][reg="
                 + StringHelper.isMatching(key, pattern) + "] is not as expected";

--- a/src/test/java/teammates/test/cases/testdriver/BackDoorTest.java
+++ b/src/test/java/teammates/test/cases/testdriver/BackDoorTest.java
@@ -310,7 +310,10 @@ public class BackDoorTest extends BaseTestCase {
 
         StudentAttributes student = new StudentAttributes("sect1", "t1", "name of tgsr student", "tgsr@gmail.tmt", "", "course1");
         BackDoor.createStudent(student);
-        String key = BackDoor.getKeyForStudent(student.course, student.email); 
+        String key = "[BACKDOOR_STATUS_FAILURE]";
+        while (key.startsWith("[BACKDOOR_STATUS_FAILURE]")) {
+            key = BackDoor.getKeyForStudent(student.course, student.email);
+        }
 
         // The following is the google app engine description about generating
         // keys.


### PR DESCRIPTION
Fixes #3488 
Two causes of this failure:
1. In each failure case, this is the what's stored in the variable key:
[BACKDOOR_STATUS_FAILURE]teammates.common.exception.EntityDoesNotExistException: Student does not exist: [course1/tgsr@gmail.tmt]
We need to wait until a legit key is returned before proceeding.
2. Erroneous regex for `.`
`.` is a regex for anything except new line. `\\.` is the correct one in Java.
