### PR TITLE
Migrate to latest version of Selenium + Firefox #3643

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -15,7 +15,7 @@
 	<classpathentry kind="lib" path="src/test/resources/lib/appengine/appengine-api.jar"/>
 	<classpathentry kind="lib" path="src/test/resources/lib/appengine/appengine-api-stubs.jar"/>
 	<classpathentry kind="lib" path="src/test/resources/lib/appengine/appengine-api-labs.jar"/>
-	<classpathentry kind="lib" path="src/test/resources/lib/selenium/selenium-server-standalone-2.41.0.jar" sourcepath="src/test/resources/lib/selenium/selenium-java-2.41.0-srcs.jar"/>
+	<classpathentry kind="lib" path="src/test/resources/lib/selenium/selenium-server-standalone-2.46.0.jar" sourcepath="src/test/resources/lib/selenium/selenium-java-2.46.0-srcs.jar"/>
 	<classpathentry kind="lib" path="src/test/resources/lib/httpunit/httpunit.jar"/>
 	<classpathentry kind="lib" path="src/main/webapp/WEB-INF/lib/appengine-gcs-client-0.3.13.jar"/>
 	<classpathentry kind="lib" path="src/main/webapp/WEB-INF/lib/guava-15.0.jar"/>

--- a/devdocs/settingUp.md
+++ b/devdocs/settingUp.md
@@ -91,18 +91,7 @@ Important: When a version is specified, please install that version instead of t
 1. TEAMMATES automated testing requires Firefox (works on Windows and OS-X) 
     or Chrome (Windows only). The default browser used for testing is Firefox 
     because it is faster than Chrome and it can be run in the background.
-    If you plan to use Firefox for testing TEAMMATES, 
-   downgrade to Firefox 21.0 from [here](https://ftp.mozilla.org/pub/mozilla.org/firefox/releases/)
-   {The web driver we use may not work with the latest Firefox.} <br>
-   To install Firefox 21.0 while keeping the latest Firefox for
-   regular use, grab Firefox 21.0 from the above link, and choose `custom 
-   setup` during install, in which you will be able to specify a different path 
-   for this version e.g. `C:\Program Files\Mozilla Firefox 21`) in a later step.<br>
-   Remember to disable auto-updates in Firefox. `Options → Advanced tab → Update`<br>
-   After that, you need to specify which version of the Firefox
-   should be used for testing, by modifying the `test.firefox.path` property 
-   (note the double slashes).<br>
-   e.g. `test.firefox.path=C:\\Program Files\\Mozilla Firefox 21\\firefox.exe`
+    Firefox 38.0.5 (latest release as at 7th June 2015) is supported.
    
 2. Before running the test suite, both the server and the test environment 
    should be using the UTC time zone. Here is the procedure.
@@ -245,7 +234,7 @@ Troubleshooting instructions are given [in this document](https://docs.google.co
 
 ####Tools used in testing
 
-* **Selenium** [version 2.41.0]
+* **Selenium** [version 2.46.0]
     Selenium automates browsers. We use it for automating our UI tests.
     We require Selenium standalone server, Chrome driver, IE driver, and Java language bindings.
 * **JavaMail** [version 1.4.5]
@@ -255,7 +244,7 @@ Troubleshooting instructions are given [in this document](https://docs.google.co
     TestNG is a Java test automation framework.
 * **QUnit** [version 1.10.0]
     QUnit is a JavaScript unit test suite.
-* **NekoHtml** [version 1.9.16]
+* **NekoHtml** [version 1.9.21]
     NekoHTML is a simple HTML scanner and tag balancer that enables application programmers to parse HTML documents and access the information using standard XML interfaces.
     NekoHTML is included in the Selenium libraries.
     Usage: During UI testing, for doing a logical comparison of the pages generated against expected pages.

--- a/devdocs/settingUp.md
+++ b/devdocs/settingUp.md
@@ -244,7 +244,7 @@ Troubleshooting instructions are given [in this document](https://docs.google.co
     TestNG is a Java test automation framework.
 * **QUnit** [version 1.10.0]
     QUnit is a JavaScript unit test suite.
-* **NekoHtml** [version 1.9.21]
+* **NekoHtml** [version 1.9.22]
     NekoHTML is a simple HTML scanner and tag balancer that enables application programmers to parse HTML documents and access the information using standard XML interfaces.
     NekoHTML is included in the Selenium libraries.
     Usage: During UI testing, for doing a logical comparison of the pages generated against expected pages.

--- a/devdocs/settingUp.md
+++ b/devdocs/settingUp.md
@@ -50,7 +50,7 @@ Important: When a version is specified, please install that version instead of t
    * `src/main/webapp/WEB-INF/appengine-web.xml`<br>
    Create it using `appengine-web.template.xml`. 
    For now, property values can remain as they are.
-4. Download [this zip file](http://www.comp.nus.edu.sg/~seer/teammates-libs/libs.zip)
+4. Download [this zip file](http://www.comp.nus.edu.sg/~seer/teammates-libs/libsV5.46.zip)
    containing the required library files and unzip it into
    your project folder. Note that this will overwrite some existing library files,
    which is what we want. If you unzipped it into the right location, you should now see

--- a/src/test/java/teammates/test/pageobjects/Browser.java
+++ b/src/test/java/teammates/test/pageobjects/Browser.java
@@ -58,7 +58,7 @@ public class Browser {
         if (TestProperties.inst().BROWSER.equals("htmlunit")) {
             System.out.println("Using HTMLUnit.");
 
-            HtmlUnitDriver htmlUnitDriver = new HtmlUnitDriver(BrowserVersion.FIREFOX_17);
+            HtmlUnitDriver htmlUnitDriver = new HtmlUnitDriver(BrowserVersion.FIREFOX_38);
             htmlUnitDriver.setJavascriptEnabled(true);
             return htmlUnitDriver;
 

--- a/src/test/java/teammates/test/pageobjects/InstructorFeedbackResultsPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorFeedbackResultsPage.java
@@ -271,24 +271,25 @@ public class InstructorFeedbackResultsPage extends AppPage {
                                  + ".getElementsByTagName('a')[0].click();");
         Actions actions = new Actions(browser.driver);
 
-        actions.moveToElement(photoCell).build().perform();
+        actions.moveToElement(photoCell).perform();
         waitForElementToAppear(By.cssSelector(".popover-content > img"));
 
         List<WebElement> photos = browser.driver.findElements(By.cssSelector(".popover-content > img"));
         AssertHelper.assertContainsRegex(urlRegex, photos.get(photos.size() - 1).getAttribute("src"));
 
-        actions.moveByOffset(100, 100).click().build().perform();
+        actions.moveByOffset(100, 100).click().perform();
     }
 
     public void hoverClickAndViewStudentPhotoOnHeading(int panelHeadingIndex, String urlRegex) throws Exception {
+        JavascriptExecutor jsExecutor = (JavascriptExecutor) browser.driver;
         String idOfPanelHeading = "panelHeading-" + panelHeadingIndex;
         WebElement photoDiv = browser.driver.findElement(By.id(idOfPanelHeading))
                                             .findElement(By.className("profile-pic-icon-hover"));
+        jsExecutor.executeScript("arguments[0].scrollIntoView(true);", photoDiv);
         Actions actions = new Actions(browser.driver);
-        actions.moveToElement(photoDiv).build().perform();
+        actions.moveToElement(photoDiv).perform();
         waitForElementToAppear(By.cssSelector(".popover-content"));
 
-        JavascriptExecutor jsExecutor = (JavascriptExecutor) browser.driver;
         jsExecutor.executeScript("document.getElementsByClassName('popover-content')[0]"
                                  + ".getElementsByTagName('a')[0].click();");
 
@@ -309,7 +310,7 @@ public class InstructorFeedbackResultsPage extends AppPage {
                                              .findElements(By.className("profile-pic-icon-hover"))
                                              .get(0);
         Actions actions = new Actions(browser.driver);
-        actions.moveToElement(photoLink).build().perform();
+        actions.moveToElement(photoLink).perform();
 
         waitForElementToAppear(By.cssSelector(".popover-content > img"));
         ThreadHelper.waitFor(500);


### PR DESCRIPTION
Fixes #3643 
Download Selenium [here](http://selenium-release.storage.googleapis.com/index.html?path=2.46/), only `selenium-java-2.46.0-srcs.jar` (found inside the Java zip) and `selenium-server-standalone-2.46.0.jar` are required. Place them on `src/test/resources/lib/selenium/`.
Update Firefox to the latest one (38.0.5) [here](https://www.mozilla.org/en-US/firefox/new/).
Eclipse will show a few warnings due to deprecations and what-nots but everything will still work.