### PR TITLE
Suppress redundant queries in StudentHomePageAction, part 2

### DIFF
--- a/src/main/java/teammates/logic/api/Logic.java
+++ b/src/main/java/teammates/logic/api/Logic.java
@@ -3,6 +3,7 @@ package teammates.logic.api;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.logging.Logger;
 
@@ -785,16 +786,19 @@ public class Logic {
     /**
      * Preconditions: <br>
      * * All parameters are non-null.
+     * <br>
+     * @param alreadyRetrievedData The previously obtained query results to be re-used
      * 
      * @return Details of courses the student is in. CourseData objects
      *         returned contain details of feedback sessions too (except the ones
      *         still AWAITING).
      */
-    public List<CourseDetailsBundle> getCourseDetailsListForStudent(String googleId)
-            throws EntityDoesNotExistException {
+    public List<CourseDetailsBundle> getCourseDetailsListForStudent(String googleId,
+                                              Map<String, StudentAttributes> alreadyRetrievedData)
+                                     throws EntityDoesNotExistException {
         
         Assumption.assertNotNull(ERROR_NULL_PARAMETER, googleId);
-        return coursesLogic.getCourseDetailsListForStudent(googleId);
+        return coursesLogic.getCourseDetailsListForStudent(googleId, alreadyRetrievedData);
     }
     
     /**

--- a/src/main/java/teammates/logic/core/CoursesLogic.java
+++ b/src/main/java/teammates/logic/core/CoursesLogic.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.logging.Logger;
 
 import teammates.common.datatransfer.AccountAttributes;
@@ -139,8 +140,12 @@ public class CoursesLogic {
         return courseSummary;
     }
 
-    public List<CourseDetailsBundle> getCourseDetailsListForStudent(String googleId) 
-                throws EntityDoesNotExistException {
+    /**
+     * @param alreadyRetrievedData The previously obtained query results to be re-used
+     */
+    public List<CourseDetailsBundle> getCourseDetailsListForStudent(String googleId,
+                                              Map<String, StudentAttributes> alreadyRetrievedData) 
+                                     throws EntityDoesNotExistException {
         
         List<CourseAttributes> courseList = getCoursesForStudentAccount(googleId);
         List<CourseDetailsBundle> courseDetailsList = new ArrayList<CourseDetailsBundle>();
@@ -148,6 +153,7 @@ public class CoursesLogic {
         for (CourseAttributes c : courseList) {
 
             StudentAttributes s = studentsLogic.getStudentForCourseIdAndGoogleId(c.id, googleId);
+            alreadyRetrievedData.put(c.id, s);
             
             if (s == null) {
                 //TODO Remove excessive logging after the reason why s can be null is found

--- a/src/test/java/teammates/test/cases/logic/CoursesLogicTest.java
+++ b/src/test/java/teammates/test/cases/logic/CoursesLogicTest.java
@@ -734,7 +734,7 @@ public class CoursesLogicTest extends BaseComponentTestCase {
     
         // Get course details for student
         List<CourseDetailsBundle> courseList = coursesLogic
-                .getCourseDetailsListForStudent(studentInBothCourses.googleId);
+                .getCourseDetailsListForStudent(studentInBothCourses.googleId, new HashMap<String, StudentAttributes>());
     
         // Verify number of courses received
         assertEquals(2, courseList.size());
@@ -749,7 +749,7 @@ public class CoursesLogicTest extends BaseComponentTestCase {
         ______TS("non-existent student");
     
         try {
-            coursesLogic.getCourseDetailsListForStudent("non-existent-student");
+            coursesLogic.getCourseDetailsListForStudent("non-existent-student", new HashMap<String, StudentAttributes>());
             signalFailureToDetectException();
         } catch (EntityDoesNotExistException e) {
             AssertHelper.assertContains("does not exist",
@@ -759,7 +759,7 @@ public class CoursesLogicTest extends BaseComponentTestCase {
         ______TS("null parameter");
     
         try {
-            coursesLogic.getCourseDetailsListForStudent(null);
+            coursesLogic.getCourseDetailsListForStudent(null, new HashMap<String, StudentAttributes>());
             signalFailureToDetectException();
         } catch (AssertionError e) {
             assertEquals("Supplied parameter was null\n", e.getMessage());


### PR DESCRIPTION
Extension of #3651.
Because `coursesLogic.getCourseDetailsListForStudent` has already made query for StudentAttributes for each respective course, I supply a HashMap to memo-ize the query result so that they can be re-used in the subsequent steps.