### PR TITLE
Suppress redundant queries in StudentHomePageAction, part 5

### DIFF
--- a/src/main/java/teammates/logic/api/Logic.java
+++ b/src/main/java/teammates/logic/api/Logic.java
@@ -1587,15 +1587,13 @@ public class Logic {
      * Preconditions: <br>
      * * All parameters are non-null.
      */
-    public boolean hasStudentSubmittedFeedback(String courseId, String feedbackSessionName, String studentEmail)
+    public boolean hasStudentSubmittedFeedback(FeedbackSessionAttributes fsa, String studentEmail)
             throws InvalidParametersException, EntityDoesNotExistException {
         
-        Assumption.assertNotNull(ERROR_NULL_PARAMETER, courseId);
-        Assumption.assertNotNull(ERROR_NULL_PARAMETER, feedbackSessionName);
+        Assumption.assertNotNull(ERROR_NULL_PARAMETER, fsa);
         Assumption.assertNotNull(ERROR_NULL_PARAMETER, studentEmail);
     
-        return feedbackSessionsLogic.isFeedbackSessionCompletedByStudent(
-                feedbackSessionName, courseId, studentEmail);
+        return feedbackSessionsLogic.isFeedbackSessionCompletedByStudent(fsa, studentEmail);
     }
     
     /**

--- a/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
@@ -987,12 +987,9 @@ public class FeedbackSessionsLogic {
         return !allQuestions.isEmpty();
     }
 
-    public boolean isFeedbackSessionCompletedByStudent(
-            String feedbackSessionName,
-            String courseId, String userEmail)
-            throws EntityDoesNotExistException {
-
-        FeedbackSessionAttributes  fsa = this.getFeedbackSession(feedbackSessionName, courseId);
+    public boolean isFeedbackSessionCompletedByStudent(FeedbackSessionAttributes fsa,
+                                                       String userEmail)
+                   throws EntityDoesNotExistException {
         if (fsa == null) {
             throw new EntityDoesNotExistException(
                     "Trying to check a feedback session that does not exist.");
@@ -1002,12 +999,21 @@ public class FeedbackSessionsLogic {
             return true;
         }
         
-        
+        String feedbackSessionName = fsa.feedbackSessionName;
+        String courseId = fsa.courseId;
         List<FeedbackQuestionAttributes> allQuestions =
-                fqLogic.getFeedbackQuestionsForStudents(feedbackSessionName,
-                        courseId);
+                fqLogic.getFeedbackQuestionsForStudents(feedbackSessionName, courseId);
         // if there is no question for students, session is complete
         return allQuestions.isEmpty();
+    }
+
+    public boolean isFeedbackSessionCompletedByStudent(
+            String feedbackSessionName,
+            String courseId, String userEmail)
+            throws EntityDoesNotExistException {
+
+        FeedbackSessionAttributes  fsa = this.getFeedbackSession(feedbackSessionName, courseId);
+        return isFeedbackSessionCompletedByStudent(fsa, userEmail);
     }
 
     public boolean isFeedbackSessionCompletedByInstructor(
@@ -1380,9 +1386,7 @@ public class FeedbackSessionsLogic {
         // Filter out students who have submitted the feedback session
         List<StudentAttributes> studentsToRemindList = new ArrayList<StudentAttributes>();
         for (StudentAttributes student : studentList) {
-            if (!isFeedbackSessionCompletedByStudent(
-                    session.feedbackSessionName, session.courseId,
-                    student.email)) {
+            if (!isFeedbackSessionCompletedByStudent(session, student.email)) {
                 studentsToRemindList.add(student);
             }
         }

--- a/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
@@ -990,11 +990,7 @@ public class FeedbackSessionsLogic {
     public boolean isFeedbackSessionCompletedByStudent(FeedbackSessionAttributes fsa,
                                                        String userEmail)
                    throws EntityDoesNotExistException {
-        if (fsa == null) {
-            throw new EntityDoesNotExistException(
-                    "Trying to check a feedback session that does not exist.");
-        }
-        
+        Assumption.assertNotNull(fsa);
         if (fsa.respondingStudentList.contains(userEmail)) {
             return true;
         }
@@ -1011,8 +1007,11 @@ public class FeedbackSessionsLogic {
             String feedbackSessionName,
             String courseId, String userEmail)
             throws EntityDoesNotExistException {
-
         FeedbackSessionAttributes  fsa = this.getFeedbackSession(feedbackSessionName, courseId);
+        if (fsa == null) {
+            throw new EntityDoesNotExistException(
+                    "Trying to check a feedback session that does not exist.");
+        }
         return isFeedbackSessionCompletedByStudent(fsa, userEmail);
     }
 

--- a/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
+++ b/src/main/java/teammates/logic/core/FeedbackSessionsLogic.java
@@ -1019,18 +1019,6 @@ public class FeedbackSessionsLogic {
         return allQuestions.isEmpty();
     }
 
-    public boolean isFeedbackSessionCompletedByStudent(
-            String feedbackSessionName,
-            String courseId, String userEmail)
-            throws EntityDoesNotExistException {
-        FeedbackSessionAttributes  fsa = this.getFeedbackSession(feedbackSessionName, courseId);
-        if (fsa == null) {
-            throw new EntityDoesNotExistException(
-                    "Trying to check a feedback session that does not exist.");
-        }
-        return isFeedbackSessionCompletedByStudent(fsa, userEmail);
-    }
-
     public boolean isFeedbackSessionCompletedByInstructor(
             String feedbackSessionName,
             String courseId, String userEmail)

--- a/src/main/java/teammates/ui/controller/StudentHomePageAction.java
+++ b/src/main/java/teammates/ui/controller/StudentHomePageAction.java
@@ -77,8 +77,7 @@ public class StudentHomePageAction extends Action {
         String studentEmail = student.email;
         
         try {
-            return logic.hasStudentSubmittedFeedback(
-                    fs.courseId, fs.feedbackSessionName, studentEmail);
+            return logic.hasStudentSubmittedFeedback(fs, studentEmail);
         } catch (InvalidParametersException | EntityDoesNotExistException e) {
             Assumption.fail("Parameters are expected to be valid at this point :"
                              + TeammatesException.toStringWithStackTrace(e));

--- a/src/test/java/teammates/test/cases/logic/FeedbackSessionsLogicTest.java
+++ b/src/test/java/teammates/test/cases/logic/FeedbackSessionsLogicTest.java
@@ -1899,21 +1899,11 @@ public class FeedbackSessionsLogicTest extends BaseComponentUsingTaskQueueTestCa
         FeedbackSessionAttributes fs = dataBundle.feedbackSessions.get("session1InCourse1");
         StudentAttributes student = dataBundle.students.get("student2InCourse1");
         
-        ______TS("failure: non-existent feedback session for student");
-        
-        try {
-            fsLogic.isFeedbackSessionCompletedByStudent(fs.courseId, "nonExistentFSName","random.student@email");
-            signalFailureToDetectException();
-        } catch (EntityDoesNotExistException edne) {
-            assertEquals("Trying to check a feedback session that does not exist.",
-                         edne.getMessage());
-        }
-        
         ______TS("success: empty session");
         
         fs = dataBundle.feedbackSessions.get("empty.session");
         
-        assertTrue(fsLogic.isFeedbackSessionCompletedByStudent(fs.feedbackSessionName, fs.courseId, student.email));
+        assertTrue(fsLogic.isFeedbackSessionCompletedByStudent(fs, student.email));
     }
     
     public void testIsFeedbackSessionFullyCompletedByStudent() throws Exception {
@@ -1965,11 +1955,12 @@ public class FeedbackSessionsLogicTest extends BaseComponentUsingTaskQueueTestCa
                 fsLogic.sendReminderForFeedbackSession(fs.courseId, fs.feedbackSessionName);
         assertEquals(9, emailsSent.size());
 
+        fs = fsLogic.getFeedbackSession(fs.feedbackSessionName, fs.courseId);
+
         List<StudentAttributes> studentList = logic.getStudentsForCourse(fs.courseId);
         for (StudentAttributes s : studentList) {
             MimeMessage emailToStudent = TestHelper.getEmailToStudent(s, emailsSent);
-            
-            if(fsLogic.isFeedbackSessionCompletedByStudent(fs.feedbackSessionName, fs.courseId, s.email)) {
+            if (fsLogic.isFeedbackSessionCompletedByStudent(fs, s.email)) {
                 String errorMessage = "Email sent to " + s.email + " when he already completed the session.";
                 assertNull(errorMessage, emailToStudent);
             } else {


### PR DESCRIPTION
Extension of #3651.
`isFeedbackSessionCompletedByStudent` queries for FeedbackSessionAttributes from the supplied session name and course ID, but these supplied parameters came from previously queried FeedbackSessionAttributes, making querying the Attributes once again redundant.
Again, the added method is not new per se but rather a separation from the existing method.