### PR TITLE
AdminHomePageUiTest occasionally fails when verifying for NJI #3538

### DIFF
--- a/src/test/java/teammates/test/pageobjects/InstructorHomePage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorHomePage.java
@@ -87,6 +87,7 @@ public class InstructorHomePage extends AppPage {
     public InstructorFeedbacksPage clickCourseAddEvaluationLink(String courseId) {
         getCourseLinkInRow("course-add-eval-for-test", getCourseRowId(courseId)).click();
         waitForPageToLoad();
+        ThreadHelper.waitBriefly();
         return changePageType(InstructorFeedbacksPage.class);
     }
     


### PR DESCRIPTION
Fixes #3538 

By waiting briefly to let AJAX finish, instantly verifying the HTML sometimes make it try to verify while it is still loading