### PR TITLE
Suppress redundant queries in StudentHomePageAction, part 3

### DIFF
--- a/src/main/java/teammates/logic/core/CoursesLogic.java
+++ b/src/main/java/teammates/logic/core/CoursesLogic.java
@@ -164,9 +164,11 @@ public class CoursesLogic {
                 Assumption.assertNotNull("Student should not be null at this point.", s);
             }
             
+            // Skip the course existence check since the course ID is obtained from a
+            // valid CourseAttributes resulting from query
             List<FeedbackSessionAttributes> feedbackSessionList = 
-                    feedbackSessionsLogic.getFeedbackSessionsForUserInCourse(c.id, s.email);
-            
+                    feedbackSessionsLogic.getFeedbackSessionsForUserInCourseSkipCheck(c.id, s.email);
+
             CourseDetailsBundle cdd = new CourseDetailsBundle(c);
             
             for (FeedbackSessionAttributes fs : feedbackSessionList) {

--- a/src/main/java/teammates/logic/core/FeedbackQuestionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackQuestionsLogic.java
@@ -224,14 +224,24 @@ public class FeedbackQuestionsLogic {
     public List<FeedbackQuestionAttributes> getFeedbackQuestionsForCreatorInstructor(
                                     String feedbackSessionName, String courseId) 
                     throws EntityDoesNotExistException {
-        
-        if (fsLogic.getFeedbackSession(feedbackSessionName, courseId) == null) {
+
+        FeedbackSessionAttributes fsa = fsLogic.getFeedbackSession(feedbackSessionName, courseId);
+        if (fsa == null) {
             throw new EntityDoesNotExistException(
                     "Trying to get questions for a feedback session that does not exist.");
         }
+        
+        return getFeedbackQuestionsForCreatorInstructor(fsa);
+    }
+    
+    public List<FeedbackQuestionAttributes> getFeedbackQuestionsForCreatorInstructor(
+                                    FeedbackSessionAttributes fsa) {
 
         List<FeedbackQuestionAttributes> questions =
                 new ArrayList<FeedbackQuestionAttributes>();
+        
+        String feedbackSessionName = fsa.feedbackSessionName;
+        String courseId = fsa.courseId;
         
         questions.addAll(fqDb.getFeedbackQuestionsForGiverType(
                                        feedbackSessionName, courseId, INSTRUCTORS));
@@ -272,8 +282,7 @@ public class FeedbackQuestionsLogic {
      * students can view/submit.
      */
     public List<FeedbackQuestionAttributes> getFeedbackQuestionsForStudents(
-            String feedbackSessionName, String courseId) 
-                    throws EntityDoesNotExistException {
+            String feedbackSessionName, String courseId) {
 
         List<FeedbackQuestionAttributes> questions =
                 new ArrayList<FeedbackQuestionAttributes>();

--- a/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
@@ -129,6 +129,8 @@ public class FeedbackSessionsLogic {
     }
 
     /**
+     * Checks if the specified course exists, then gets the feedback sessions for
+     * the specified user in the course if it does exist.
      * 
      * @param courseId
      * @param userEmail
@@ -143,7 +145,23 @@ public class FeedbackSessionsLogic {
             throw new EntityDoesNotExistException(
                     "Trying to get feedback sessions for a course that does not exist.");
         }
+        return getFeedbackSessionsForUserInCourseSkipCheck(courseId, userEmail);
+    }
 
+    /**
+     * Gets the feedback sessions for the specified user in the specified course
+     * without checking for the course's existence.<br>
+     * This method is usually called after the course's existence is assumed or
+     * has been verified.
+     * 
+     * @param courseId
+     * @param userEmail
+     * @return a list of viewable feedback sessions for any user for his course.
+     * @throws EntityDoesNotExistException
+     */
+    public List<FeedbackSessionAttributes> getFeedbackSessionsForUserInCourseSkipCheck(
+            String courseId, String userEmail)
+            throws EntityDoesNotExistException {
         List<FeedbackSessionAttributes> sessions =
                 getFeedbackSessionsForCourse(courseId);
         List<FeedbackSessionAttributes> viewableSessions = new ArrayList<FeedbackSessionAttributes>();

--- a/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
@@ -157,11 +157,9 @@ public class FeedbackSessionsLogic {
      * @param courseId
      * @param userEmail
      * @return a list of viewable feedback sessions for any user for his course.
-     * @throws EntityDoesNotExistException
      */
     public List<FeedbackSessionAttributes> getFeedbackSessionsForUserInCourseSkipCheck(
-            String courseId, String userEmail)
-            throws EntityDoesNotExistException {
+            String courseId, String userEmail) {
         List<FeedbackSessionAttributes> sessions =
                 getFeedbackSessionsForCourse(courseId);
         List<FeedbackSessionAttributes> viewableSessions = new ArrayList<FeedbackSessionAttributes>();
@@ -2377,12 +2375,7 @@ public class FeedbackSessionsLogic {
      */
     private boolean isFeedbackSessionViewableTo(
             FeedbackSessionAttributes session,
-            String userEmail) throws EntityDoesNotExistException {
-
-        if (session == null) {
-            throw new EntityDoesNotExistException(
-                    "Trying to get a feedback session that does not exist.");
-        }
+            String userEmail) {
 
         // Check for private type first.
         if (session.feedbackSessionType == FeedbackSessionType.PRIVATE) {
@@ -2402,8 +2395,7 @@ public class FeedbackSessionsLogic {
     }
 
     public boolean isFeedbackSessionViewableToStudents(
-            FeedbackSessionAttributes session)
-            throws EntityDoesNotExistException {
+            FeedbackSessionAttributes session) {
         // Allow students to view the feedback session if there are questions for them
         List<FeedbackQuestionAttributes> questionsToAnswer =
                 fqLogic.getFeedbackQuestionsForStudents(
@@ -2418,8 +2410,7 @@ public class FeedbackSessionsLogic {
         // where the responses of the questions are visible to the students
         List<FeedbackQuestionAttributes> questionsWithVisibleResponses = new ArrayList<FeedbackQuestionAttributes>();
         List<FeedbackQuestionAttributes> questionsForInstructors =
-                                        fqLogic.getFeedbackQuestionsForCreatorInstructor(session.feedbackSessionName, 
-                                                                                         session.courseId);
+                                        fqLogic.getFeedbackQuestionsForCreatorInstructor(session);
         for (FeedbackQuestionAttributes question : questionsForInstructors) {
             if (frLogic.isResponseOfFeedbackQuestionVisibleToStudent(question)) {
                 questionsWithVisibleResponses.add(question);


### PR DESCRIPTION
Extension of #3651.
`getFeedbackSessionsForUserInCourse` checks first for course presence, which is redundant since we have already queried for the course beforehand.
The added method (`getFeedbackSessionsForUserInCourseSkipCheck`) is not new per se but rather a separation from the existing method.