### PR TITLE
Suppress redundant queries in StudentHomePageAction, part 4

### DIFF
--- a/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
@@ -149,10 +149,9 @@ public class FeedbackSessionsLogic {
         List<FeedbackSessionAttributes> viewableSessions = new ArrayList<FeedbackSessionAttributes>();
         if (!sessions.isEmpty()) {
             InstructorAttributes instructor = instructorsLogic.getInstructorForEmail(courseId, userEmail);
-            // Allow all instructors to view always
             boolean isInstructorOfCourse = instructor != null;
             for (FeedbackSessionAttributes session : sessions) {
-                if (isInstructorOfCourse || isFeedbackSessionViewableTo(session, userEmail)) {
+                if (isFeedbackSessionViewableTo(session, userEmail, isInstructorOfCourse)) {
                     viewableSessions.add(session);
                 }
             }
@@ -2364,7 +2363,8 @@ public class FeedbackSessionsLogic {
      */
     private boolean isFeedbackSessionViewableTo(
             FeedbackSessionAttributes session,
-            String userEmail) throws EntityDoesNotExistException {
+            String userEmail,
+            boolean isInstructorOfCourse) throws EntityDoesNotExistException {
 
         if (session == null) {
             throw new EntityDoesNotExistException(
@@ -2374,6 +2374,11 @@ public class FeedbackSessionsLogic {
         // If the session is a private session created by the same user, it is viewable to the user
         if (session.feedbackSessionType == FeedbackSessionType.PRIVATE) {
             return session.creatorEmail.equals(userEmail);
+        }
+        
+        // Allow all instructors to view always
+        if (isInstructorOfCourse) {
+            return true;
         }
 
         // Allow viewing if session is viewable to students

--- a/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
@@ -147,8 +147,9 @@ public class FeedbackSessionsLogic {
         List<FeedbackSessionAttributes> sessions =
                 getFeedbackSessionsForCourse(courseId);
         List<FeedbackSessionAttributes> viewableSessions = new ArrayList<FeedbackSessionAttributes>();
+        InstructorAttributes instructor = instructorsLogic.getInstructorForEmail(courseId, userEmail);
         for (FeedbackSessionAttributes session : sessions) {
-            if (isFeedbackSessionViewableTo(session, userEmail)) {
+            if (isFeedbackSessionViewableTo(session, userEmail, instructor)) {
                 viewableSessions.add(session);
             }
         }
@@ -2359,7 +2360,8 @@ public class FeedbackSessionsLogic {
      */
     private boolean isFeedbackSessionViewableTo(
             FeedbackSessionAttributes session,
-            String userEmail) throws EntityDoesNotExistException {
+            String userEmail,
+            InstructorAttributes instructorOfCourse) throws EntityDoesNotExistException {
 
         if (session == null) {
             throw new EntityDoesNotExistException(
@@ -2372,11 +2374,8 @@ public class FeedbackSessionsLogic {
         }
 
         // Allow all instructors to view always
-        InstructorAttributes instructor = instructorsLogic.
-                getInstructorForEmail(session.courseId, userEmail);
-        if (instructor != null) {
-            return instructorsLogic.isEmailOfInstructorOfCourse(
-                    instructor.email, session.courseId);
+        if (instructorOfCourse != null) {
+            return true;
         }
 
         // Allow viewing if session is viewable to students

--- a/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
@@ -149,8 +149,10 @@ public class FeedbackSessionsLogic {
         List<FeedbackSessionAttributes> viewableSessions = new ArrayList<FeedbackSessionAttributes>();
         if (!sessions.isEmpty()) {
             InstructorAttributes instructor = instructorsLogic.getInstructorForEmail(courseId, userEmail);
+            // Allow all instructors to view always
+            boolean isInstructorOfCourse = instructor != null;
             for (FeedbackSessionAttributes session : sessions) {
-                if (isFeedbackSessionViewableTo(session, userEmail, instructor)) {
+                if (isInstructorOfCourse || isFeedbackSessionViewableTo(session, userEmail)) {
                     viewableSessions.add(session);
                 }
             }
@@ -2362,22 +2364,16 @@ public class FeedbackSessionsLogic {
      */
     private boolean isFeedbackSessionViewableTo(
             FeedbackSessionAttributes session,
-            String userEmail,
-            InstructorAttributes instructorOfCourse) throws EntityDoesNotExistException {
+            String userEmail) throws EntityDoesNotExistException {
 
         if (session == null) {
             throw new EntityDoesNotExistException(
                     "Trying to get a feedback session that does not exist.");
         }
 
-        // Check for private type first.
+        // If the session is a private session created by the same user, it is viewable to the user
         if (session.feedbackSessionType == FeedbackSessionType.PRIVATE) {
             return session.creatorEmail.equals(userEmail);
-        }
-
-        // Allow all instructors to view always
-        if (instructorOfCourse != null) {
-            return true;
         }
 
         // Allow viewing if session is viewable to students

--- a/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
@@ -2358,8 +2358,7 @@ public class FeedbackSessionsLogic {
     }
 
     /**
-     * This method returns a list of feedback sessions which are relevant for a
-     * user.
+     * Checks whether the feedback session is viewable to the specified user.
      */
     private boolean isFeedbackSessionViewableTo(
             FeedbackSessionAttributes session,

--- a/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
@@ -147,10 +147,12 @@ public class FeedbackSessionsLogic {
         List<FeedbackSessionAttributes> sessions =
                 getFeedbackSessionsForCourse(courseId);
         List<FeedbackSessionAttributes> viewableSessions = new ArrayList<FeedbackSessionAttributes>();
-        InstructorAttributes instructor = instructorsLogic.getInstructorForEmail(courseId, userEmail);
-        for (FeedbackSessionAttributes session : sessions) {
-            if (isFeedbackSessionViewableTo(session, userEmail, instructor)) {
-                viewableSessions.add(session);
+        if (!sessions.isEmpty()) {
+            InstructorAttributes instructor = instructorsLogic.getInstructorForEmail(courseId, userEmail);
+            for (FeedbackSessionAttributes session : sessions) {
+                if (isFeedbackSessionViewableTo(session, userEmail, instructor)) {
+                    viewableSessions.add(session);
+                }
             }
         }
 


### PR DESCRIPTION
Extension of #3651.
The number of query made for the same InstructorAttributes is the amount of feedback session, which is redundant.