### PR TITLE
StudentFeedbackResultsPageActionTest occasionally fails at line 199 #3700

### DIFF
--- a/src/test/java/teammates/test/cases/ui/StudentFeedbackResultsPageActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/StudentFeedbackResultsPageActionTest.java
@@ -16,6 +16,7 @@ import teammates.common.datatransfer.FeedbackSessionAttributes;
 import teammates.common.datatransfer.StudentAttributes;
 import teammates.common.exception.UnauthorizedAccessException;
 import teammates.common.util.Const;
+import teammates.common.util.TimeHelper;
 import teammates.logic.core.FeedbackSessionsLogic;
 import teammates.test.util.TestHelper;
 import teammates.ui.controller.ShowPageResult;
@@ -188,7 +189,7 @@ public class StudentFeedbackResultsPageActionTest extends BaseActionTest {
 
         // databundle time changed here because publishing sets resultsVisibleTime to now.
         dataBundle.feedbackSessions.get("session1InCourse1").resultsVisibleFromTime =
-                                        pageData.bundle.feedbackSession.resultsVisibleFromTime;
+                TimeHelper.now( dataBundle.feedbackSessions.get("session1InCourse1").timeZone).getTime();
 
         List<FeedbackSessionAttributes> expectedInfoList = new ArrayList<FeedbackSessionAttributes>();
         List<FeedbackSessionAttributes> actualInfoList = new ArrayList<FeedbackSessionAttributes>();

--- a/src/test/java/teammates/test/cases/ui/StudentFeedbackResultsPageActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/StudentFeedbackResultsPageActionTest.java
@@ -191,6 +191,22 @@ public class StudentFeedbackResultsPageActionTest extends BaseActionTest {
         dataBundle.feedbackSessions.get("session1InCourse1").resultsVisibleFromTime =
                 TimeHelper.now( dataBundle.feedbackSessions.get("session1InCourse1").timeZone).getTime();
 
+        /*
+         * The above test can fail if the time elapsed between pageData... and dataBundle...
+         * changes the time recorded by dataBundle up to the precision of seconds.
+         * To solve that, verify that the time elapsed is less than one second (or else the test
+         * fails after all) and if it does, change the value in the dataBundle to match.
+         */
+        long pageDataResultsVisibleFromTime = pageData.bundle.feedbackSession.resultsVisibleFromTime.getTime();
+        long dataBundleResultsVisibleFromTime = dataBundle.feedbackSessions.get("session1InCourse1")
+                                                                           .resultsVisibleFromTime.getTime();
+        long TOLERANCE_TIME_IN_MILLISECONDS = 1000;
+        if (dataBundleResultsVisibleFromTime - pageDataResultsVisibleFromTime < TOLERANCE_TIME_IN_MILLISECONDS) {
+            // change to the value that will never make the test fail
+            dataBundle.feedbackSessions.get("session1InCourse1").resultsVisibleFromTime = 
+                                            pageData.bundle.feedbackSession.resultsVisibleFromTime;
+        }
+
         List<FeedbackSessionAttributes> expectedInfoList = new ArrayList<FeedbackSessionAttributes>();
         List<FeedbackSessionAttributes> actualInfoList = new ArrayList<FeedbackSessionAttributes>();
         expectedInfoList.add(dataBundle.feedbackSessions.get("session1InCourse1"));

--- a/src/test/java/teammates/test/cases/ui/StudentFeedbackResultsPageActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/StudentFeedbackResultsPageActionTest.java
@@ -16,7 +16,6 @@ import teammates.common.datatransfer.FeedbackSessionAttributes;
 import teammates.common.datatransfer.StudentAttributes;
 import teammates.common.exception.UnauthorizedAccessException;
 import teammates.common.util.Const;
-import teammates.common.util.TimeHelper;
 import teammates.logic.core.FeedbackSessionsLogic;
 import teammates.test.util.TestHelper;
 import teammates.ui.controller.ShowPageResult;
@@ -189,7 +188,7 @@ public class StudentFeedbackResultsPageActionTest extends BaseActionTest {
 
         // databundle time changed here because publishing sets resultsVisibleTime to now.
         dataBundle.feedbackSessions.get("session1InCourse1").resultsVisibleFromTime =
-                TimeHelper.now( dataBundle.feedbackSessions.get("session1InCourse1").timeZone).getTime();
+                                        pageData.bundle.feedbackSession.resultsVisibleFromTime;
 
         List<FeedbackSessionAttributes> expectedInfoList = new ArrayList<FeedbackSessionAttributes>();
         List<FeedbackSessionAttributes> actualInfoList = new ArrayList<FeedbackSessionAttributes>();


### PR DESCRIPTION
![oldnewbugexplained](https://cloud.githubusercontent.com/assets/7261051/8125719/d9f56978-111a-11e5-98a2-5b4b8c90002c.png)
The test failure is caused by the incorrectly used `TimeHelper.now`. The intention is correct (as can be seen in the comment), but `TimeHelper.now` is not the correct tool to use. Here is why:
Between lines 188 and 191, time will elapse, perhaps just a few milliseconds or even hundreds of microseconds. However, if the time elapsed is enough to change the recorded time (precision up to seconds) in the `expectedInfoList`, the test will fail.
For example:
Line 188 `pageData`, `resultVisibleFromTime` 00:00:00.500
Line 191 `dataBundle`, `resultVisibleFromTime` 00:00:00.502
This is perfectly fine. But if this happens:
Line 188 `pageData`, `resultVisibleFromTime` 00:00:00.999
Line 191 `dataBundle`, `resultVisibleFromTime` 00:00:01.001
The test will fail.
To achieve the same without having to experience the above, we can just take the `resultVisibleFromTime` value directly from `pageData` itself.