### PR TITLE
'&' is not handled properly in the page footer #3430

### DIFF
--- a/src/main/java/teammates/common/util/Sanitizer.java
+++ b/src/main/java/teammates/common/util/Sanitizer.java
@@ -1,9 +1,12 @@
 package teammates.common.util;
 
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+
 import static org.apache.commons.lang3.StringEscapeUtils.escapeHtml4;
 
 import com.google.appengine.api.datastore.Text;
@@ -115,6 +118,14 @@ public class Sanitizer {
                 //To ensure when apply sanitizeForHtml for multiple times, the string's still fine
                 //Regex meaning: replace '&' with safe encoding, but not the one that is safe already
                 .replaceAll("&(?!(amp;)|(lt;)|(gt;)|(quot;)|(#x2f;)|(#39;))", "&amp;");
+    }
+    
+    public static String sanitizeForUri(String uri) {
+        try {
+            return URLEncoder.encode(uri, "UTF-8");
+        } catch (UnsupportedEncodingException wonthappen) {
+            return uri;
+        }
     }
     
     public static String sanitizeForRichText(String richText) {

--- a/src/main/webapp/jsp/instructorCourseJoinConfirmation.jsp
+++ b/src/main/webapp/jsp/instructorCourseJoinConfirmation.jsp
@@ -2,6 +2,7 @@
     pageEncoding="UTF-8"%>
 
 <%@ page import="teammates.common.util.Const"%>
+<%@ page import="teammates.common.util.Sanitizer"%>
 <%@ page import="teammates.ui.controller.PageData"%>
 <%@ page import="teammates.ui.controller.InstructorCourseJoinConfirmationPageData"%>
 <%
@@ -65,7 +66,7 @@
                             ref = Const.ActionURIs.INSTRUCTOR_COURSE_JOIN_AUTHENTICATED
                                     + "?key=" + data.regkey + "&"
                                     + Const.ParamsNames.INSTRUCTOR_INSTITUTION + "="
-                                    + data.institute;
+                                    + Sanitizer.sanitizeForUri(data.institute);
                         }
                     %>
                     <a href="<%=ref%>" id="button_confirm"


### PR DESCRIPTION
Fixes #3430 
Along with it, also '#' and '+' which did give problems as well (although I don't think there are institutes with those characters in their name :p)
![solved](https://cloud.githubusercontent.com/assets/7261051/7928325/ace71122-0920-11e5-85bf-7a7a1b88cf91.png)
