### PR TITLE
JSTL - page.tag fix.

### DIFF
--- a/src/main/webapp/WEB-INF/tags/instructor/instructorPage.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/instructorPage.tag
@@ -1,5 +1,4 @@
 <%@ tag description="Generic Instructor Page" %>
-<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib tagdir="/WEB-INF/tags" prefix="t" %>
 <%@ taglib tagdir="/WEB-INF/tags/instructor" prefix="ti" %>
 <%@ attribute name="pageTitle" required="true" %>

--- a/src/main/webapp/WEB-INF/tags/page.tag
+++ b/src/main/webapp/WEB-INF/tags/page.tag
@@ -38,7 +38,7 @@
         <t:bodyHeader title="${bodyTitle}" />
         <jsp:doBody />
     </div>
-    <c:if test="{data.account.instructor}">
+    <c:if test="${not empty data.account.institute}">
         <t:bodyFooter />
     </c:if>
 </body>


### PR DESCRIPTION
Changes a condition in page.tag to display the footer if the account has an institute rather than whether it is an instructor.