### PR TITLE
StudentCourseJoinConfirmationPageUiTest fails due to invalid login page #3607

### DIFF
--- a/src/test/java/teammates/test/cases/ui/browsertests/StudentCourseJoinConfirmationPageUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/StudentCourseJoinConfirmationPageUiTest.java
@@ -62,7 +62,7 @@ public class StudentCourseJoinConfirmationPageUiTest extends BaseUiTestCase {
         String courseName = testData.courses.get("SCJConfirmationUiT.CS2104").name;
         String studentEmail = testData.students.get("alice.tmms@SCJConfirmationUiT.CS2104").email;
         joinLink = new Url(joinActionUrl)
-                        .withRegistrationKey(BackDoor.getKeyForStudent(courseId, studentEmail))
+                        .withRegistrationKey(getKeyFromBackDoor(courseId, studentEmail))
                         .withCourseId(courseId)
                         .withStudentEmail(studentEmail)
                         .toString();
@@ -84,7 +84,7 @@ public class StudentCourseJoinConfirmationPageUiTest extends BaseUiTestCase {
         courseName = testData.courses.get("SCJConfirmationUiT.CS2103").name;
         studentEmail = testData.students.get("alice.tmms@SCJConfirmationUiT.CS2103").email;
         joinLink = Url.addParamToUrl(joinActionUrl,Const.ParamsNames.REGKEY,
-                BackDoor.getKeyForStudent(courseId, studentEmail));
+                                     getKeyFromBackDoor(courseId, studentEmail));
         
         browser.driver.get(joinLink);
         confirmationPage = createNewPage(browser, StudentCourseJoinConfirmationPage.class);
@@ -150,7 +150,7 @@ public class StudentCourseJoinConfirmationPageUiTest extends BaseUiTestCase {
         String courseName = testData.courses.get("SCJConfirmationUiT.CS2104").name;
         String studentEmail = testData.students.get("alice.tmms@SCJConfirmationUiT.CS2104").email;
         joinLink = Url.addParamToUrl(joinActionUrl,Const.ParamsNames.REGKEY,
-                                     BackDoor.getKeyForStudent(courseId, studentEmail));
+                                     getKeyFromBackDoor(courseId, studentEmail));
         
         browser.driver.get(joinLink);
         studentHomePage = createCorrectLoginPageType(browser.driver.getPageSource())
@@ -169,7 +169,7 @@ public class StudentCourseJoinConfirmationPageUiTest extends BaseUiTestCase {
         courseName = testData.courses.get("SCJConfirmationUiT.CS2103").name;
         studentEmail = testData.students.get("alice.tmms@SCJConfirmationUiT.CS2103").email;
         joinLink = Url.addParamToUrl(joinActionUrl,Const.ParamsNames.REGKEY,
-                BackDoor.getKeyForStudent(courseId, studentEmail));
+                                     getKeyFromBackDoor(courseId, studentEmail));
         
         browser.driver.get(joinLink);
         confirmationPage = createNewPage(browser, StudentCourseJoinConfirmationPage.class);
@@ -233,4 +233,14 @@ public class StudentCourseJoinConfirmationPageUiTest extends BaseUiTestCase {
             throw new RuntimeException(e);
         }
     }
+
+    // continuously ask BackDoor to get the key until a legit key is returned
+    private String getKeyFromBackDoor(String courseId, String studentEmail) {
+        String key = "[BACKDOOR_STATUS_FAILURE]";
+        while (key.startsWith("[BACKDOOR_STATUS_FAILURE]")) {
+            key = BackDoor.getKeyForStudent(courseId, studentEmail);
+        }
+        return key;
+    }
+
 }

--- a/src/test/java/teammates/test/cases/ui/browsertests/StudentCourseJoinConfirmationPageUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/StudentCourseJoinConfirmationPageUiTest.java
@@ -11,6 +11,7 @@ import org.testng.annotations.Test;
 
 import teammates.common.datatransfer.DataBundle;
 import teammates.common.util.Const;
+import teammates.common.util.ThreadHelper;
 import teammates.common.util.Url;
 import teammates.test.driver.BackDoor;
 import teammates.test.driver.TestProperties;
@@ -236,9 +237,12 @@ public class StudentCourseJoinConfirmationPageUiTest extends BaseUiTestCase {
 
     // continuously ask BackDoor to get the key until a legit key is returned
     private String getKeyFromBackDoor(String courseId, String studentEmail) {
+        int NUMBER_OF_REMAINING_RETRIES = 10;
         String key = "[BACKDOOR_STATUS_FAILURE]";
-        while (key.startsWith("[BACKDOOR_STATUS_FAILURE]")) {
+        while (key.startsWith("[BACKDOOR_STATUS_FAILURE]") && NUMBER_OF_REMAINING_RETRIES > 0) {
             key = BackDoor.getKeyForStudent(courseId, studentEmail);
+            NUMBER_OF_REMAINING_RETRIES--;
+            ThreadHelper.waitFor(100);
         }
         return key;
     }


### PR DESCRIPTION
Fixes #3607 
This is one of the pages that can be left behind when it fails:
![scjcbugexplained](https://cloud.githubusercontent.com/assets/7261051/7952893/442dd4f2-09ef-11e5-8f12-e0f7840db4da.png)
And everything suddenly becomes obvious.