### PR TITLE
InstructorCommentsPageUiTest occasionally fails at line 177 #3537

### DIFF
--- a/src/test/java/teammates/test/pageobjects/InstructorCommentsPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorCommentsPage.java
@@ -205,10 +205,14 @@ public class InstructorCommentsPage extends AppPage {
         if(idNumber == 4){
             WebElement commentRow = browser.driver.findElement(By.id("responseCommentEditForm-" + commentTableIdSuffix));
             waitForPageToLoad();
+            By errorSpan = By.cssSelector(".col-sm-offset-5 > span");
+            waitForElementPresence(errorSpan, 5);
             assertEquals(errorMessage, commentRow.findElement(By.className("col-sm-offset-5")).findElement(By.tagName("span")).getText());
         } else if(idNumber == 3){
             WebElement commentRow = browser.driver.findElement(By.id("showResponseCommentAddForm-" + commentTableIdSuffix));
             waitForPageToLoad();
+            By errorSpan = By.cssSelector(".col-sm-offset-5 > span");
+            waitForElementPresence(errorSpan, 5);
             assertEquals(errorMessage, commentRow.findElement(By.className("col-sm-offset-5")).findElement(By.tagName("span")).getText());
         }
     }


### PR DESCRIPTION
Fixes #3537

Gave it 5 seconds to be loaded, can return earlier (and most likely will), it used to timeout because Selenium isn't waiting for it after clicking add, which can make it timeout with an exception in 16ms, error is prone when running entire test suite and it might take longer than 16ms for the error message to actually load