### PR TITLE
Standardize FRCs in InstructorFeedbackResults, InstructorStudentRecords, InstructorComments, and InstructorSearch #3839

### DIFF
--- a/src/main/java/teammates/common/datatransfer/FeedbackResponseCommentAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/FeedbackResponseCommentAttributes.java
@@ -8,7 +8,6 @@ import java.util.List;
 
 import teammates.common.util.Const;
 import teammates.common.util.FieldValidator;
-import teammates.common.util.TimeHelper;
 import teammates.common.util.Utils;
 import teammates.common.util.FieldValidator.FieldType;
 import teammates.common.util.Sanitizer;
@@ -215,25 +214,14 @@ public class FeedbackResponseCommentAttributes extends EntityAttributes {
         });
     }
     
-    private String getEditedAtText(Boolean isGiverAnonymous, String displayGiverAs, String displayTimeAs) {
+    public String getEditedAtText(Boolean isGiverAnonymous) {
         if (this.lastEditedAt != null && (!this.lastEditedAt.equals(this.createdAt))) {
             return "(last edited "
-                  + (isGiverAnonymous ? "" : "by " + displayGiverAs + " ")
-                  + "at " + displayTimeAs + ")";
+                  + (isGiverAnonymous ? "" : "by " + this.lastEditorEmail + " ")
+                  + "at " + this.lastEditedAt.toString() + ")";
         } else {
             return "";
         }
     }
 
-    public String getEditedAtTextForInstructor(Boolean isGiverAnonymous) {
-        return getEditedAtText(isGiverAnonymous, this.lastEditorEmail, TimeHelper.formatTime(this.lastEditedAt));
-    }
-    
-    public String getEditedAtTextForSessionsView(Boolean isGiverAnonymous) {
-        return getEditedAtText(isGiverAnonymous, this.lastEditorEmail, this.lastEditedAt.toString());        
-    }
-
-    public String getEditedAtTextForStudent(Boolean isGiverAnonymous, String displayGiverAs) {
-        return getEditedAtText(isGiverAnonymous, displayGiverAs, TimeHelper.formatDate(this.lastEditedAt));
-    }
 }

--- a/src/main/java/teammates/ui/controller/InstructorFeedbackResponseCommentAddAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbackResponseCommentAddAction.java
@@ -8,9 +8,11 @@ import java.util.TimeZone;
 
 import teammates.common.datatransfer.CommentSendingState;
 import teammates.common.datatransfer.FeedbackParticipantType;
+import teammates.common.datatransfer.FeedbackQuestionAttributes;
 import teammates.common.datatransfer.FeedbackResponseAttributes;
 import teammates.common.datatransfer.FeedbackResponseCommentAttributes;
 import teammates.common.datatransfer.FeedbackSessionAttributes;
+import teammates.common.datatransfer.FeedbackSessionResultsBundle;
 import teammates.common.datatransfer.InstructorAttributes;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.InvalidParametersException;
@@ -40,6 +42,7 @@ public class InstructorFeedbackResponseCommentAddAction extends Action {
         
         InstructorAttributes instructor = logic.getInstructorForGoogleId(courseId, account.googleId);
         FeedbackSessionAttributes session = logic.getFeedbackSession(feedbackSessionName, courseId);
+        FeedbackQuestionAttributes question = logic.getFeedbackQuestion(feedbackQuestionId);
         FeedbackResponseAttributes response = logic.getFeedbackResponse(feedbackResponseId);
         Assumption.assertNotNull(response);
         boolean isCreatorOnly = true;
@@ -52,6 +55,18 @@ public class InstructorFeedbackResponseCommentAddAction extends Action {
         InstructorFeedbackResponseCommentAjaxPageData data = 
                 new InstructorFeedbackResponseCommentAjaxPageData(account);
         
+        String giverEmail = response.giverEmail;
+        String recipientEmail = response.recipientEmail;
+        FeedbackSessionResultsBundle bundle = logic.getFeedbackSessionResultsForInstructor(feedbackSessionName, courseId, instructor.email);
+
+        String giverName = bundle.getGiverNameForResponse(question, response);
+        String giverTeamName = bundle.getTeamNameForEmail(giverEmail);
+        data.giverName = bundle.appendTeamNameToName(giverName, giverTeamName);
+
+        String recipientName = bundle.getRecipientNameForResponse(question, response);
+        String recipientTeamName = bundle.getTeamNameForEmail(recipientEmail);
+        data.recipientName = bundle.appendTeamNameToName(recipientName, recipientTeamName);
+
         //Set up comment text
         String commentText = getRequestParamValue(Const.ParamsNames.FEEDBACK_RESPONSE_COMMENT_TEXT);
         Assumption.assertNotNull("null comment text", commentText);

--- a/src/main/java/teammates/ui/controller/InstructorFeedbackResponseCommentAddAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbackResponseCommentAddAction.java
@@ -1,10 +1,8 @@
 package teammates.ui.controller;
 
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import java.util.TimeZone;
 
 import teammates.common.datatransfer.CommentSendingState;
 import teammates.common.datatransfer.FeedbackParticipantType;
@@ -123,10 +121,7 @@ public class InstructorFeedbackResponseCommentAddAction extends Action {
         }
         
         data.comment = createdComment;
-        SimpleDateFormat sdf = new SimpleDateFormat("EEE MMM dd HH:mm:ss zzz YYYY");
-        sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
         data.commentId = commentId;
-        data.commentTime = sdf.format(createdComment.createdAt);
         data.showCommentToString = joinParticipantTypes(createdComment.showCommentTo, ",");
         data.showGiverNameToString = joinParticipantTypes(createdComment.showGiverNameTo, ",");
         

--- a/src/main/java/teammates/ui/controller/InstructorFeedbackResponseCommentAjaxPageData.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbackResponseCommentAjaxPageData.java
@@ -11,6 +11,8 @@ public class InstructorFeedbackResponseCommentAjaxPageData extends PageData {
     public FeedbackResponseCommentAttributes comment;
     public String commentId;
     public String commentTime;
+    public String giverName;
+    public String recipientName;
     public String showCommentToString;
     public String showGiverNameToString;
     public boolean isError;

--- a/src/main/webapp/jsp/instructorFeedbackResponseCommentsAdd.jsp
+++ b/src/main/webapp/jsp/instructorFeedbackResponseCommentsAdd.jsp
@@ -9,7 +9,7 @@
     id="responseCommentRow-<%= data.commentId %>">
     <div id="commentBar-<%= data.commentId %>">
         <span class="text-muted">
-            From: you [<%= data.comment.createdAt %>]
+            From: <%= data.comment.giverEmail %> [<%= data.comment.createdAt %>]
         </span>
         <form class="responseCommentDeleteForm pull-right">
             <a href="/page/instructorFeedbackResponseCommentDelete"

--- a/src/main/webapp/jsp/instructorFeedbackResponseCommentsAdd.jsp
+++ b/src/main/webapp/jsp/instructorFeedbackResponseCommentsAdd.jsp
@@ -9,7 +9,7 @@
     id="responseCommentRow-<%= data.commentId %>">
     <div id="commentBar-<%= data.commentId %>">
         <span class="text-muted">
-            From: <b>you</b> [<%= data.commentTime %>]
+            From: you [<%= data.comment.createdAt %>]
         </span>
         <form class="responseCommentDeleteForm pull-right">
             <a href="/page/instructorFeedbackResponseCommentDelete"

--- a/src/main/webapp/jsp/instructorFeedbackResponseCommentsAdd.jsp
+++ b/src/main/webapp/jsp/instructorFeedbackResponseCommentsAdd.jsp
@@ -42,6 +42,10 @@
     <form style="display: none;" id="responseCommentEditForm-<%= data.commentId %>" class="responseCommentEditForm">
         <div class="form-group form-inline">
             <div class="form-group text-muted">
+                <p>
+                    Giver: <%= data.giverName %><br>
+                    Recipient: <%= data.recipientName %>
+                </p>
                 You may change comment's visibility using the visibility options on the right hand side.
             </div>
             <a id="frComment-visibility-options-trigger-<%= data.commentId %>"

--- a/src/main/webapp/jsp/instructorFeedbackResponseCommentsLoad.jsp
+++ b/src/main/webapp/jsp/instructorFeedbackResponseCommentsLoad.jsp
@@ -150,14 +150,14 @@
                                     }
                                 %>
                                 <%
-                                    if (frc.giverEmail.equals(data.instructorEmail)
+                                    Boolean isAllowedToEditOrDeleteComment = (frc.giverEmail.equals(data.instructorEmail)
                                                             || (data.currentInstructor != null &&
                                                                     data.currentInstructor.isAllowedForPrivilege(responseEntry.giverSection,
                                                                             responseEntry.feedbackSessionName,
                                                                             Const.ParamsNames.INSTRUCTOR_PERMISSION_MODIFY_SESSION_COMMENT_IN_SECTIONS)
                                                                     && data.currentInstructor.isAllowedForPrivilege(responseEntry.recipientSection,
                                                                     responseEntry.feedbackSessionName,
-                                                                    Const.ParamsNames.INSTRUCTOR_PERMISSION_MODIFY_SESSION_COMMENT_IN_SECTIONS))) {//FeedbackResponseComment edit/delete control starts
+                                                                    Const.ParamsNames.INSTRUCTOR_PERMISSION_MODIFY_SESSION_COMMENT_IN_SECTIONS)));
                                 %>
                                 <form
                                     class="responseCommentDeleteForm pull-right">
@@ -169,8 +169,11 @@
                                         data-toggle="tooltip"
                                         data-placement="top"
                                         title="<%=Const.Tooltips.COMMENT_DELETE%>"
-                                        style="display: none;"> <span
-                                        class="glyphicon glyphicon-trash glyphicon-primary"></span>
+                                        style="display: none;"
+                                        <% if (!isAllowedToEditOrDeleteComment) { %>
+                                            disabled="disabled"
+                                        <% } %>>
+                                        <span class="glyphicon glyphicon-trash glyphicon-primary"></span>
                                     </a> <input type="hidden"
                                         name="<%=Const.ParamsNames.FEEDBACK_RESPONSE_ID%>"
                                         value="<%=frc.feedbackResponseId%>">
@@ -194,12 +197,12 @@
                                     data-toggle="tooltip"
                                     data-placement="top"
                                     title="<%=Const.Tooltips.COMMENT_EDIT%>"
-                                    style="display: none;"> <span
-                                    class="glyphicon glyphicon-pencil glyphicon-primary"></span>
+                                    style="display: none;"
+                                    <% if (!isAllowedToEditOrDeleteComment) { %>
+                                        disabled="disabled"
+                                    <% } %>>
+                                    <span class="glyphicon glyphicon-pencil glyphicon-primary"></span>
                                 </a>
-                                <%
-                                    }//FeedbackResponseComment edit/delete control ends
-                                %>
                             </div> <!-- frComment Content -->
                             <div
                                 id="plainCommentText-<%=fsIndx%>-<%=qnIndx%>-<%=responseIndex%>-<%=responseCommentIndex%>"><%=frc.commentText.getValue()%></div>

--- a/src/main/webapp/jsp/instructorFeedbackResponseCommentsLoad.jsp
+++ b/src/main/webapp/jsp/instructorFeedbackResponseCommentsLoad.jsp
@@ -238,8 +238,7 @@
                                         <div class="panel-heading">Visibility
                                             Options</div>
                                         <table class="table text-center"
-                                            style="color: #000;"
-                                            style="background: #fff;">
+                                            style="color: #000;">
                                             <tbody>
                                                 <tr>
                                                     <th

--- a/src/main/webapp/jsp/instructorFeedbackResponseCommentsLoad.jsp
+++ b/src/main/webapp/jsp/instructorFeedbackResponseCommentsLoad.jsp
@@ -119,8 +119,7 @@
                                             */
                                             Boolean isPublicResponseComment = data.isResponseCommentPublicToRecipient(frc);
                         %>
-                        <li id="<%=frc.getId()%>"
-                            class="list-group-item list-group-item-warning <%=frCommentGiver.equals("you") ? "giver_display-by-you" : "giver_display-by-others"%> <%=isPublicResponseComment && bundle.feedbackSession.isPublished() ? "status_display-public" : "status_display-private"%>"
+                        <li class="list-group-item list-group-item-warning <%=frCommentGiver.equals("you") ? "giver_display-by-you" : "giver_display-by-others"%> <%=isPublicResponseComment && bundle.feedbackSession.isPublished() ? "status_display-public" : "status_display-private"%>"
                             id="responseCommentRow-<%=fsIndx%>-<%=qnIndx%>-<%=responseIndex%>-<%=responseCommentIndex%>">
                             <div
                                 id="commentBar-<%=fsIndx%>-<%=qnIndx%>-<%=responseIndex%>-<%=responseCommentIndex%>">

--- a/src/main/webapp/jsp/instructorFeedbackResponseCommentsLoad.jsp
+++ b/src/main/webapp/jsp/instructorFeedbackResponseCommentsLoad.jsp
@@ -111,9 +111,12 @@
                                             String frCommentGiver = frc.giverEmail;
                                             if (frc.giverEmail.equals(data.instructorEmail)) {
                                                 frCommentGiver = "you";
-                                            } else if (data.roster.getInstructorForEmail(frc.giverEmail) != null) {
+                                            }/*
+                                            keep for reference on how to implement "you" and display name
+                                            else if (data.roster.getInstructorForEmail(frc.giverEmail) != null) {
                                                 frCommentGiver = data.roster.getInstructorForEmail(frc.giverEmail).name;
                                             }
+                                            */
                                             Boolean isPublicResponseComment = data.isResponseCommentPublicToRecipient(frc);
                         %>
                         <li id="<%=frc.getId()%>"
@@ -122,7 +125,7 @@
                             <div
                                 id="commentBar-<%=fsIndx%>-<%=qnIndx%>-<%=responseIndex%>-<%=responseCommentIndex%>">
                                 <span class="text-muted">From: <%= frc.giverEmail %>
-                                    [<%=frc.createdAt%>] <%=frc.getEditedAtText(frCommentGiver.equals("Anonymous"))%>
+                                    [<%=frc.createdAt%>] <%=frc.getEditedAtText(frc.giverEmail.equals("Anonymous"))%>
                                 </span>
                                 <%
                                     if (isPublicResponseComment && bundle.feedbackSession.isPublished()) {

--- a/src/main/webapp/jsp/instructorFeedbackResponseCommentsLoad.jsp
+++ b/src/main/webapp/jsp/instructorFeedbackResponseCommentsLoad.jsp
@@ -121,7 +121,7 @@
                             id="responseCommentRow-<%=fsIndx%>-<%=qnIndx%>-<%=responseIndex%>-<%=responseCommentIndex%>">
                             <div
                                 id="commentBar-<%=fsIndx%>-<%=qnIndx%>-<%=responseIndex%>-<%=responseCommentIndex%>">
-                                <span class="text-muted">From: <b><%=frCommentGiver%></b>
+                                <span class="text-muted">From: <%= frc.giverEmail %>
                                     [<%=frc.createdAt%>] <%=frc.getEditedAtText(frCommentGiver.equals("Anonymous"))%>
                                 </span>
                                 <%

--- a/src/main/webapp/jsp/instructorFeedbackResponseCommentsLoad.jsp
+++ b/src/main/webapp/jsp/instructorFeedbackResponseCommentsLoad.jsp
@@ -122,7 +122,7 @@
                             <div
                                 id="commentBar-<%=fsIndx%>-<%=qnIndx%>-<%=responseIndex%>-<%=responseCommentIndex%>">
                                 <span class="text-muted">From: <b><%=frCommentGiver%></b>
-                                    [<%=frc.createdAt%>] <%=frc.getEditedAtTextForSessionsView(frCommentGiver.equals("Anonymous"))%>
+                                    [<%=frc.createdAt%>] <%=frc.getEditedAtText(frCommentGiver.equals("Anonymous"))%>
                                 </span>
                                 <%
                                     if (isPublicResponseComment && bundle.feedbackSession.isPublished()) {

--- a/src/main/webapp/jsp/instructorFeedbackResultsByGiverRecipientQuestion.jsp
+++ b/src/main/webapp/jsp/instructorFeedbackResultsByGiverRecipientQuestion.jsp
@@ -508,7 +508,7 @@
                                             %>
                                         <li class="list-group-item list-group-item-warning" id="responseCommentRow-<%=recipientIndex%>-<%=giverIndex%>-<%=qnIndx%>-<%=responseCommentIndex%>">
                                             <div id="commentBar-<%=recipientIndex%>-<%=giverIndex%>-<%=qnIndx%>-<%=responseCommentIndex%>">
-                                            <span class="text-muted">From: <%=comment.giverEmail%> [<%=comment.createdAt%>] <%=comment.getEditedAtTextForSessionsView(comment.giverEmail.equals("Anonymous"))%>
+                                            <span class="text-muted">From: <%=comment.giverEmail%> [<%=comment.createdAt%>] <%=comment.getEditedAtText(comment.giverEmail.equals("Anonymous"))%>
                                             </span>
                                             <!-- frComment delete Form -->
                                             <form class="responseCommentDeleteForm pull-right">

--- a/src/main/webapp/jsp/instructorFeedbackResultsByGiverRecipientQuestion.jsp
+++ b/src/main/webapp/jsp/instructorFeedbackResultsByGiverRecipientQuestion.jsp
@@ -567,8 +567,7 @@
                                                     <div id="visibility-options-<%=recipientIndex%>-<%=giverIndex%>-<%=qnIndx%>-<%=responseCommentIndex%>" class="panel panel-default"
                                                         style="display: none;">
                                                         <div class="panel-heading">Visibility Options</div>
-                                                        <table class="table text-center" style="color:#000;"
-                                                            style="background: #fff;">
+                                                        <table class="table text-center" style="color:#000;">
                                                             <tbody>
                                                                 <tr>
                                                                     <th class="text-center">User/Group</th>

--- a/src/main/webapp/jsp/instructorFeedbackResultsByRecipientGiverQuestion.jsp
+++ b/src/main/webapp/jsp/instructorFeedbackResultsByRecipientGiverQuestion.jsp
@@ -547,8 +547,7 @@
                                                     <div id="visibility-options-<%=recipientIndex%>-<%=giverIndex%>-<%=qnIndx%>-<%=responseCommentIndex%>" class="panel panel-default"
                                                         style="display: none;">
                                                         <div class="panel-heading">Visibility Options</div>
-                                                        <table class="table text-center" style="color:#000;"
-                                                            style="background: #fff;">
+                                                        <table class="table text-center" style="color:#000;">
                                                             <tbody>
                                                                 <tr>
                                                                     <th class="text-center">User/Group</th>

--- a/src/main/webapp/jsp/instructorFeedbackResultsByRecipientGiverQuestion.jsp
+++ b/src/main/webapp/jsp/instructorFeedbackResultsByRecipientGiverQuestion.jsp
@@ -489,7 +489,7 @@
                                             %>
                                         <li class="list-group-item list-group-item-warning" id="responseCommentRow-<%=recipientIndex%>-<%=giverIndex%>-<%=qnIndx%>-<%=responseCommentIndex%>">
                                             <div id="commentBar-<%=recipientIndex%>-<%=giverIndex%>-<%=qnIndx%>-<%=responseCommentIndex%>">
-                                            <span class="text-muted">From: <%=comment.giverEmail%> [<%=comment.createdAt%>] <%=comment.getEditedAtTextForSessionsView(comment.giverEmail.equals("Anonymous"))%>
+                                            <span class="text-muted">From: <%=comment.giverEmail%> [<%=comment.createdAt%>] <%=comment.getEditedAtText(comment.giverEmail.equals("Anonymous"))%>
                                             </span>
                                             <!-- frComment delete Form -->
                                             <form class="responseCommentDeleteForm pull-right">

--- a/src/main/webapp/jsp/instructorSearch.jsp
+++ b/src/main/webapp/jsp/instructorSearch.jsp
@@ -278,13 +278,16 @@
                                                         responseCommentIndex++;
                                                         String frCommentGiver = data.feedbackResponseCommentSearchResultBundle
                                                                                          .commentGiverTable.get(frc.getId().toString());
+                                                        if (!frCommentGiver.equals("Anonymous")) {
+                                                            frCommentGiver = frc.giverEmail;
+                                                        }
                                                 %>
                                                 <li class="list-group-item list-group-item-warning"
                                                     id="responseCommentRow-<%=fsIndx%>-<%=qnIndx%>-<%=responseIndex%>-<%=responseCommentIndex%>">
                                                     <div id="commentBar-<%=fsIndx%>-<%=qnIndx%>-<%=responseIndex%>-<%=responseCommentIndex%>">
                                                         <span class="text-muted">
                                                             From:
-                                                            <%= frc.giverEmail %>
+                                                            <%= frCommentGiver %>
                                                             [<%= frc.createdAt %>] <%=frc.getEditedAtText(frc.giverEmail.equals("Anonymous"))%>
                                                         </span>
                                                         <a type="button" href="<%=data.getInstructorCommentsLink() + "&" + Const.ParamsNames.COURSE_ID 

--- a/src/main/webapp/jsp/instructorSearch.jsp
+++ b/src/main/webapp/jsp/instructorSearch.jsp
@@ -285,7 +285,7 @@
                                                         <span class="text-muted">
                                                             From:
                                                             <b><%=frCommentGiver%></b>
-                                                            [<%=TimeHelper.formatTime(frc.createdAt)%>] <%=frc.getEditedAtTextForInstructor(frc.giverEmail.equals("Anonymous"))%>
+                                                            [<%=TimeHelper.formatTime(frc.createdAt)%>] <%=frc.getEditedAtText(frc.giverEmail.equals("Anonymous"))%>
                                                         </span>
                                                         <a type="button" href="<%=data.getInstructorCommentsLink() + "&" + Const.ParamsNames.COURSE_ID 
                                                         + "=" + frc.courseId + "#" + frc.getId()%>" target="_blank" class="btn btn-default btn-xs icon-button pull-right"

--- a/src/main/webapp/jsp/instructorSearch.jsp
+++ b/src/main/webapp/jsp/instructorSearch.jsp
@@ -285,7 +285,7 @@
                                                         <span class="text-muted">
                                                             From:
                                                             <b><%=frCommentGiver%></b>
-                                                            on <%=TimeHelper.formatTime(frc.createdAt)%>
+                                                            on <%=TimeHelper.formatTime(frc.createdAt)%> <%=frc.getEditedAtTextForInstructor(frc.giverEmail.equals("Anonymous"))%>
                                                         </span>
                                                         <a type="button" href="<%=data.getInstructorCommentsLink() + "&" + Const.ParamsNames.COURSE_ID 
                                                         + "=" + frc.courseId + "#" + frc.getId()%>" target="_blank" class="btn btn-default btn-xs icon-button pull-right"

--- a/src/main/webapp/jsp/instructorSearch.jsp
+++ b/src/main/webapp/jsp/instructorSearch.jsp
@@ -293,7 +293,7 @@
                                                             <span class="glyphicon glyphicon-new-window glyphicon-primary"></span>
                                                         </a>
                                                     </div> <!-- frComment Content -->
-                                                    <div id="plainCommentText-<%=fsIndx%>-<%=qnIndx%>-<%=responseIndex%>-<%=responseCommentIndex%>">
+                                                    <div id="plainCommentText-<%=fsIndx%>-<%=qnIndx%>-<%=responseIndex%>-<%=responseCommentIndex%>" style="margin-left: 15px;">
                                                         <%=frc.commentText.getValue()%>
                                                     </div>
                                                 </li>

--- a/src/main/webapp/jsp/instructorSearch.jsp
+++ b/src/main/webapp/jsp/instructorSearch.jsp
@@ -284,8 +284,8 @@
                                                     <div id="commentBar-<%=fsIndx%>-<%=qnIndx%>-<%=responseIndex%>-<%=responseCommentIndex%>">
                                                         <span class="text-muted">
                                                             From:
-                                                            <b><%=frCommentGiver%></b>
-                                                            [<%=TimeHelper.formatTime(frc.createdAt)%>] <%=frc.getEditedAtText(frc.giverEmail.equals("Anonymous"))%>
+                                                            <%= frc.giverEmail %>
+                                                            [<%= frc.createdAt %>] <%=frc.getEditedAtText(frc.giverEmail.equals("Anonymous"))%>
                                                         </span>
                                                         <a type="button" href="<%=data.getInstructorCommentsLink() + "&" + Const.ParamsNames.COURSE_ID 
                                                         + "=" + frc.courseId + "#" + frc.getId()%>" target="_blank" class="btn btn-default btn-xs icon-button pull-right"

--- a/src/main/webapp/jsp/instructorSearch.jsp
+++ b/src/main/webapp/jsp/instructorSearch.jsp
@@ -285,7 +285,7 @@
                                                         <span class="text-muted">
                                                             From:
                                                             <b><%=frCommentGiver%></b>
-                                                            on <%=TimeHelper.formatTime(frc.createdAt)%> <%=frc.getEditedAtTextForInstructor(frc.giverEmail.equals("Anonymous"))%>
+                                                            [<%=TimeHelper.formatTime(frc.createdAt)%>] <%=frc.getEditedAtTextForInstructor(frc.giverEmail.equals("Anonymous"))%>
                                                         </span>
                                                         <a type="button" href="<%=data.getInstructorCommentsLink() + "&" + Const.ParamsNames.COURSE_ID 
                                                         + "=" + frc.courseId + "#" + frc.getId()%>" target="_blank" class="btn btn-default btn-xs icon-button pull-right"

--- a/src/main/webapp/jsp/instructorSearch.jsp
+++ b/src/main/webapp/jsp/instructorSearch.jsp
@@ -288,7 +288,7 @@
                                                         <span class="text-muted">
                                                             From:
                                                             <%= frCommentGiver %>
-                                                            [<%= frc.createdAt %>] <%=frc.getEditedAtText(frc.giverEmail.equals("Anonymous"))%>
+                                                            [<%= frc.createdAt %>] <%= frc.getEditedAtText(frCommentGiver.equals("Anonymous")) %>
                                                         </span>
                                                         <a type="button" href="<%=data.getInstructorCommentsLink() + "&" + Const.ParamsNames.COURSE_ID 
                                                         + "=" + frc.courseId + "#" + frc.getId()%>" target="_blank" class="btn btn-default btn-xs icon-button pull-right"

--- a/src/main/webapp/jsp/instructorStudentRecordsAjax.jsp
+++ b/src/main/webapp/jsp/instructorStudentRecordsAjax.jsp
@@ -57,13 +57,13 @@ for (SessionResultsBundle sessionResult: data.results) {
                                             if (responseComments != null) { %>
                                                 <ul class="list-group comment-list">
                                                     <% for (FeedbackResponseCommentAttributes comment : responseComments) { %>
-                                                        <li class="list-group-item list-group-item-warning" id="">
-                                                            <div id="">
+                                                        <li class="list-group-item list-group-item-warning" id="responseCommentRow-<%= comment.getId() %>">
+                                                            <div id="commentBar-<%= comment.getId() %>">
                                                                 <span class="text-muted">
                                                                     From: <%= comment.giverEmail %> [<%= comment.createdAt %>] <%=comment.getEditedAtText(comment.giverEmail.equals("Anonymous"))%>
                                                                 </span>
                                                             </div>
-                                                            <div id="" style="margin-left: 15px;">
+                                                            <div id="plainCommentText-<%= comment.getId() %>" style="margin-left: 15px;">
                                                                 <%= comment.commentText.getValue() %>
                                                             </div>
                                                         </li>

--- a/src/main/webapp/jsp/instructorStudentRecordsAjax.jsp
+++ b/src/main/webapp/jsp/instructorStudentRecordsAjax.jsp
@@ -60,7 +60,7 @@ for (SessionResultsBundle sessionResult: data.results) {
                                                         <li class="list-group-item list-group-item-warning" id="">
                                                             <div id="">
                                                                 <span class="text-muted">
-                                                                    From: <%= comment.giverEmail %> [<%= comment.createdAt %>] <%=comment.getEditedAtTextForSessionsView(comment.giverEmail.equals("Anonymous"))%>
+                                                                    From: <%= comment.giverEmail %> [<%= comment.createdAt %>] <%=comment.getEditedAtText(comment.giverEmail.equals("Anonymous"))%>
                                                                 </span>
                                                             </div>
                                                             <div id="" style="margin-left: 15px;">
@@ -126,7 +126,7 @@ for (SessionResultsBundle sessionResult: data.results) {
                                                         <li class="list-group-item list-group-item-warning" id="">
                                                             <div id="">
                                                                 <span class="text-muted">
-                                                                    From: <%= comment.giverEmail %> [<%= comment.createdAt %>] <%= comment.getEditedAtTextForSessionsView(comment.giverEmail.equals("Anonymous")) %>
+                                                                    From: <%= comment.giverEmail %> [<%= comment.createdAt %>] <%= comment.getEditedAtText(comment.giverEmail.equals("Anonymous")) %>
                                                                 </span>
                                                             </div>
                                                             <div id="" style="margin-left: 15px;">

--- a/src/main/webapp/jsp/instructorStudentRecordsAjax.jsp
+++ b/src/main/webapp/jsp/instructorStudentRecordsAjax.jsp
@@ -57,11 +57,13 @@ for (SessionResultsBundle sessionResult: data.results) {
                                             if (responseComments != null) { %>
                                                 <ul class="list-group comment-list">
                                                     <% for (FeedbackResponseCommentAttributes comment : responseComments) { %>
-                                                        <li class="list-group-item list-group-item-warning">
-                                                            <span class="text-muted">
-                                                                From: <%= comment.giverEmail %> [<%= comment.createdAt %>]
-                                                            </span>
-                                                            <div>
+                                                        <li class="list-group-item list-group-item-warning" id="">
+                                                            <div id="">
+                                                                <span class="text-muted">
+                                                                    From: <%= comment.giverEmail %> [<%= comment.createdAt %>] <%=comment.getEditedAtTextForInstructor(comment.giverEmail.equals("Anonymous"))%>
+                                                                </span>
+                                                            </div>
+                                                            <div id="" style="margin-left: 15px;">
                                                                 <%= comment.commentText.getValue() %>
                                                             </div>
                                                         </li>
@@ -121,11 +123,13 @@ for (SessionResultsBundle sessionResult: data.results) {
                                             if (responseComments != null) { %>
                                                 <ul class="list-group comment-list">
                                                     <% for (FeedbackResponseCommentAttributes comment : responseComments) { %>
-                                                        <li class="list-group-item list-group-item-warning">
-                                                            <span class="text-muted">
-                                                                From: <%= comment.giverEmail %> [<%= comment.createdAt %>]
-                                                            </span>
-                                                            <div>
+                                                        <li class="list-group-item list-group-item-warning" id="">
+                                                            <div id="">
+                                                                <span class="text-muted">
+                                                                    From: <%= comment.giverEmail %> [<%= comment.createdAt %>] <%= comment.getEditedAtTextForInstructor(comment.giverEmail.equals("Anonymous")) %>
+                                                                </span>
+                                                            </div>
+                                                            <div id="" style="margin-left: 15px;">
                                                                 <%= comment.commentText.getValue() %>
                                                             </div>
                                                         </li>

--- a/src/main/webapp/jsp/instructorStudentRecordsAjax.jsp
+++ b/src/main/webapp/jsp/instructorStudentRecordsAjax.jsp
@@ -60,7 +60,7 @@ for (SessionResultsBundle sessionResult: data.results) {
                                                         <li class="list-group-item list-group-item-warning" id="">
                                                             <div id="">
                                                                 <span class="text-muted">
-                                                                    From: <%= comment.giverEmail %> [<%= comment.createdAt %>] <%=comment.getEditedAtTextForInstructor(comment.giverEmail.equals("Anonymous"))%>
+                                                                    From: <%= comment.giverEmail %> [<%= comment.createdAt %>] <%=comment.getEditedAtTextForSessionsView(comment.giverEmail.equals("Anonymous"))%>
                                                                 </span>
                                                             </div>
                                                             <div id="" style="margin-left: 15px;">
@@ -126,7 +126,7 @@ for (SessionResultsBundle sessionResult: data.results) {
                                                         <li class="list-group-item list-group-item-warning" id="">
                                                             <div id="">
                                                                 <span class="text-muted">
-                                                                    From: <%= comment.giverEmail %> [<%= comment.createdAt %>] <%= comment.getEditedAtTextForInstructor(comment.giverEmail.equals("Anonymous")) %>
+                                                                    From: <%= comment.giverEmail %> [<%= comment.createdAt %>] <%= comment.getEditedAtTextForSessionsView(comment.giverEmail.equals("Anonymous")) %>
                                                                 </span>
                                                             </div>
                                                             <div id="" style="margin-left: 15px;">

--- a/src/main/webapp/jsp/studentComments.jsp
+++ b/src/main/webapp/jsp/studentComments.jsp
@@ -242,8 +242,8 @@
                                                     <div
                                                         id="commentBar-<%=fsIndx%>-<%=qnIndx%>-<%=responseIndex%>-<%=responseCommentIndex%>">
                                                         <span class="text-muted">From:
-                                                            <b><%=frCommentGiver%></b>
-                                                            [<%=TimeHelper.formatDate(frc.createdAt)%>] <%=frc.getEditedAtText(frCommentGiver.equals("Anonymous")) %>
+                                                            <%= frc.giverEmail %>
+                                                            [<%= frc.createdAt %>] <%= frc.getEditedAtText(frc.giverEmail.equals("Anonymous")) %>
                                                         </span>
                                                     </div> <!-- frComment Content -->
                                                     <div

--- a/src/main/webapp/jsp/studentComments.jsp
+++ b/src/main/webapp/jsp/studentComments.jsp
@@ -247,7 +247,7 @@
                                                         </span>
                                                     </div> <!-- frComment Content -->
                                                     <div
-                                                        id="plainCommentText-<%=fsIndx%>-<%=qnIndx%>-<%=responseIndex%>-<%=responseCommentIndex%>"><%=frc.commentText.getValue()%></div>
+                                                        id="plainCommentText-<%=fsIndx%>-<%=qnIndx%>-<%=responseIndex%>-<%=responseCommentIndex%>" style="margin-left: 15px;"><%=frc.commentText.getValue()%></div>
                                                 </li>
                                                 <%
                                                     }//FeedbackResponseComments loop ends

--- a/src/main/webapp/jsp/studentComments.jsp
+++ b/src/main/webapp/jsp/studentComments.jsp
@@ -243,7 +243,7 @@
                                                         id="commentBar-<%=fsIndx%>-<%=qnIndx%>-<%=responseIndex%>-<%=responseCommentIndex%>">
                                                         <span class="text-muted">From:
                                                             <b><%=frCommentGiver%></b>
-                                                            [<%=TimeHelper.formatDate(frc.createdAt)%>] <%=frc.getEditedAtTextForStudent(frCommentGiver.equals("Anonymous"), lastEditorDisplay) %>
+                                                            [<%=TimeHelper.formatDate(frc.createdAt)%>] <%=frc.getEditedAtText(frCommentGiver.equals("Anonymous")) %>
                                                         </span>
                                                     </div> <!-- frComment Content -->
                                                     <div

--- a/src/main/webapp/jsp/studentComments.jsp
+++ b/src/main/webapp/jsp/studentComments.jsp
@@ -243,7 +243,7 @@
                                                         id="commentBar-<%=fsIndx%>-<%=qnIndx%>-<%=responseIndex%>-<%=responseCommentIndex%>">
                                                         <span class="text-muted">From:
                                                             <b><%=frCommentGiver%></b>
-                                                            on <%=TimeHelper.formatDate(frc.createdAt)%> <%=frc.getEditedAtTextForStudent(frCommentGiver.equals("Anonymous"), lastEditorDisplay) %>
+                                                            [<%=TimeHelper.formatDate(frc.createdAt)%>] <%=frc.getEditedAtTextForStudent(frCommentGiver.equals("Anonymous"), lastEditorDisplay) %>
                                                         </span>
                                                     </div> <!-- frComment Content -->
                                                     <div

--- a/src/main/webapp/jsp/studentFeedbackResults.jsp
+++ b/src/main/webapp/jsp/studentFeedbackResults.jsp
@@ -202,7 +202,7 @@
                                                                                     %>
                                                                                             <li class="list-group-item list-group-item-warning" id="">
                                                                                                 <div id="">
-                                                                                                    <span class="text-muted">From: <%= comment.giverEmail %> [<%= TimeHelper.formatDate(comment.createdAt) %>] <%= comment.getEditedAtText(comment.giverEmail.equals("Anonymous"), comment.giverEmail) %></span>
+                                                                                                    <span class="text-muted">From: <%= comment.giverEmail %> [<%= comment.createdAt %>] <%= comment.getEditedAtText(comment.giverEmail.equals("Anonymous"), comment.giverEmail) %></span>
                                                                                                 </div>
                                                                                                 <div id="" style="margin-left: 15px;"><%= comment.commentText.getValue() %></div>
                                                                                             </li>

--- a/src/main/webapp/jsp/studentFeedbackResults.jsp
+++ b/src/main/webapp/jsp/studentFeedbackResults.jsp
@@ -200,11 +200,11 @@
                                                                                     <%
                                                                                         for (FeedbackResponseCommentAttributes comment : responseComments) {
                                                                                     %>
-                                                                                            <li class="list-group-item list-group-item-warning" id="">
-                                                                                                <div id="">
+                                                                                            <li class="list-group-item list-group-item-warning" id="responseCommentRow-<%= comment.getId() %>">
+                                                                                                <div id="commentBar-<%= comment.getId() %>">
                                                                                                     <span class="text-muted">From: <%= comment.giverEmail %> [<%= comment.createdAt %>] <%= comment.getEditedAtText(comment.giverEmail.equals("Anonymous"), comment.giverEmail) %></span>
                                                                                                 </div>
-                                                                                                <div id="" style="margin-left: 15px;"><%= comment.commentText.getValue() %></div>
+                                                                                                <div id="plainCommentText-<%= comment.getId() %>" style="margin-left: 15px;"><%= comment.commentText.getValue() %></div>
                                                                                             </li>
                                                                                     <%
                                                                                         }

--- a/src/main/webapp/jsp/studentFeedbackResults.jsp
+++ b/src/main/webapp/jsp/studentFeedbackResults.jsp
@@ -202,7 +202,7 @@
                                                                                     %>
                                                                                             <li class="list-group-item list-group-item-warning" id="responseCommentRow-<%= comment.getId() %>">
                                                                                                 <div id="commentBar-<%= comment.getId() %>">
-                                                                                                    <span class="text-muted">From: <%= comment.giverEmail %> [<%= comment.createdAt %>] <%= comment.getEditedAtText(comment.giverEmail.equals("Anonymous"), comment.giverEmail) %></span>
+                                                                                                    <span class="text-muted">From: <%= comment.giverEmail %> [<%= comment.createdAt %>] <%= comment.getEditedAtText(comment.giverEmail.equals("Anonymous")) %></span>
                                                                                                 </div>
                                                                                                 <div id="plainCommentText-<%= comment.getId() %>" style="margin-left: 15px;"><%= comment.commentText.getValue() %></div>
                                                                                             </li>

--- a/src/main/webapp/jsp/studentFeedbackResults.jsp
+++ b/src/main/webapp/jsp/studentFeedbackResults.jsp
@@ -202,7 +202,7 @@
                                                                                     %>
                                                                                             <li class="list-group-item list-group-item-warning" id="">
                                                                                                 <div id="">
-                                                                                                    <span class="text-muted">From: <%= comment.giverEmail %> [<%= TimeHelper.formatDate(comment.createdAt) %>] <%= comment.getEditedAtTextForStudent(comment.giverEmail.equals("Anonymous"), comment.giverEmail) %></span>
+                                                                                                    <span class="text-muted">From: <%= comment.giverEmail %> [<%= TimeHelper.formatDate(comment.createdAt) %>] <%= comment.getEditedAtText(comment.giverEmail.equals("Anonymous"), comment.giverEmail) %></span>
                                                                                                 </div>
                                                                                                 <div id="" style="margin-left: 15px;"><%= comment.commentText.getValue() %></div>
                                                                                             </li>

--- a/src/main/webapp/jsp/studentFeedbackResults.jsp
+++ b/src/main/webapp/jsp/studentFeedbackResults.jsp
@@ -6,6 +6,7 @@
 <%@ page import="teammates.common.util.Assumption" %>
 <%@ page import="teammates.common.util.Const" %>
 <%@ page import="teammates.common.util.Url" %>
+<%@ page import="teammates.common.util.TimeHelper" %>
 <%@ page import="teammates.common.datatransfer.AccountAttributes" %>
 <%@ page import="teammates.common.datatransfer.FeedbackParticipantType" %>
 <%@ page import="teammates.common.datatransfer.FeedbackQuestionAttributes" %>
@@ -199,9 +200,11 @@
                                                                                     <%
                                                                                         for (FeedbackResponseCommentAttributes comment : responseComments) {
                                                                                     %>
-                                                                                            <li class="list-group-item list-group-item-warning">
-                                                                                                <span class="text-muted">From: <%= comment.giverEmail %> [<%= comment.createdAt %>]</span>
-                                                                                                <div><%= comment.commentText.getValue() %></div>
+                                                                                            <li class="list-group-item list-group-item-warning" id="">
+                                                                                                <div id="">
+                                                                                                    <span class="text-muted">From: <%= comment.giverEmail %> [<%= TimeHelper.formatDate(comment.createdAt) %>] <%= comment.getEditedAtTextForStudent(comment.giverEmail.equals("Anonymous"), comment.giverEmail) %></span>
+                                                                                                </div>
+                                                                                                <div id="" style="margin-left: 15px;"><%= comment.commentText.getValue() %></div>
                                                                                             </li>
                                                                                     <%
                                                                                         }

--- a/src/test/resources/data/InstructorStudentRecordsPageUiTest.json
+++ b/src/test/resources/data/InstructorStudentRecordsPageUiTest.json
@@ -524,6 +524,8 @@
             "giverEmail":"teammates.test@gmail.tmt",
             "feedbackResponseId":"2%alice.b.tmms@gmail.tmt%benny.c.tmms@gmail.tmt",
             "createdAt":"2016-03-01 11:59 PM UTC",
+            "lastEditorEmail":"teammates.test@gmail.tmt",
+            "lastEditedAt":"2016-03-02 11:59 PM UTC",
             "commentText":{
                 "value":"Instructor first comment to Alice about feedback to Benny"	
             }

--- a/src/test/resources/data/StudentFeedbackResultsPageUiTest.json
+++ b/src/test/resources/data/StudentFeedbackResultsPageUiTest.json
@@ -1785,6 +1785,8 @@
             "createdAt":"2016-03-01 11:59 PM UTC",
             "showCommentTo":[STUDENTS];
             "showGiverNameTo":[STUDENTS];
+            "lastEditorEmail":"SFResultsUiT.instr@gmail.tmt",
+            "lastEditedAt":"2016-03-02 11:59 PM UTC",
             "commentText":{
                 "value":"Instructor first comment to Alice"	
             }

--- a/src/test/resources/pages/instructorCommentsPageAddFrc.html
+++ b/src/test/resources/pages/instructorCommentsPageAddFrc.html
@@ -1477,7 +1477,7 @@
                         
                         <li id="{*}" class="list-group-item list-group-item-warning giver_display-by-you status_display-public">
                             <div id="commentBar-1-1-1-1">
-                                <span class="text-muted">From: <b>you</b>
+                                <span class="text-muted">From: comments.instructor1@course1.tmt
                                     [{*}] 
                                 </span>
                                 
@@ -1577,7 +1577,7 @@
                         
                         <li id="{*}" class="list-group-item list-group-item-warning giver_display-by-you status_display-private">
                             <div id="commentBar-1-1-1-2">
-                                <span class="text-muted">From: <b>you</b>
+                                <span class="text-muted">From: comments.instructor1@course1.tmt
                                     [Tue Mar 01 23:59:00 UTC 2016] (last edited by comments.instructor1@course1.tmt at Wed Mar 02 23:59:00 UTC 2016)
                                 </span>
                                 
@@ -1786,7 +1786,7 @@ Multiline test.
                         
                         <li id="{*}" class="list-group-item list-group-item-warning giver_display-by-you status_display-private">
                             <div id="commentBar-1-2-1-1">
-                                <span class="text-muted">From: <b>you</b>
+                                <span class="text-muted">From: comments.instructor1@course1.tmt
                                     [Mon Feb 01 23:59:00 UTC 2016] 
                                 </span>
                                 
@@ -1920,7 +1920,7 @@ Multiline test.
                         
                         <li id="{*}" class="list-group-item list-group-item-warning giver_display-by-others status_display-public">
                             <div id="commentBar-1-2-1-2">
-                                <span class="text-muted">From: <b>Anonymous</b>
+                                <span class="text-muted">From: Anonymous
                                     [Tue Feb 02 23:59:00 UTC 2016] 
                                 </span>
                                 
@@ -2056,7 +2056,7 @@ Multiline test.
                         
                         <li id="{*}" class="list-group-item list-group-item-warning giver_display-by-others status_display-public">
                             <div id="commentBar-1-2-1-3">
-                                <span class="text-muted">From: <b>Instructor2 Course1</b>
+                                <span class="text-muted">From: comments.instructor2@course1.tmt
                                     [Wed Feb 03 23:59:00 UTC 2016] 
                                 </span>
                                 

--- a/src/test/resources/pages/instructorCommentsPageDeleteFrc.html
+++ b/src/test/resources/pages/instructorCommentsPageDeleteFrc.html
@@ -1477,7 +1477,7 @@
                         
                         <li id="{*}" class="list-group-item list-group-item-warning giver_display-by-you status_display-private">
                             <div id="commentBar-1-1-1-1">
-                                <span class="text-muted">From: <b>you</b>
+                                <span class="text-muted">From: comments.instructor1@course1.tmt
                                     [Tue Mar 01 23:59:00 UTC 2016] (last edited by comments.instructor1@course1.tmt at Wed Mar 02 23:59:00 UTC 2016)
                                 </span>
                                 
@@ -1686,7 +1686,7 @@ Multiline test.
                         
                         <li id="{*}" class="list-group-item list-group-item-warning giver_display-by-you status_display-private">
                             <div id="commentBar-1-2-1-1">
-                                <span class="text-muted">From: <b>you</b>
+                                <span class="text-muted">From: comments.instructor1@course1.tmt
                                     [Mon Feb 01 23:59:00 UTC 2016] 
                                 </span>
                                 
@@ -1820,7 +1820,7 @@ Multiline test.
                         
                         <li id="{*}" class="list-group-item list-group-item-warning giver_display-by-others status_display-public">
                             <div id="commentBar-1-2-1-2">
-                                <span class="text-muted">From: <b>Anonymous</b>
+                                <span class="text-muted">From: Anonymous
                                     [Tue Feb 02 23:59:00 UTC 2016] 
                                 </span>
                                 
@@ -1956,7 +1956,7 @@ Multiline test.
                         
                         <li id="{*}" class="list-group-item list-group-item-warning giver_display-by-others status_display-public">
                             <div id="commentBar-1-2-1-3">
-                                <span class="text-muted">From: <b>Instructor2 Course1</b>
+                                <span class="text-muted">From: comments.instructor2@course1.tmt
                                     [Wed Feb 03 23:59:00 UTC 2016] 
                                 </span>
                                 

--- a/src/test/resources/pages/instructorCommentsPageEditFrc.html
+++ b/src/test/resources/pages/instructorCommentsPageEditFrc.html
@@ -1477,7 +1477,7 @@
                         
                         <li id="{*}" class="list-group-item list-group-item-warning giver_display-by-you status_display-private">
                             <div id="commentBar-1-1-1-1">
-                                <span class="text-muted">From: <b>you</b>
+                                <span class="text-muted">From: comments.instructor1@course1.tmt
                                     [{*}] (last edited by comments.instructor1@course1.tmt at {*})
                                 </span>
                                 
@@ -1575,7 +1575,7 @@
                         
                         <li id="{*}" class="list-group-item list-group-item-warning giver_display-by-you status_display-private">
                             <div id="commentBar-1-1-1-2">
-                                <span class="text-muted">From: <b>you</b>
+                                <span class="text-muted">From: comments.instructor1@course1.tmt
                                     [Tue Mar 01 23:59:00 UTC 2016] (last edited by comments.instructor1@course1.tmt at Wed Mar 02 23:59:00 UTC 2016)
                                 </span>
                                 
@@ -1784,7 +1784,7 @@ Multiline test.
                         
                         <li id="{*}" class="list-group-item list-group-item-warning giver_display-by-you status_display-private">
                             <div id="commentBar-1-2-1-1">
-                                <span class="text-muted">From: <b>you</b>
+                                <span class="text-muted">From: comments.instructor1@course1.tmt
                                     [Mon Feb 01 23:59:00 UTC 2016] 
                                 </span>
                                 
@@ -1918,7 +1918,7 @@ Multiline test.
                         
                         <li id="{*}" class="list-group-item list-group-item-warning giver_display-by-others status_display-public">
                             <div id="commentBar-1-2-1-2">
-                                <span class="text-muted">From: <b>Anonymous</b>
+                                <span class="text-muted">From: Anonymous
                                     [Tue Feb 02 23:59:00 UTC 2016] 
                                 </span>
                                 
@@ -2054,7 +2054,7 @@ Multiline test.
                         
                         <li id="{*}" class="list-group-item list-group-item-warning giver_display-by-others status_display-public">
                             <div id="commentBar-1-2-1-3">
-                                <span class="text-muted">From: <b>Instructor2 Course1</b>
+                                <span class="text-muted">From: comments.instructor2@course1.tmt
                                     [Wed Feb 03 23:59:00 UTC 2016] 
                                 </span>
                                 

--- a/src/test/resources/pages/instructorCommentsPageForCourseWithURIEncodedSessionName.html
+++ b/src/test/resources/pages/instructorCommentsPageForCourseWithURIEncodedSessionName.html
@@ -361,7 +361,7 @@
                         
                         <li id="{*}" class="list-group-item list-group-item-warning giver_display-by-you status_display-private">
                             <div id="commentBar-1-1-1-1">
-                                <span class="text-muted">From: <b>you</b>
+                                <span class="text-muted">From: comments.instructor@courseuri.tmt
                                     [Tue Mar 01 23:59:00 UTC 2016] 
                                 </span>
                                 

--- a/src/test/resources/pages/instructorCommentsPageForTypicalCourseWithComments.html
+++ b/src/test/resources/pages/instructorCommentsPageForTypicalCourseWithComments.html
@@ -1571,7 +1571,7 @@
                         
                         <li id="{*}" class="list-group-item list-group-item-warning giver_display-by-you status_display-private">
                             <div id="commentBar-1-1-1-1">
-                                <span class="text-muted">From: <b>you</b>
+                                <span class="text-muted">From: comments.instructor1@course1.tmt
                                     [Tue Mar 01 23:59:00 UTC 2016] (last edited by comments.instructor1@course1.tmt at Wed Mar 02 23:59:00 UTC 2016)
                                 </span>
                                 
@@ -1780,7 +1780,7 @@ Multiline test.
                         
                         <li id="{*}" class="list-group-item list-group-item-warning giver_display-by-you status_display-private">
                             <div id="commentBar-1-2-1-1">
-                                <span class="text-muted">From: <b>you</b>
+                                <span class="text-muted">From: comments.instructor1@course1.tmt
                                     [Mon Feb 01 23:59:00 UTC 2016] 
                                 </span>
                                 
@@ -1914,7 +1914,7 @@ Multiline test.
                         
                         <li id="{*}" class="list-group-item list-group-item-warning giver_display-by-others status_display-public">
                             <div id="commentBar-1-2-1-2">
-                                <span class="text-muted">From: <b>Anonymous</b>
+                                <span class="text-muted">From: Anonymous
                                     [Tue Feb 02 23:59:00 UTC 2016] 
                                 </span>
                                 
@@ -2050,7 +2050,7 @@ Multiline test.
                         
                         <li id="{*}" class="list-group-item list-group-item-warning giver_display-by-others status_display-public">
                             <div id="commentBar-1-2-1-3">
-                                <span class="text-muted">From: <b>Instructor2 Course1</b>
+                                <span class="text-muted">From: comments.instructor2@course1.tmt
                                     [Wed Feb 03 23:59:00 UTC 2016] 
                                 </span>
                                 

--- a/src/test/resources/pages/instructorCommentsPageSearchNormal.html
+++ b/src/test/resources/pages/instructorCommentsPageSearchNormal.html
@@ -152,7 +152,7 @@
                                                     <div id="commentBar-1-1-1-1">
                                                         <span class="text-muted">From:
                                                             <b>Instructor Instructor1 Course1</b>
-                                                            on Tue, 01 Mar 2016, 23:59
+                                                            [Tue, 01 Mar 2016, 23:59] (last edited by comments.instructor1@course1.tmt at {*})
                                                         </span>
                                                         <a type="button" href="/page/instructorCommentsPage?user=comments.idOfInstructor1OfCourse1&amp;courseid=comments.idOfTypicalCourse1#{*}" target="_blank" class="btn btn-default btn-xs icon-button pull-right" data-toggle="tooltip" data-placement="top" data-original-title="Edit comment in the Comments page" style="display:none;">
                                                             <span class="glyphicon glyphicon-new-window glyphicon-primary"></span>

--- a/src/test/resources/pages/instructorCommentsPageSearchNormal.html
+++ b/src/test/resources/pages/instructorCommentsPageSearchNormal.html
@@ -151,8 +151,8 @@
                                                 <li class="list-group-item list-group-item-warning" id="responseCommentRow-1-1-1-1">
                                                     <div id="commentBar-1-1-1-1">
                                                         <span class="text-muted">From:
-                                                            <b>Instructor Instructor1 Course1</b>
-                                                            [Tue, 01 Mar 2016, 23:59] (last edited by comments.instructor1@course1.tmt at {*})
+                                                            comments.instructor1@course1.tmt
+                                                            [Tue Mar 01 23:59:00 UTC 2016] (last edited by comments.instructor1@course1.tmt at {*})
                                                         </span>
                                                         <a type="button" href="/page/instructorCommentsPage?user=comments.idOfInstructor1OfCourse1&amp;courseid=comments.idOfTypicalCourse1#{*}" target="_blank" class="btn btn-default btn-xs icon-button pull-right" data-toggle="tooltip" data-placement="top" data-original-title="Edit comment in the Comments page" style="display:none;">
                                                             <span class="glyphicon glyphicon-new-window glyphicon-primary"></span>

--- a/src/test/resources/pages/instructorCommentsPageShowCommentsForAll.html
+++ b/src/test/resources/pages/instructorCommentsPageShowCommentsForAll.html
@@ -1571,7 +1571,7 @@
                         
                         <li id="{*}" class="list-group-item list-group-item-warning giver_display-by-you status_display-private">
                             <div id="commentBar-1-1-1-1">
-                                <span class="text-muted">From: <b>you</b>
+                                <span class="text-muted">From: comments.instructor1@course1.tmt
                                     [Tue Mar 01 23:59:00 UTC 2016] (last edited by comments.instructor1@course1.tmt at Wed Mar 02 23:59:00 UTC 2016)
                                 </span>
                                 
@@ -1780,7 +1780,7 @@ Multiline test.
                         
                         <li id="{*}" class="list-group-item list-group-item-warning giver_display-by-you status_display-private">
                             <div id="commentBar-1-2-1-1">
-                                <span class="text-muted">From: <b>you</b>
+                                <span class="text-muted">From: comments.instructor1@course1.tmt
                                     [Mon Feb 01 23:59:00 UTC 2016] 
                                 </span>
                                 
@@ -1914,7 +1914,7 @@ Multiline test.
                         
                         <li id="{*}" class="list-group-item list-group-item-warning giver_display-by-others status_display-public">
                             <div id="commentBar-1-2-1-2">
-                                <span class="text-muted">From: <b>Anonymous</b>
+                                <span class="text-muted">From: Anonymous
                                     [Tue Feb 02 23:59:00 UTC 2016] 
                                 </span>
                                 
@@ -2050,7 +2050,7 @@ Multiline test.
                         
                         <li id="{*}" class="list-group-item list-group-item-warning giver_display-by-others status_display-public">
                             <div id="commentBar-1-2-1-3">
-                                <span class="text-muted">From: <b>Instructor2 Course1</b>
+                                <span class="text-muted">From: comments.instructor2@course1.tmt
                                     [Wed Feb 03 23:59:00 UTC 2016] 
                                 </span>
                                 

--- a/src/test/resources/pages/instructorCommentsPageShowCommentsForPrivate.html
+++ b/src/test/resources/pages/instructorCommentsPageShowCommentsForPrivate.html
@@ -1571,7 +1571,7 @@
                         
                         <li style="display: block;" id="{*}" class="list-group-item list-group-item-warning giver_display-by-you status_display-private">
                             <div id="commentBar-1-1-1-1">
-                                <span class="text-muted">From: <b>you</b>
+                                <span class="text-muted">From: comments.instructor1@course1.tmt
                                     [Tue Mar 01 23:59:00 UTC 2016] (last edited by comments.instructor1@course1.tmt at Wed Mar 02 23:59:00 UTC 2016)
                                 </span>
                                 
@@ -1780,7 +1780,7 @@ Multiline test.
                         
                         <li style="display: block;" id="{*}" class="list-group-item list-group-item-warning giver_display-by-you status_display-private">
                             <div id="commentBar-1-2-1-1">
-                                <span class="text-muted">From: <b>you</b>
+                                <span class="text-muted">From: comments.instructor1@course1.tmt
                                     [Mon Feb 01 23:59:00 UTC 2016] 
                                 </span>
                                 
@@ -1914,7 +1914,7 @@ Multiline test.
                         
                         <li style="display: block;" id="{*}" class="list-group-item list-group-item-warning giver_display-by-others status_display-public">
                             <div id="commentBar-1-2-1-2">
-                                <span class="text-muted">From: <b>Anonymous</b>
+                                <span class="text-muted">From: Anonymous
                                     [Tue Feb 02 23:59:00 UTC 2016] 
                                 </span>
                                 
@@ -2050,7 +2050,7 @@ Multiline test.
                         
                         <li style="display: block;" id="{*}" class="list-group-item list-group-item-warning giver_display-by-others status_display-public">
                             <div id="commentBar-1-2-1-3">
-                                <span class="text-muted">From: <b>Instructor2 Course1</b>
+                                <span class="text-muted">From: comments.instructor2@course1.tmt
                                     [Wed Feb 03 23:59:00 UTC 2016] 
                                 </span>
                                 

--- a/src/test/resources/pages/instructorCommentsPageShowCommentsForPublic.html
+++ b/src/test/resources/pages/instructorCommentsPageShowCommentsForPublic.html
@@ -1571,7 +1571,7 @@
                         
                         <li style="display: none;" id="{*}" class="list-group-item list-group-item-warning giver_display-by-you status_display-private">
                             <div id="commentBar-1-1-1-1">
-                                <span class="text-muted">From: <b>you</b>
+                                <span class="text-muted">From: comments.instructor1@course1.tmt
                                     [Tue Mar 01 23:59:00 UTC 2016] (last edited by comments.instructor1@course1.tmt at Wed Mar 02 23:59:00 UTC 2016)
                                 </span>
                                 
@@ -1780,7 +1780,7 @@ Multiline test.
                         
                         <li style="display: none;" id="{*}" class="list-group-item list-group-item-warning giver_display-by-you status_display-private">
                             <div id="commentBar-1-2-1-1">
-                                <span class="text-muted">From: <b>you</b>
+                                <span class="text-muted">From: comments.instructor1@course1.tmt
                                     [Mon Feb 01 23:59:00 UTC 2016] 
                                 </span>
                                 
@@ -1914,7 +1914,7 @@ Multiline test.
                         
                         <li style="display: block;" id="{*}" class="list-group-item list-group-item-warning giver_display-by-others status_display-public">
                             <div id="commentBar-1-2-1-2">
-                                <span class="text-muted">From: <b>Anonymous</b>
+                                <span class="text-muted">From: Anonymous
                                     [Tue Feb 02 23:59:00 UTC 2016] 
                                 </span>
                                 
@@ -2050,7 +2050,7 @@ Multiline test.
                         
                         <li style="display: block;" id="{*}" class="list-group-item list-group-item-warning giver_display-by-others status_display-public">
                             <div id="commentBar-1-2-1-3">
-                                <span class="text-muted">From: <b>Instructor2 Course1</b>
+                                <span class="text-muted">From: comments.instructor2@course1.tmt
                                     [Wed Feb 03 23:59:00 UTC 2016] 
                                 </span>
                                 

--- a/src/test/resources/pages/instructorCommentsPageShowCommentsForSessionCommentPanel.html
+++ b/src/test/resources/pages/instructorCommentsPageShowCommentsForSessionCommentPanel.html
@@ -1571,7 +1571,7 @@
                         
                         <li id="{*}" class="list-group-item list-group-item-warning giver_display-by-you status_display-private">
                             <div id="commentBar-1-1-1-1">
-                                <span class="text-muted">From: <b>you</b>
+                                <span class="text-muted">From: comments.instructor1@course1.tmt
                                     [Tue Mar 01 23:59:00 UTC 2016] (last edited by comments.instructor1@course1.tmt at Wed Mar 02 23:59:00 UTC 2016)
                                 </span>
                                 
@@ -1780,7 +1780,7 @@ Multiline test.
                         
                         <li id="{*}" class="list-group-item list-group-item-warning giver_display-by-you status_display-private">
                             <div id="commentBar-1-2-1-1">
-                                <span class="text-muted">From: <b>you</b>
+                                <span class="text-muted">From: comments.instructor1@course1.tmt
                                     [Mon Feb 01 23:59:00 UTC 2016] 
                                 </span>
                                 
@@ -1914,7 +1914,7 @@ Multiline test.
                         
                         <li id="{*}" class="list-group-item list-group-item-warning giver_display-by-others status_display-public">
                             <div id="commentBar-1-2-1-2">
-                                <span class="text-muted">From: <b>Anonymous</b>
+                                <span class="text-muted">From: Anonymous
                                     [Tue Feb 02 23:59:00 UTC 2016] 
                                 </span>
                                 
@@ -2050,7 +2050,7 @@ Multiline test.
                         
                         <li id="{*}" class="list-group-item list-group-item-warning giver_display-by-others status_display-public">
                             <div id="commentBar-1-2-1-3">
-                                <span class="text-muted">From: <b>Instructor2 Course1</b>
+                                <span class="text-muted">From: comments.instructor2@course1.tmt
                                     [Wed Feb 03 23:59:00 UTC 2016] 
                                 </span>
                                 

--- a/src/test/resources/pages/instructorCommentsPageShowCommentsForStudentCommentPanel.html
+++ b/src/test/resources/pages/instructorCommentsPageShowCommentsForStudentCommentPanel.html
@@ -1571,7 +1571,7 @@
                         
                         <li id="{*}" class="list-group-item list-group-item-warning giver_display-by-you status_display-private">
                             <div id="commentBar-1-1-1-1">
-                                <span class="text-muted">From: <b>you</b>
+                                <span class="text-muted">From: comments.instructor1@course1.tmt
                                     [Tue Mar 01 23:59:00 UTC 2016] (last edited by comments.instructor1@course1.tmt at Wed Mar 02 23:59:00 UTC 2016)
                                 </span>
                                 
@@ -1780,7 +1780,7 @@ Multiline test.
                         
                         <li id="{*}" class="list-group-item list-group-item-warning giver_display-by-you status_display-private">
                             <div id="commentBar-1-2-1-1">
-                                <span class="text-muted">From: <b>you</b>
+                                <span class="text-muted">From: comments.instructor1@course1.tmt
                                     [Mon Feb 01 23:59:00 UTC 2016] 
                                 </span>
                                 
@@ -1914,7 +1914,7 @@ Multiline test.
                         
                         <li id="{*}" class="list-group-item list-group-item-warning giver_display-by-others status_display-public">
                             <div id="commentBar-1-2-1-2">
-                                <span class="text-muted">From: <b>Anonymous</b>
+                                <span class="text-muted">From: Anonymous
                                     [Tue Feb 02 23:59:00 UTC 2016] 
                                 </span>
                                 
@@ -2050,7 +2050,7 @@ Multiline test.
                         
                         <li id="{*}" class="list-group-item list-group-item-warning giver_display-by-others status_display-public">
                             <div id="commentBar-1-2-1-3">
-                                <span class="text-muted">From: <b>Instructor2 Course1</b>
+                                <span class="text-muted">From: comments.instructor2@course1.tmt
                                     [Wed Feb 03 23:59:00 UTC 2016] 
                                 </span>
                                 

--- a/src/test/resources/pages/instructorCommentsPageShowCommentsFromAll.html
+++ b/src/test/resources/pages/instructorCommentsPageShowCommentsFromAll.html
@@ -1571,7 +1571,7 @@
                         
                         <li style="display: none;" id="{*}" class="list-group-item list-group-item-warning giver_display-by-you status_display-private">
                             <div id="commentBar-1-1-1-1">
-                                <span class="text-muted">From: <b>you</b>
+                                <span class="text-muted">From: comments.instructor1@course1.tmt
                                     [Tue Mar 01 23:59:00 UTC 2016] (last edited by comments.instructor1@course1.tmt at Wed Mar 02 23:59:00 UTC 2016)
                                 </span>
                                 
@@ -1780,7 +1780,7 @@ Multiline test.
                         
                         <li style="display: none;" id="{*}" class="list-group-item list-group-item-warning giver_display-by-you status_display-private">
                             <div id="commentBar-1-2-1-1">
-                                <span class="text-muted">From: <b>you</b>
+                                <span class="text-muted">From: comments.instructor1@course1.tmt
                                     [Mon Feb 01 23:59:00 UTC 2016] 
                                 </span>
                                 
@@ -1914,7 +1914,7 @@ Multiline test.
                         
                         <li style="display: none;" id="{*}" class="list-group-item list-group-item-warning giver_display-by-others status_display-public">
                             <div id="commentBar-1-2-1-2">
-                                <span class="text-muted">From: <b>Anonymous</b>
+                                <span class="text-muted">From: Anonymous
                                     [Tue Feb 02 23:59:00 UTC 2016] 
                                 </span>
                                 
@@ -2050,7 +2050,7 @@ Multiline test.
                         
                         <li style="display: none;" id="{*}" class="list-group-item list-group-item-warning giver_display-by-others status_display-public">
                             <div id="commentBar-1-2-1-3">
-                                <span class="text-muted">From: <b>Instructor2 Course1</b>
+                                <span class="text-muted">From: comments.instructor2@course1.tmt
                                     [Wed Feb 03 23:59:00 UTC 2016] 
                                 </span>
                                 

--- a/src/test/resources/pages/instructorCommentsPageShowCommentsFromAllStatus.html
+++ b/src/test/resources/pages/instructorCommentsPageShowCommentsFromAllStatus.html
@@ -1571,7 +1571,7 @@
                         
                         <li style="display: none;" id="{*}" class="list-group-item list-group-item-warning giver_display-by-you status_display-private">
                             <div id="commentBar-1-1-1-1">
-                                <span class="text-muted">From: <b>you</b>
+                                <span class="text-muted">From: comments.instructor1@course1.tmt
                                     [Tue Mar 01 23:59:00 UTC 2016] (last edited by comments.instructor1@course1.tmt at Wed Mar 02 23:59:00 UTC 2016)
                                 </span>
                                 
@@ -1780,7 +1780,7 @@ Multiline test.
                         
                         <li style="display: none;" id="{*}" class="list-group-item list-group-item-warning giver_display-by-you status_display-private">
                             <div id="commentBar-1-2-1-1">
-                                <span class="text-muted">From: <b>you</b>
+                                <span class="text-muted">From: comments.instructor1@course1.tmt
                                     [Mon Feb 01 23:59:00 UTC 2016] 
                                 </span>
                                 
@@ -1914,7 +1914,7 @@ Multiline test.
                         
                         <li style="display: none;" id="{*}" class="list-group-item list-group-item-warning giver_display-by-others status_display-public">
                             <div id="commentBar-1-2-1-2">
-                                <span class="text-muted">From: <b>Anonymous</b>
+                                <span class="text-muted">From: Anonymous
                                     [Tue Feb 02 23:59:00 UTC 2016] 
                                 </span>
                                 
@@ -2050,7 +2050,7 @@ Multiline test.
                         
                         <li style="display: none;" id="{*}" class="list-group-item list-group-item-warning giver_display-by-others status_display-public">
                             <div id="commentBar-1-2-1-3">
-                                <span class="text-muted">From: <b>Instructor2 Course1</b>
+                                <span class="text-muted">From: comments.instructor2@course1.tmt
                                     [Wed Feb 03 23:59:00 UTC 2016] 
                                 </span>
                                 

--- a/src/test/resources/pages/instructorCommentsPageShowCommentsFromOthers.html
+++ b/src/test/resources/pages/instructorCommentsPageShowCommentsFromOthers.html
@@ -1571,7 +1571,7 @@
                         
                         <li style="display: block;" id="{*}" class="list-group-item list-group-item-warning giver_display-by-you status_display-private">
                             <div id="commentBar-1-1-1-1">
-                                <span class="text-muted">From: <b>you</b>
+                                <span class="text-muted">From: comments.instructor1@course1.tmt
                                     [Tue Mar 01 23:59:00 UTC 2016] (last edited by comments.instructor1@course1.tmt at Wed Mar 02 23:59:00 UTC 2016)
                                 </span>
                                 
@@ -1780,7 +1780,7 @@ Multiline test.
                         
                         <li style="display: block;" id="{*}" class="list-group-item list-group-item-warning giver_display-by-you status_display-private">
                             <div id="commentBar-1-2-1-1">
-                                <span class="text-muted">From: <b>you</b>
+                                <span class="text-muted">From: comments.instructor1@course1.tmt
                                     [Mon Feb 01 23:59:00 UTC 2016] 
                                 </span>
                                 
@@ -1914,7 +1914,7 @@ Multiline test.
                         
                         <li style="display: block;" id="{*}" class="list-group-item list-group-item-warning giver_display-by-others status_display-public">
                             <div id="commentBar-1-2-1-2">
-                                <span class="text-muted">From: <b>Anonymous</b>
+                                <span class="text-muted">From: Anonymous
                                     [Tue Feb 02 23:59:00 UTC 2016] 
                                 </span>
                                 
@@ -2050,7 +2050,7 @@ Multiline test.
                         
                         <li style="display: block;" id="{*}" class="list-group-item list-group-item-warning giver_display-by-others status_display-public">
                             <div id="commentBar-1-2-1-3">
-                                <span class="text-muted">From: <b>Instructor2 Course1</b>
+                                <span class="text-muted">From: comments.instructor2@course1.tmt
                                     [Wed Feb 03 23:59:00 UTC 2016] 
                                 </span>
                                 

--- a/src/test/resources/pages/instructorCommentsPageShowCommentsFromYou.html
+++ b/src/test/resources/pages/instructorCommentsPageShowCommentsFromYou.html
@@ -1571,7 +1571,7 @@
                         
                         <li style="display: block;" id="{*}" class="list-group-item list-group-item-warning giver_display-by-you status_display-private">
                             <div id="commentBar-1-1-1-1">
-                                <span class="text-muted">From: <b>you</b>
+                                <span class="text-muted">From: comments.instructor1@course1.tmt
                                     [Tue Mar 01 23:59:00 UTC 2016] (last edited by comments.instructor1@course1.tmt at Wed Mar 02 23:59:00 UTC 2016)
                                 </span>
                                 
@@ -1780,7 +1780,7 @@ Multiline test.
                         
                         <li style="display: block;" id="{*}" class="list-group-item list-group-item-warning giver_display-by-you status_display-private">
                             <div id="commentBar-1-2-1-1">
-                                <span class="text-muted">From: <b>you</b>
+                                <span class="text-muted">From: comments.instructor1@course1.tmt
                                     [Mon Feb 01 23:59:00 UTC 2016] 
                                 </span>
                                 
@@ -1914,7 +1914,7 @@ Multiline test.
                         
                         <li style="display: none;" id="{*}" class="list-group-item list-group-item-warning giver_display-by-others status_display-public">
                             <div id="commentBar-1-2-1-2">
-                                <span class="text-muted">From: <b>Anonymous</b>
+                                <span class="text-muted">From: Anonymous
                                     [Tue Feb 02 23:59:00 UTC 2016] 
                                 </span>
                                 
@@ -2050,7 +2050,7 @@ Multiline test.
                         
                         <li style="display: none;" id="{*}" class="list-group-item list-group-item-warning giver_display-by-others status_display-public">
                             <div id="commentBar-1-2-1-3">
-                                <span class="text-muted">From: <b>Instructor2 Course1</b>
+                                <span class="text-muted">From: comments.instructor2@course1.tmt
                                     [Wed Feb 03 23:59:00 UTC 2016] 
                                 </span>
                                 

--- a/src/test/resources/pages/instructorFeedbackResultsAddComment.html
+++ b/src/test/resources/pages/instructorFeedbackResultsAddComment.html
@@ -385,6 +385,10 @@
     <form style="display: none;" id="responseCommentEditForm-0-1-1-1" class="responseCommentEditForm">
         <div class="form-group form-inline">
             <div class="form-group text-muted">
+                <p>
+                    Giver: Teammates Test (Instructors)<br>
+                    Recipient: -
+                </p>
                 You may change comment's visibility using the visibility options on the right hand side.
             </div>
             <a id="frComment-visibility-options-trigger-0-1-1-1" class="btn btn-sm btn-info pull-right" onclick="toggleVisibilityEditForm(0, 1, 1, 1)">
@@ -471,6 +475,10 @@
     <form style="display: none;" id="responseCommentEditForm-0-1-1-2" class="responseCommentEditForm">
         <div class="form-group form-inline">
             <div class="form-group text-muted">
+                <p>
+                    Giver: Teammates Test (Instructors)<br>
+                    Recipient: -
+                </p>
                 You may change comment's visibility using the visibility options on the right hand side.
             </div>
             <a id="frComment-visibility-options-trigger-0-1-1-2" class="btn btn-sm btn-info pull-right" onclick="toggleVisibilityEditForm(0, 1, 1, 2)">

--- a/src/test/resources/pages/instructorFeedbackResultsAddComment.html
+++ b/src/test/resources/pages/instructorFeedbackResultsAddComment.html
@@ -364,7 +364,7 @@
 <li class="list-group-item list-group-item-warning" id="responseCommentRow-0-1-1-1">
     <div id="commentBar-0-1-1-1">
         <span class="text-muted">
-            From: <b>you</b> [{*}]
+            From: CFResultsUiT.instr@gmail.tmt [{*}]
         </span>
         <form class="responseCommentDeleteForm pull-right">
             <a data-original-title="Delete this comment" href="/page/instructorFeedbackResponseCommentDelete" type="button" id="commentdelete-{*}" class="btn btn-default btn-xs icon-button" data-toggle="tooltip" data-placement="top" title="">
@@ -454,7 +454,7 @@
 <li class="list-group-item list-group-item-warning" id="responseCommentRow-0-1-1-2">
     <div id="commentBar-0-1-1-2">
         <span class="text-muted">
-            From: <b>you</b> [{*}]
+            From: CFResultsUiT.instr@gmail.tmt [{*}]
         </span>
         <form class="responseCommentDeleteForm pull-right">
             <a data-original-title="Delete this comment" href="/page/instructorFeedbackResponseCommentDelete" type="button" id="commentdelete-{*}" class="btn btn-default btn-xs icon-button" data-toggle="tooltip" data-placement="top" title="">

--- a/src/test/resources/pages/instructorSearchPageSearchComments.html
+++ b/src/test/resources/pages/instructorSearchPageSearchComments.html
@@ -251,7 +251,7 @@
                                                         <span class="text-muted">
                                                             From:
                                                             <b>Instructor Instructor1 Course1</b>
-                                                            on Tue, 01 Mar 2016, 23:59
+                                                            [Tue, 01 Mar 2016, 23:59] 
                                                         </span>
                                                         <a type="button" href="/page/instructorCommentsPage?user=searchUI.idOfInstructor1OfCourse1&amp;courseid=searchUI.idOfTypicalCourse1#{*}" target="_blank" class="btn btn-default btn-xs icon-button pull-right" data-toggle="tooltip" data-placement="top" data-original-title="Edit comment in the Comments page" style="display:none;">
                                                             <span class="glyphicon glyphicon-new-window glyphicon-primary"></span>
@@ -305,7 +305,7 @@ Multiline test.
                                                         <span class="text-muted">
                                                             From:
                                                             <b>Instructor Instructor1 Course1</b>
-                                                            on Mon, 01 Feb 2016, 23:59
+                                                            [Mon, 01 Feb 2016, 23:59] 
                                                         </span>
                                                         <a type="button" href="/page/instructorCommentsPage?user=searchUI.idOfInstructor1OfCourse1&amp;courseid=searchUI.idOfTypicalCourse1#{*}" target="_blank" class="btn btn-default btn-xs icon-button pull-right" data-toggle="tooltip" data-placement="top" data-original-title="Edit comment in the Comments page" style="display:none;">
                                                             <span class="glyphicon glyphicon-new-window glyphicon-primary"></span>
@@ -321,7 +321,7 @@ Multiline test.
                                                         <span class="text-muted">
                                                             From:
                                                             <b>Anonymous</b>
-                                                            on Tue, 02 Feb 2016, 23:59
+                                                            [Tue, 02 Feb 2016, 23:59] 
                                                         </span>
                                                         <a type="button" href="/page/instructorCommentsPage?user=searchUI.idOfInstructor1OfCourse1&amp;courseid=searchUI.idOfTypicalCourse1#{*}" target="_blank" class="btn btn-default btn-xs icon-button pull-right" data-toggle="tooltip" data-placement="top" data-original-title="Edit comment in the Comments page" style="display:none;">
                                                             <span class="glyphicon glyphicon-new-window glyphicon-primary"></span>
@@ -337,7 +337,7 @@ Multiline test.
                                                         <span class="text-muted">
                                                             From:
                                                             <b>Instructor Instructor2 Course1</b>
-                                                            on Wed, 03 Feb 2016, 23:59
+                                                            [Wed, 03 Feb 2016, 23:59] 
                                                         </span>
                                                         <a type="button" href="/page/instructorCommentsPage?user=searchUI.idOfInstructor1OfCourse1&amp;courseid=searchUI.idOfTypicalCourse1#{*}" target="_blank" class="btn btn-default btn-xs icon-button pull-right" data-toggle="tooltip" data-placement="top" data-original-title="Edit comment in the Comments page" style="display:none;">
                                                             <span class="glyphicon glyphicon-new-window glyphicon-primary"></span>

--- a/src/test/resources/pages/instructorSearchPageSearchComments.html
+++ b/src/test/resources/pages/instructorSearchPageSearchComments.html
@@ -250,8 +250,8 @@
                                                     <div id="commentBar-1-1-1-1">
                                                         <span class="text-muted">
                                                             From:
-                                                            <b>Instructor Instructor1 Course1</b>
-                                                            [Tue, 01 Mar 2016, 23:59] 
+                                                            searchUI.instructor1@course1.tmt
+                                                            [Tue Mar 01 23:59:00 UTC 2016]
                                                         </span>
                                                         <a type="button" href="/page/instructorCommentsPage?user=searchUI.idOfInstructor1OfCourse1&amp;courseid=searchUI.idOfTypicalCourse1#{*}" target="_blank" class="btn btn-default btn-xs icon-button pull-right" data-toggle="tooltip" data-placement="top" data-original-title="Edit comment in the Comments page" style="display:none;">
                                                             <span class="glyphicon glyphicon-new-window glyphicon-primary"></span>
@@ -304,8 +304,8 @@ Multiline test.
                                                     <div id="commentBar-1-2-1-1">
                                                         <span class="text-muted">
                                                             From:
-                                                            <b>Instructor Instructor1 Course1</b>
-                                                            [Mon, 01 Feb 2016, 23:59] 
+                                                            searchUI.instructor1@course1.tmt
+                                                            [Mon Feb 01 23:59:00 UTC 2016]
                                                         </span>
                                                         <a type="button" href="/page/instructorCommentsPage?user=searchUI.idOfInstructor1OfCourse1&amp;courseid=searchUI.idOfTypicalCourse1#{*}" target="_blank" class="btn btn-default btn-xs icon-button pull-right" data-toggle="tooltip" data-placement="top" data-original-title="Edit comment in the Comments page" style="display:none;">
                                                             <span class="glyphicon glyphicon-new-window glyphicon-primary"></span>
@@ -320,8 +320,8 @@ Multiline test.
                                                     <div id="commentBar-1-2-1-2">
                                                         <span class="text-muted">
                                                             From:
-                                                            <b>Anonymous</b>
-                                                            [Tue, 02 Feb 2016, 23:59] 
+                                                            Anonymous
+                                                            [Tue Feb 02 23:59:00 UTC 2016]
                                                         </span>
                                                         <a type="button" href="/page/instructorCommentsPage?user=searchUI.idOfInstructor1OfCourse1&amp;courseid=searchUI.idOfTypicalCourse1#{*}" target="_blank" class="btn btn-default btn-xs icon-button pull-right" data-toggle="tooltip" data-placement="top" data-original-title="Edit comment in the Comments page" style="display:none;">
                                                             <span class="glyphicon glyphicon-new-window glyphicon-primary"></span>
@@ -336,8 +336,8 @@ Multiline test.
                                                     <div id="commentBar-1-2-1-3">
                                                         <span class="text-muted">
                                                             From:
-                                                            <b>Instructor Instructor2 Course1</b>
-                                                            [Wed, 03 Feb 2016, 23:59] 
+                                                            searchUI.instructor2@course1.tmt
+                                                            [Wed Feb 03 23:59:00 UTC 2016]
                                                         </span>
                                                         <a type="button" href="/page/instructorCommentsPage?user=searchUI.idOfInstructor1OfCourse1&amp;courseid=searchUI.idOfTypicalCourse1#{*}" target="_blank" class="btn btn-default btn-xs icon-button pull-right" data-toggle="tooltip" data-placement="top" data-original-title="Edit comment in the Comments page" style="display:none;">
                                                             <span class="glyphicon glyphicon-new-window glyphicon-primary"></span>

--- a/src/test/resources/pages/instructorSearchPageSearchFeedbackResponseComments.html
+++ b/src/test/resources/pages/instructorSearchPageSearchFeedbackResponseComments.html
@@ -94,7 +94,7 @@
                                                         <span class="text-muted">
                                                             From:
                                                             <b>Instructor Instructor1 Course1</b>
-                                                            on Tue, 01 Mar 2016, 23:59
+                                                            [Tue, 01 Mar 2016, 23:59] 
                                                         </span>
                                                         <a type="button" href="/page/instructorCommentsPage?user=searchUI.idOfInstructor1OfCourse1&amp;courseid=searchUI.idOfTypicalCourse1#{*}" target="_blank" class="btn btn-default btn-xs icon-button pull-right" data-toggle="tooltip" data-placement="top" data-original-title="Edit comment in the Comments page" style="display:none;">
                                                             <span class="glyphicon glyphicon-new-window glyphicon-primary"></span>
@@ -148,7 +148,7 @@ Multiline test.
                                                         <span class="text-muted">
                                                             From:
                                                             <b>Instructor Instructor1 Course1</b>
-                                                            on Mon, 01 Feb 2016, 23:59
+                                                            [Mon, 01 Feb 2016, 23:59] 
                                                         </span>
                                                         <a type="button" href="/page/instructorCommentsPage?user=searchUI.idOfInstructor1OfCourse1&amp;courseid=searchUI.idOfTypicalCourse1#{*}" target="_blank" class="btn btn-default btn-xs icon-button pull-right" data-toggle="tooltip" data-placement="top" data-original-title="Edit comment in the Comments page" style="display:none;">
                                                             <span class="glyphicon glyphicon-new-window glyphicon-primary"></span>
@@ -164,7 +164,7 @@ Multiline test.
                                                         <span class="text-muted">
                                                             From:
                                                             <b>Anonymous</b>
-                                                            on Tue, 02 Feb 2016, 23:59
+                                                            [Tue, 02 Feb 2016, 23:59] 
                                                         </span>
                                                         <a type="button" href="/page/instructorCommentsPage?user=searchUI.idOfInstructor1OfCourse1&amp;courseid=searchUI.idOfTypicalCourse1#{*}" target="_blank" class="btn btn-default btn-xs icon-button pull-right" data-toggle="tooltip" data-placement="top" data-original-title="Edit comment in the Comments page" style="display:none;">
                                                             <span class="glyphicon glyphicon-new-window glyphicon-primary"></span>
@@ -180,7 +180,7 @@ Multiline test.
                                                         <span class="text-muted">
                                                             From:
                                                             <b>Instructor Instructor2 Course1</b>
-                                                            on Wed, 03 Feb 2016, 23:59
+                                                            [Wed, 03 Feb 2016, 23:59] 
                                                         </span>
                                                         <a type="button" href="/page/instructorCommentsPage?user=searchUI.idOfInstructor1OfCourse1&amp;courseid=searchUI.idOfTypicalCourse1#{*}" target="_blank" class="btn btn-default btn-xs icon-button pull-right" data-toggle="tooltip" data-placement="top" data-original-title="Edit comment in the Comments page" style="display:none;">
                                                             <span class="glyphicon glyphicon-new-window glyphicon-primary"></span>

--- a/src/test/resources/pages/instructorSearchPageSearchFeedbackResponseComments.html
+++ b/src/test/resources/pages/instructorSearchPageSearchFeedbackResponseComments.html
@@ -93,8 +93,8 @@
                                                     <div id="commentBar-1-1-1-1">
                                                         <span class="text-muted">
                                                             From:
-                                                            <b>Instructor Instructor1 Course1</b>
-                                                            [Tue, 01 Mar 2016, 23:59] 
+                                                            searchUI.instructor1@course1.tmt
+                                                            [Tue Mar 01 23:59:00 UTC 2016]
                                                         </span>
                                                         <a type="button" href="/page/instructorCommentsPage?user=searchUI.idOfInstructor1OfCourse1&amp;courseid=searchUI.idOfTypicalCourse1#{*}" target="_blank" class="btn btn-default btn-xs icon-button pull-right" data-toggle="tooltip" data-placement="top" data-original-title="Edit comment in the Comments page" style="display:none;">
                                                             <span class="glyphicon glyphicon-new-window glyphicon-primary"></span>
@@ -147,8 +147,8 @@ Multiline test.
                                                     <div id="commentBar-1-2-1-1">
                                                         <span class="text-muted">
                                                             From:
-                                                            <b>Instructor Instructor1 Course1</b>
-                                                            [Mon, 01 Feb 2016, 23:59] 
+                                                            searchUI.instructor1@course1.tmt
+                                                            [Mon Feb 01 23:59:00 UTC 2016]
                                                         </span>
                                                         <a type="button" href="/page/instructorCommentsPage?user=searchUI.idOfInstructor1OfCourse1&amp;courseid=searchUI.idOfTypicalCourse1#{*}" target="_blank" class="btn btn-default btn-xs icon-button pull-right" data-toggle="tooltip" data-placement="top" data-original-title="Edit comment in the Comments page" style="display:none;">
                                                             <span class="glyphicon glyphicon-new-window glyphicon-primary"></span>
@@ -163,8 +163,8 @@ Multiline test.
                                                     <div id="commentBar-1-2-1-2">
                                                         <span class="text-muted">
                                                             From:
-                                                            <b>Anonymous</b>
-                                                            [Tue, 02 Feb 2016, 23:59] 
+                                                            Anonymous
+                                                            [Tue Feb 02 23:59:00 UTC 2016]
                                                         </span>
                                                         <a type="button" href="/page/instructorCommentsPage?user=searchUI.idOfInstructor1OfCourse1&amp;courseid=searchUI.idOfTypicalCourse1#{*}" target="_blank" class="btn btn-default btn-xs icon-button pull-right" data-toggle="tooltip" data-placement="top" data-original-title="Edit comment in the Comments page" style="display:none;">
                                                             <span class="glyphicon glyphicon-new-window glyphicon-primary"></span>
@@ -179,8 +179,8 @@ Multiline test.
                                                     <div id="commentBar-1-2-1-3">
                                                         <span class="text-muted">
                                                             From:
-                                                            <b>Instructor Instructor2 Course1</b>
-                                                            [Wed, 03 Feb 2016, 23:59] 
+                                                            searchUI.instructor2@course1.tmt
+                                                            [Wed Feb 03 23:59:00 UTC 2016]
                                                         </span>
                                                         <a type="button" href="/page/instructorCommentsPage?user=searchUI.idOfInstructor1OfCourse1&amp;courseid=searchUI.idOfTypicalCourse1#{*}" target="_blank" class="btn btn-default btn-xs icon-button pull-right" data-toggle="tooltip" data-placement="top" data-original-title="Edit comment in the Comments page" style="display:none;">
                                                             <span class="glyphicon glyphicon-new-window glyphicon-primary"></span>

--- a/src/test/resources/pages/instructorStudentRecords.html
+++ b/src/test/resources/pages/instructorStudentRecords.html
@@ -562,20 +562,24 @@
                                                 
                                                     <ul class="list-group comment-list">
                                                         
-                                                            <li class="list-group-item list-group-item-warning">
-                                                                <span class="text-muted">
-                                                                    From: teammates.test@gmail.tmt [Tue Mar 01 23:59:00 UTC 2016]
-                                                                </span>
-                                                                <div>
+                                                            <li class="list-group-item list-group-item-warning" id="">
+                                                                <div id="">
+                                                                    <span class="text-muted">
+                                                                        From: teammates.test@gmail.tmt [Tue Mar 01 23:59:00 UTC 2016] 
+                                                                    </span>
+                                                                </div>
+                                                                <div id="" style="margin-left: 15px;">
                                                                     Instructor first comment to Alice about feedback to Benny
                                                                 </div>
                                                             </li>
                                                         
-                                                            <li class="list-group-item list-group-item-warning">
-                                                                <span class="text-muted">
-                                                                    From: teammates.test@gmail.tmt [Wed Mar 02 23:59:00 UTC 2016]
-                                                                </span>
-                                                                <div>
+                                                            <li class="list-group-item list-group-item-warning" id="">
+                                                                <div id="">
+                                                                    <span class="text-muted">
+                                                                        From: teammates.test@gmail.tmt [Wed Mar 02 23:59:00 UTC 2016] 
+                                                                    </span>
+                                                                </div>
+                                                                <div id="" style="margin-left: 15px;">
                                                                     Instructor second comment to Alice about feedback to Benny
                                                                 </div>
                                                             </li>

--- a/src/test/resources/pages/instructorStudentRecords.html
+++ b/src/test/resources/pages/instructorStudentRecords.html
@@ -562,24 +562,24 @@
                                                 
                                                     <ul class="list-group comment-list">
                                                         
-                                                            <li class="list-group-item list-group-item-warning" id="">
-                                                                <div id="">
+                                                            <li class="list-group-item list-group-item-warning" id="responseCommentRow-{*}">
+                                                                <div id="commentBar-{*}">
                                                                     <span class="text-muted">
                                                                         From: teammates.test@gmail.tmt [Tue Mar 01 23:59:00 UTC 2016] (last edited by teammates.test@gmail.tmt at Wed Mar 02 23:59:00 UTC 2016)
                                                                     </span>
                                                                 </div>
-                                                                <div id="" style="margin-left: 15px;">
+                                                                <div id="plainCommentText-{*}" style="margin-left: 15px;">
                                                                     Instructor first comment to Alice about feedback to Benny
                                                                 </div>
                                                             </li>
                                                         
-                                                            <li class="list-group-item list-group-item-warning" id="">
-                                                                <div id="">
+                                                            <li class="list-group-item list-group-item-warning" id="responseCommentRow-{*}">
+                                                                <div id="commentBar-{*}">
                                                                     <span class="text-muted">
                                                                         From: teammates.test@gmail.tmt [Wed Mar 02 23:59:00 UTC 2016] 
                                                                     </span>
                                                                 </div>
-                                                                <div id="" style="margin-left: 15px;">
+                                                                <div id="plainCommentText-{*}" style="margin-left: 15px;">
                                                                     Instructor second comment to Alice about feedback to Benny
                                                                 </div>
                                                             </li>

--- a/src/test/resources/pages/instructorStudentRecords.html
+++ b/src/test/resources/pages/instructorStudentRecords.html
@@ -565,7 +565,7 @@
                                                             <li class="list-group-item list-group-item-warning" id="">
                                                                 <div id="">
                                                                     <span class="text-muted">
-                                                                        From: teammates.test@gmail.tmt [Tue Mar 01 23:59:00 UTC 2016] 
+                                                                        From: teammates.test@gmail.tmt [Tue Mar 01 23:59:00 UTC 2016] (last edited by teammates.test@gmail.tmt at Wed Mar 02 23:59:00 UTC 2016)
                                                                     </span>
                                                                 </div>
                                                                 <div id="" style="margin-left: 15px;">

--- a/src/test/resources/pages/studentCommentsPageForStudent1.html
+++ b/src/test/resources/pages/studentCommentsPageForStudent1.html
@@ -434,8 +434,8 @@ Multiline test.
                                                 <li id="responseCommentRow-1-1-1-1" class="list-group-item list-group-item-warning">
                                                     <div id="commentBar-1-1-1-1">
                                                         <span class="text-muted">From:
-                                                            <b>Anonymous</b>
-                                                            [02/02/2016] 
+                                                            Anonymous
+                                                            [Tue Feb 02 23:59:00 UTC 2016] 
                                                         </span>
                                                     </div> <!-- frComment Content -->
                                                     <div id="plainCommentText-1-1-1-1" style="margin-left: 15px;">Anonymous comment to feedback Question 2</div>
@@ -444,8 +444,8 @@ Multiline test.
                                                 <li id="responseCommentRow-1-1-1-2" class="list-group-item list-group-item-warning">
                                                     <div id="commentBar-1-1-1-2">
                                                         <span class="text-muted">From:
-                                                            <b>Instructor Instructor2 Course1</b>
-                                                            [03/02/2016] 
+                                                            comments.instructor2@course1.tmt
+                                                            [Wed Feb 03 23:59:00 UTC 2016]
                                                         </span>
                                                     </div> <!-- frComment Content -->
                                                     <div id="plainCommentText-1-1-1-2" style="margin-left: 15px;">Instructor 2 comment to feedback Question 2 (Student 3 see this as anonymous comment)</div>

--- a/src/test/resources/pages/studentCommentsPageForStudent1.html
+++ b/src/test/resources/pages/studentCommentsPageForStudent1.html
@@ -435,7 +435,7 @@ Multiline test.
                                                     <div id="commentBar-1-1-1-1">
                                                         <span class="text-muted">From:
                                                             <b>Anonymous</b>
-                                                            on 02/02/2016 
+                                                            [02/02/2016] 
                                                         </span>
                                                     </div> <!-- frComment Content -->
                                                     <div id="plainCommentText-1-1-1-1" style="margin-left: 15px;">Anonymous comment to feedback Question 2</div>
@@ -445,7 +445,7 @@ Multiline test.
                                                     <div id="commentBar-1-1-1-2">
                                                         <span class="text-muted">From:
                                                             <b>Instructor Instructor2 Course1</b>
-                                                            on 03/02/2016 
+                                                            [03/02/2016] 
                                                         </span>
                                                     </div> <!-- frComment Content -->
                                                     <div id="plainCommentText-1-1-1-2" style="margin-left: 15px;">Instructor 2 comment to feedback Question 2 (Student 3 see this as anonymous comment)</div>

--- a/src/test/resources/pages/studentCommentsPageForStudent2.html
+++ b/src/test/resources/pages/studentCommentsPageForStudent2.html
@@ -183,7 +183,7 @@ Multiline test.
                                                     <div id="commentBar-1-1-1-1">
                                                         <span class="text-muted">From:
                                                             <b>Anonymous</b>
-                                                            on 02/02/2016 
+                                                            [02/02/2016] 
                                                         </span>
                                                     </div> <!-- frComment Content -->
                                                     <div style="margin-left: 15px;" id="plainCommentText-1-1-1-1">Anonymous comment to feedback Question 2</div>
@@ -193,7 +193,7 @@ Multiline test.
                                                     <div id="commentBar-1-1-1-2">
                                                         <span class="text-muted">From:
                                                             <b>Instructor Instructor2 Course1</b>
-                                                            on 03/02/2016 
+                                                            [03/02/2016] 
                                                         </span>
                                                     </div> <!-- frComment Content -->
                                                     <div style="margin-left: 15px;" id="plainCommentText-1-1-1-2">Instructor 2 comment to feedback Question 2 (Student 3 see this as anonymous comment)</div>

--- a/src/test/resources/pages/studentCommentsPageForStudent2.html
+++ b/src/test/resources/pages/studentCommentsPageForStudent2.html
@@ -182,8 +182,8 @@ Multiline test.
                                                 <li class="list-group-item list-group-item-warning" id="responseCommentRow-1-1-1-1">
                                                     <div id="commentBar-1-1-1-1">
                                                         <span class="text-muted">From:
-                                                            <b>Anonymous</b>
-                                                            [02/02/2016] 
+                                                            Anonymous
+                                                            [Tue Feb 02 23:59:00 UTC 2016] 
                                                         </span>
                                                     </div> <!-- frComment Content -->
                                                     <div style="margin-left: 15px;" id="plainCommentText-1-1-1-1">Anonymous comment to feedback Question 2</div>
@@ -192,8 +192,8 @@ Multiline test.
                                                 <li class="list-group-item list-group-item-warning" id="responseCommentRow-1-1-1-2">
                                                     <div id="commentBar-1-1-1-2">
                                                         <span class="text-muted">From:
-                                                            <b>Instructor Instructor2 Course1</b>
-                                                            [03/02/2016] 
+                                                            comments.instructor2@course1.tmt
+                                                            [Wed Feb 03 23:59:00 UTC 2016]
                                                         </span>
                                                     </div> <!-- frComment Content -->
                                                     <div style="margin-left: 15px;" id="plainCommentText-1-1-1-2">Instructor 2 comment to feedback Question 2 (Student 3 see this as anonymous comment)</div>

--- a/src/test/resources/pages/studentCommentsPageForStudent3.html
+++ b/src/test/resources/pages/studentCommentsPageForStudent3.html
@@ -106,8 +106,8 @@ Multiline test.
                                                 <li class="list-group-item list-group-item-warning" id="responseCommentRow-1-1-1-1">
                                                     <div id="commentBar-1-1-1-1">
                                                         <span class="text-muted">From:
-                                                            <b>Anonymous</b>
-                                                            [02/02/2016] 
+                                                            Anonymous
+                                                            [Tue Feb 02 23:59:00 UTC 2016] 
                                                         </span>
                                                     </div> <!-- frComment Content -->
                                                     <div style="margin-left: 15px;" id="plainCommentText-1-1-1-1">Anonymous comment to feedback Question 2</div>
@@ -116,8 +116,8 @@ Multiline test.
                                                 <li class="list-group-item list-group-item-warning" id="responseCommentRow-1-1-1-2">
                                                     <div id="commentBar-1-1-1-2">
                                                         <span class="text-muted">From:
-                                                            <b>Anonymous</b>
-                                                            [03/02/2016] 
+                                                            Anonymous
+                                                            [Wed Feb 03 23:59:00 UTC 2016]
                                                         </span>
                                                     </div> <!-- frComment Content -->
                                                     <div style="margin-left: 15px;" id="plainCommentText-1-1-1-2">Instructor 2 comment to feedback Question 2 (Student 3 see this as anonymous comment)</div>

--- a/src/test/resources/pages/studentCommentsPageForStudent3.html
+++ b/src/test/resources/pages/studentCommentsPageForStudent3.html
@@ -107,7 +107,7 @@ Multiline test.
                                                     <div id="commentBar-1-1-1-1">
                                                         <span class="text-muted">From:
                                                             <b>Anonymous</b>
-                                                            on 02/02/2016 
+                                                            [02/02/2016] 
                                                         </span>
                                                     </div> <!-- frComment Content -->
                                                     <div style="margin-left: 15px;" id="plainCommentText-1-1-1-1">Anonymous comment to feedback Question 2</div>
@@ -117,7 +117,7 @@ Multiline test.
                                                     <div id="commentBar-1-1-1-2">
                                                         <span class="text-muted">From:
                                                             <b>Anonymous</b>
-                                                            on 03/02/2016 
+                                                            [03/02/2016] 
                                                         </span>
                                                     </div> <!-- frComment Content -->
                                                     <div style="margin-left: 15px;" id="plainCommentText-1-1-1-2">Instructor 2 comment to feedback Question 2 (Student 3 see this as anonymous comment)</div>

--- a/src/test/resources/pages/studentFeedbackResultsPageOpen.html
+++ b/src/test/resources/pages/studentFeedbackResultsPageOpen.html
@@ -78,18 +78,18 @@
                                                                         <td>
                                                                             <ul class="list-group comment-list">
                                                                                     
-                                                                                            <li class="list-group-item list-group-item-warning" id="">
-                                                                                                <div id="">
-                                                                                                    <span class="text-muted">From: SFResultsUiT.instr@gmail.tmt [01/03/2016] (last edited by SFResultsUiT.instr@gmail.tmt at 02/03/2016)</span>
+                                                                                            <li class="list-group-item list-group-item-warning" id="responseCommentRow-{*}">
+                                                                                                <div id="commentBar-{*}">
+                                                                                                    <span class="text-muted">From: SFResultsUiT.instr@gmail.tmt [Tue Mar 01 23:59:00 UTC 2016] (last edited by SFResultsUiT.instr@gmail.tmt at Wed Mar 02 23:59:00 UTC 2016)</span>
                                                                                                 </div>
-                                                                                                <div id="" style="margin-left: 15px;">Instructor first comment to Alice</div>
+                                                                                                <div id="plainCommentText-{*}" style="margin-left: 15px;">Instructor first comment to Alice</div>
                                                                                             </li>
                                                                                     
-                                                                                            <li class="list-group-item list-group-item-warning" id="">
-                                                                                                <div id="">
-                                                                                                    <span class="text-muted">From: SFResultsUiT.instr@gmail.tmt [02/03/2016] </span>
+                                                                                            <li class="list-group-item list-group-item-warning" id="responseCommentRow-{*}">
+                                                                                                <div id="commentBar-{*}">
+                                                                                                    <span class="text-muted">From: SFResultsUiT.instr@gmail.tmt [Wed Mar 02 23:59:00 UTC 2016] </span>
                                                                                                 </div>
-                                                                                                <div id="" style="margin-left: 15px;">Instructor second comment to Alice</div>
+                                                                                                <div id="plainCommentText-{*}" style="margin-left: 15px;">Instructor second comment to Alice</div>
                                                                                             </li>
                                                                                     
                                                                             </ul>

--- a/src/test/resources/pages/studentFeedbackResultsPageOpen.html
+++ b/src/test/resources/pages/studentFeedbackResultsPageOpen.html
@@ -80,7 +80,7 @@
                                                                                     
                                                                                             <li class="list-group-item list-group-item-warning" id="">
                                                                                                 <div id="">
-                                                                                                    <span class="text-muted">From: SFResultsUiT.instr@gmail.tmt [01/03/2016] </span>
+                                                                                                    <span class="text-muted">From: SFResultsUiT.instr@gmail.tmt [01/03/2016] (last edited by SFResultsUiT.instr@gmail.tmt at 02/03/2016)</span>
                                                                                                 </div>
                                                                                                 <div id="" style="margin-left: 15px;">Instructor first comment to Alice</div>
                                                                                             </li>

--- a/src/test/resources/pages/studentFeedbackResultsPageOpen.html
+++ b/src/test/resources/pages/studentFeedbackResultsPageOpen.html
@@ -78,14 +78,18 @@
                                                                         <td>
                                                                             <ul class="list-group comment-list">
                                                                                     
-                                                                                            <li class="list-group-item list-group-item-warning">
-                                                                                                <span class="text-muted">From: SFResultsUiT.instr@gmail.tmt [Tue Mar 01 23:59:00 UTC 2016]</span>
-                                                                                                <div>Instructor first comment to Alice</div>
+                                                                                            <li class="list-group-item list-group-item-warning" id="">
+                                                                                                <div id="">
+                                                                                                    <span class="text-muted">From: SFResultsUiT.instr@gmail.tmt [01/03/2016] </span>
+                                                                                                </div>
+                                                                                                <div id="" style="margin-left: 15px;">Instructor first comment to Alice</div>
                                                                                             </li>
                                                                                     
-                                                                                            <li class="list-group-item list-group-item-warning">
-                                                                                                <span class="text-muted">From: SFResultsUiT.instr@gmail.tmt [Wed Mar 02 23:59:00 UTC 2016]</span>
-                                                                                                <div>Instructor second comment to Alice</div>
+                                                                                            <li class="list-group-item list-group-item-warning" id="">
+                                                                                                <div id="">
+                                                                                                    <span class="text-muted">From: SFResultsUiT.instr@gmail.tmt [02/03/2016] </span>
+                                                                                                </div>
+                                                                                                <div id="" style="margin-left: 15px;">Instructor second comment to Alice</div>
                                                                                             </li>
                                                                                     
                                                                             </ul>

--- a/src/test/resources/pages/studentFeedbackResultsPageTeamToTeam.html
+++ b/src/test/resources/pages/studentFeedbackResultsPageTeamToTeam.html
@@ -78,18 +78,18 @@
                                                                         <td>
                                                                             <ul class="list-group comment-list">
                                                                                     
-                                                                                            <li class="list-group-item list-group-item-warning" id="">
-                                                                                                <div id="">
-                                                                                                    <span class="text-muted">From: SFResultsUiT.instr@gmail.tmt [01/03/2016] (last edited by SFResultsUiT.instr@gmail.tmt at 02/03/2016)</span>
+                                                                                            <li class="list-group-item list-group-item-warning" id="responseCommentRow-{*}">
+                                                                                                <div id="commentBar-{*}">
+                                                                                                    <span class="text-muted">From: SFResultsUiT.instr@gmail.tmt [Tue Mar 01 23:59:00 UTC 2016] (last edited by SFResultsUiT.instr@gmail.tmt at Wed Mar 02 23:59:00 UTC 2016)</span>
                                                                                                 </div>
-                                                                                                <div id="" style="margin-left: 15px;">Instructor first comment to Alice</div>
+                                                                                                <div id="plainCommentText-{*}" style="margin-left: 15px;">Instructor first comment to Alice</div>
                                                                                             </li>
                                                                                     
-                                                                                            <li class="list-group-item list-group-item-warning" id="">
-                                                                                                <div id="">
-                                                                                                    <span class="text-muted">From: SFResultsUiT.instr@gmail.tmt [02/03/2016] </span>
+                                                                                            <li class="list-group-item list-group-item-warning" id="responseCommentRow-{*}">
+                                                                                                <div id="commentBar-{*}">
+                                                                                                    <span class="text-muted">From: SFResultsUiT.instr@gmail.tmt [Wed Mar 02 23:59:00 UTC 2016] </span>
                                                                                                 </div>
-                                                                                                <div id="" style="margin-left: 15px;">Instructor second comment to Alice</div>
+                                                                                                <div id="plainCommentText-{*}" style="margin-left: 15px;">Instructor second comment to Alice</div>
                                                                                             </li>
                                                                                     
                                                                             </ul>

--- a/src/test/resources/pages/studentFeedbackResultsPageTeamToTeam.html
+++ b/src/test/resources/pages/studentFeedbackResultsPageTeamToTeam.html
@@ -80,7 +80,7 @@
                                                                                     
                                                                                             <li class="list-group-item list-group-item-warning" id="">
                                                                                                 <div id="">
-                                                                                                    <span class="text-muted">From: SFResultsUiT.instr@gmail.tmt [01/03/2016] </span>
+                                                                                                    <span class="text-muted">From: SFResultsUiT.instr@gmail.tmt [01/03/2016] (last edited by SFResultsUiT.instr@gmail.tmt at 02/03/2016)</span>
                                                                                                 </div>
                                                                                                 <div id="" style="margin-left: 15px;">Instructor first comment to Alice</div>
                                                                                             </li>

--- a/src/test/resources/pages/studentFeedbackResultsPageTeamToTeam.html
+++ b/src/test/resources/pages/studentFeedbackResultsPageTeamToTeam.html
@@ -78,14 +78,18 @@
                                                                         <td>
                                                                             <ul class="list-group comment-list">
                                                                                     
-                                                                                            <li class="list-group-item list-group-item-warning">
-                                                                                                <span class="text-muted">From: SFResultsUiT.instr@gmail.tmt [Tue Mar 01 23:59:00 UTC 2016]</span>
-                                                                                                <div>Instructor first comment to Alice</div>
+                                                                                            <li class="list-group-item list-group-item-warning" id="">
+                                                                                                <div id="">
+                                                                                                    <span class="text-muted">From: SFResultsUiT.instr@gmail.tmt [01/03/2016] </span>
+                                                                                                </div>
+                                                                                                <div id="" style="margin-left: 15px;">Instructor first comment to Alice</div>
                                                                                             </li>
                                                                                     
-                                                                                            <li class="list-group-item list-group-item-warning">
-                                                                                                <span class="text-muted">From: SFResultsUiT.instr@gmail.tmt [Wed Mar 02 23:59:00 UTC 2016]</span>
-                                                                                                <div>Instructor second comment to Alice</div>
+                                                                                            <li class="list-group-item list-group-item-warning" id="">
+                                                                                                <div id="">
+                                                                                                    <span class="text-muted">From: SFResultsUiT.instr@gmail.tmt [02/03/2016] </span>
+                                                                                                </div>
+                                                                                                <div id="" style="margin-left: 15px;">Instructor second comment to Alice</div>
                                                                                             </li>
                                                                                     
                                                                             </ul>

--- a/src/test/resources/pages/unregisteredStudentFeedbackResultsPageOpen.html
+++ b/src/test/resources/pages/unregisteredStudentFeedbackResultsPageOpen.html
@@ -84,7 +84,7 @@
                                                                                     
                                                                                             <li class="list-group-item list-group-item-warning" id="">
                                                                                                 <div id="">
-                                                                                                    <span class="text-muted">From: SFResultsUiT.instr@gmail.tmt [01/03/2016] </span>
+                                                                                                    <span class="text-muted">From: SFResultsUiT.instr@gmail.tmt [01/03/2016] (last edited by SFResultsUiT.instr@gmail.tmt at 02/03/2016)</span>
                                                                                                 </div>
                                                                                                 <div id="" style="margin-left: 15px;">Instructor first comment to Alice</div>
                                                                                             </li>

--- a/src/test/resources/pages/unregisteredStudentFeedbackResultsPageOpen.html
+++ b/src/test/resources/pages/unregisteredStudentFeedbackResultsPageOpen.html
@@ -82,18 +82,18 @@
                                                                         <td>
                                                                             <ul class="list-group comment-list">
                                                                                     
-                                                                                            <li class="list-group-item list-group-item-warning" id="">
-                                                                                                <div id="">
-                                                                                                    <span class="text-muted">From: SFResultsUiT.instr@gmail.tmt [01/03/2016] (last edited by SFResultsUiT.instr@gmail.tmt at 02/03/2016)</span>
+                                                                                            <li class="list-group-item list-group-item-warning" id="responseCommentRow-{*}">
+                                                                                                <div id="commentBar-{*}">
+                                                                                                    <span class="text-muted">From: SFResultsUiT.instr@gmail.tmt [Tue Mar 01 23:59:00 UTC 2016] (last edited by SFResultsUiT.instr@gmail.tmt at Wed Mar 02 23:59:00 UTC 2016)</span>
                                                                                                 </div>
-                                                                                                <div id="" style="margin-left: 15px;">Instructor first comment to Alice</div>
+                                                                                                <div id="plainCommentText-{*}" style="margin-left: 15px;">Instructor first comment to Alice</div>
                                                                                             </li>
                                                                                     
-                                                                                            <li class="list-group-item list-group-item-warning" id="">
-                                                                                                <div id="">
-                                                                                                    <span class="text-muted">From: SFResultsUiT.instr@gmail.tmt [02/03/2016] </span>
+                                                                                            <li class="list-group-item list-group-item-warning" id="responseCommentRow-{*}">
+                                                                                                <div id="commentBar-{*}">
+                                                                                                    <span class="text-muted">From: SFResultsUiT.instr@gmail.tmt [Wed Mar 02 23:59:00 UTC 2016] </span>
                                                                                                 </div>
-                                                                                                <div id="" style="margin-left: 15px;">Instructor second comment to Alice</div>
+                                                                                                <div id="plainCommentText-{*}" style="margin-left: 15px;">Instructor second comment to Alice</div>
                                                                                             </li>
                                                                                     
                                                                             </ul>

--- a/src/test/resources/pages/unregisteredStudentFeedbackResultsPageOpen.html
+++ b/src/test/resources/pages/unregisteredStudentFeedbackResultsPageOpen.html
@@ -82,14 +82,18 @@
                                                                         <td>
                                                                             <ul class="list-group comment-list">
                                                                                     
-                                                                                            <li class="list-group-item list-group-item-warning">
-                                                                                                <span class="text-muted">From: SFResultsUiT.instr@gmail.tmt [Tue Mar 01 23:59:00 UTC 2016]</span>
-                                                                                                <div>Instructor first comment to Alice</div>
+                                                                                            <li class="list-group-item list-group-item-warning" id="">
+                                                                                                <div id="">
+                                                                                                    <span class="text-muted">From: SFResultsUiT.instr@gmail.tmt [01/03/2016] </span>
+                                                                                                </div>
+                                                                                                <div id="" style="margin-left: 15px;">Instructor first comment to Alice</div>
                                                                                             </li>
                                                                                     
-                                                                                            <li class="list-group-item list-group-item-warning">
-                                                                                                <span class="text-muted">From: SFResultsUiT.instr@gmail.tmt [Wed Mar 02 23:59:00 UTC 2016]</span>
-                                                                                                <div>Instructor second comment to Alice</div>
+                                                                                            <li class="list-group-item list-group-item-warning" id="">
+                                                                                                <div id="">
+                                                                                                    <span class="text-muted">From: SFResultsUiT.instr@gmail.tmt [02/03/2016] </span>
+                                                                                                </div>
+                                                                                                <div id="" style="margin-left: 15px;">Instructor second comment to Alice</div>
                                                                                             </li>
                                                                                     
                                                                             </ul>


### PR DESCRIPTION
Fixes #3839 
So apparently this portion is repeated 8 times: twice in InstructorFeedbackResults (GRQ and RGQ view), twice in InstructorStudentRecords (feedback to and feedback from), once in InstructorSearch, once in InstructorComments, once in StudentFeedbackResults, once in StudentComments. This is an unacceptable amount of repetition.
Before JSTL can take care of that, some sort of standardization is needed, and that's what this PR is about.

Regressing HTMLs (there's going to be a handful) are going to be generated after all changes are ok.