### PR TITLE
Remove unused method in StudentProfilePage Page Object #3624

### DIFF
--- a/src/test/java/teammates/test/pageobjects/StudentProfilePage.java
+++ b/src/test/java/teammates/test/pageobjects/StudentProfilePage.java
@@ -171,10 +171,4 @@ public class StudentProfilePage extends AppPage {
                                                           .getAttribute("value"));
     }
 
-    // TODO method unused
-    public void verifyPictureIsVisible(int height) throws Exception {
-        assertEquals(height, Integer.parseInt(browser.driver.findElement(By.className("jcrop-holder"))
-                                                     .getCssValue("height")));
-    }
-
 }


### PR DESCRIPTION
Fixes #3624 

There has been a TODO to remove it for quite some time, might as well remove it now since I saw it while working on the random failing test case.