### PR TITLE
InstructorCommentsPageUiTest occasionally fails at line 105 #3524

### DIFF
--- a/src/test/resources/data/InstructorCommentsPageUiTest.json
+++ b/src/test/resources/data/InstructorCommentsPageUiTest.json
@@ -84,6 +84,7 @@
         "typicalCourse1":{
             "id":"comments.idOfTypicalCourse1",
             "name":"Typical Course 1 with 2 Evals",
+            "createdAt": "2012-04-01 11:59 PM UTC",
             "isArchived":false
         },
         "sampleCourse":{
@@ -99,6 +100,7 @@
         "archivedCourse":{
             "id":"comments.idOfArchivedCourse",
             "name":"Archived Course",
+            "createdAt": "2012-04-01 11:58 PM UTC",
             "isArchived":true
         }
     },


### PR DESCRIPTION
Fixes #3524 
InstructorCommentsPage arranges the courses based on the createdAt time, which the json file didn't provide previously (as the result the page result is random).