### PR TITLE
Multiple String.prototype.contains() strewn across the app #3876

### DIFF
--- a/src/main/webapp/js/common.js
+++ b/src/main/webapp/js/common.js
@@ -610,3 +610,14 @@ function sanitizeForJs(string) {
     string = replaceAll(string, '\'', '\\\'');
     return string;
 }
+
+/**
+ * Polyfills the String.prototype.includes function finalized in ES6 for browsers that do not yet support
+ * the function.
+ */
+if (!String.prototype.includes) {
+    String.prototype.includes = function() {
+        'use strict';
+        return String.prototype.indexOf.apply(this, arguments) !== -1;
+    }
+}

--- a/src/main/webapp/js/contextualcomments.js
+++ b/src/main/webapp/js/contextualcomments.js
@@ -71,8 +71,6 @@ $(document).ready(function(){
 	
 	$("input[type=checkbox]").on( "click", visibilityOptionsHandler);
 	
-	String.prototype.contains = function(substr) { return this.indexOf(substr) != -1; };
-	
 	function visibilityOptionsHandler(e){
 		var visibilityOptions = [];
 		var _target = $(e.target);

--- a/src/main/webapp/js/contextualcomments.js
+++ b/src/main/webapp/js/contextualcomments.js
@@ -75,12 +75,12 @@ $(document).ready(function(){
 		var visibilityOptions = [];
 		var _target = $(e.target);
 		
-		if (_target.prop("class").contains("answerCheckbox") && !_target.prop("checked")) {
+		if (_target.prop("class").includes("answerCheckbox") && !_target.prop("checked")) {
     		_target.parent().parent().find("input[class*=giverCheckbox]").prop("checked", false);
     		_target.parent().parent().find("input[class*=recipientCheckbox]").prop("checked", false);
     	}
-    	if ((_target.prop("class").contains("giverCheckbox") || 
-    			_target.prop("class").contains("recipientCheckbox")) && _target.prop("checked")) {
+    	if ((_target.prop("class").includes("giverCheckbox") || 
+    			_target.prop("class").includes("recipientCheckbox")) && _target.prop("checked")) {
     		_target.parent().parent().find("input[class*=answerCheckbox]").prop("checked", true);
     	}
 		

--- a/src/main/webapp/js/feedbackResponseComments.js
+++ b/src/main/webapp/js/feedbackResponseComments.js
@@ -204,12 +204,12 @@ function registerResponseCommentCheckboxEvent() {
         var visibilityOptions = [];
         var _target = $(e.target);
         
-        if (_target.prop("class").contains("answerCheckbox") && !_target.prop("checked")) {
+        if (_target.prop("class").includes("answerCheckbox") && !_target.prop("checked")) {
             _target.parent().parent().find("input[class*=giverCheckbox]").prop("checked", false);
             _target.parent().parent().find("input[class*=recipientCheckbox]").prop("checked", false);
         }
-        if ((_target.prop("class").contains("giverCheckbox") || 
-             _target.prop("class").contains("recipientCheckbox")) &&
+        if ((_target.prop("class").includes("giverCheckbox") || 
+             _target.prop("class").includes("recipientCheckbox")) &&
              _target.prop("checked")) {
             _target.parent().parent().find("input[class*=answerCheckbox]").prop("checked", true);
         }
@@ -419,12 +419,12 @@ function registerCheckboxEventForVisibilityOptions() {
         var visibilityOptions = [];
         var _target = $(e.target);
         
-        if (_target.prop("class").contains("answerCheckbox") && !_target.prop("checked")) {
+        if (_target.prop("class").includes("answerCheckbox") && !_target.prop("checked")) {
             _target.parent().parent().find("input[class*=giverCheckbox]").prop("checked", false);
             _target.parent().parent().find("input[class*=recipientCheckbox]").prop("checked", false);
         }
-        if ((_target.prop("class").contains("giverCheckbox") || 
-             _target.prop("class").contains("recipientCheckbox")) &&
+        if ((_target.prop("class").includes("giverCheckbox") || 
+             _target.prop("class").includes("recipientCheckbox")) &&
              _target.prop("checked")) {
             _target.parent().parent().find("input[class*=answerCheckbox]").prop("checked", true);
         }

--- a/src/main/webapp/js/feedbackResponseComments.js
+++ b/src/main/webapp/js/feedbackResponseComments.js
@@ -192,10 +192,6 @@ function registerResponseCommentsEvent() {
     $("form[class*='responseCommentEditForm'] > div > a[id^='button_save_comment_for_edit']").click(editCommentHandler);
     $("form[class*='responseCommentDeleteForm'] > a[id^='commentdelete']").click(deleteCommentHandler);
     
-    String.prototype.contains = function(substr) {
-        return this.indexOf(substr) != -1;
-    };
-    
     registerResponseCommentCheckboxEvent();
     
     $("div[id^=plainCommentText]").css("margin-left","15px");

--- a/src/main/webapp/js/instructorStudentList.js
+++ b/src/main/webapp/js/instructorStudentList.js
@@ -238,13 +238,6 @@ function checkAllTeamsSelected() {
 }
 
 /**
- * Check whether a string contains the substr or not
- */
-String.prototype.contains = function(substr) {
-    return this.indexOf(substr) != -1;
-};
-
-/**
  * Go to the url with appended param and value pair
  */
 function gotoUrlWithParam(url, param, value) {

--- a/src/main/webapp/js/instructorStudentList.js
+++ b/src/main/webapp/js/instructorStudentList.js
@@ -242,11 +242,11 @@ function checkAllTeamsSelected() {
  */
 function gotoUrlWithParam(url, param, value) {
     var paramValuePair = param + '=' + value;
-    if (!url.contains('?')) {
+    if (!url.includes('?')) {
         window.location.href = url + '?' + paramValuePair;
-    } else if (!url.contains(param)) {
+    } else if (!url.includes(param)) {
         window.location.href = url + '&' + paramValuePair;
-    } else if (url.contains(paramValuePair)) {
+    } else if (url.includes(paramValuePair)) {
         window.location.href = url;
     } else {
         var urlWithoutParam = removeParamInUrl(url, param);

--- a/src/main/webapp/js/omniComment.js
+++ b/src/main/webapp/js/omniComment.js
@@ -222,7 +222,7 @@ $(document).ready(function(){
     	
     	//to show feedback question + feedback session panel
     	//if not all list elements are hidden within fbResponse, then show fbResponse
-    	if($(comment).prop("class").toString().contains(classNameForCommentsInFeedbackResponse)){
+    	if($(comment).prop("class").toString().includes(classNameForCommentsInFeedbackResponse)){
             if($(comment).parent().find('li[style*="display: none"]').length != $(comment).parent().find('li').length){
             	var commentListRegionForFeedbackResponse = $(comment).parent().parent().parent();
             	//a fbResponse in instructorCommentsPage (html) is made up of 4 rows as the followings
@@ -246,7 +246,7 @@ $(document).ready(function(){
             }
     	}
         //to show student comments (only works for Giver filter)
-        if ($(comment).prop("class").toString().contains(classNameForCommentsInStudentRecords)){
+        if ($(comment).prop("class").toString().includes(classNameForCommentsInStudentRecords)){
         	var studentCommentPanel = $(comment).parent().parent().parent();
         	var studentCommentPanelBody = $(comment).parent();
         	//if not all student comments are hidden, then show the student comments panel
@@ -265,7 +265,7 @@ $(document).ready(function(){
     	
     	//to hide feedback question + feedback session panel
     	//if all list elements are hidden within fbResponse, then hide fbResponse
-    	if($(comment).prop("class").toString().contains(classNameForCommentsInFeedbackResponse)){
+    	if($(comment).prop("class").toString().includes(classNameForCommentsInFeedbackResponse)){
             if($(comment).parent().find('li[style*="display: none"]').length == $(comment).parent().find('li').length){
             	var commentListRegionForFeedbackResponse = $(comment).parent().parent().parent();
             	//a fbResponse in instructorCommentsPage (html) is made up of 4 rows as the followings
@@ -289,7 +289,7 @@ $(document).ready(function(){
             }
     	}
     	//to hide student comments
-    	if ($(comment).prop("class").toString().contains(classNameForCommentsInStudentRecords)){
+    	if ($(comment).prop("class").toString().includes(classNameForCommentsInStudentRecords)){
         	var studentCommentPanel = $(comment).parent().parent().parent();
         	var studentCommentPanelBody = $(comment).parent();
         	//if all student comments are hidden, then hide the student comments panel
@@ -315,11 +315,11 @@ $(document).ready(function(){
      */
     function gotoUrlWithParam(url, param, value){
         var paramValuePair = param + "=" + value;
-        if(!url.contains("?")){
+        if(!url.includes("?")){
             window.location.href = url + "?" + paramValuePair;
-        } else if(!url.contains(param)){
+        } else if(!url.includes(param)){
             window.location.href = url + "&" + paramValuePair;
-        } else if(url.contains(paramValuePair)){
+        } else if(url.includes(paramValuePair)){
             window.location.href = url;
         } else{
             var urlWithoutParam = removeParamInUrl(url, param);
@@ -357,12 +357,12 @@ $(document).ready(function(){
     	var visibilityOptions = [];
     	var _target = $(e.target);
     	
-    	if (_target.prop("class").contains("answerCheckbox") && !_target.prop("checked")) {
+    	if (_target.prop("class").includes("answerCheckbox") && !_target.prop("checked")) {
     		_target.parent().parent().find("input[class*=giverCheckbox]").prop("checked", false);
     		_target.parent().parent().find("input[class*=recipientCheckbox]").prop("checked", false);
     	}
-    	if ((_target.prop("class").contains("giverCheckbox") || 
-    			_target.prop("class").contains("recipientCheckbox")) && _target.prop("checked")) {
+    	if ((_target.prop("class").includes("giverCheckbox") || 
+    			_target.prop("class").includes("recipientCheckbox")) && _target.prop("checked")) {
     		_target.parent().parent().find("input[class*=answerCheckbox]").prop("checked", true);
     	}
     	

--- a/src/main/webapp/js/omniComment.js
+++ b/src/main/webapp/js/omniComment.js
@@ -340,11 +340,6 @@ $(document).ready(function(){
         return urlBeforeParam + urlAfterParamValue;
     }
     
-    /**
-     * Check whether a string contains the substr or not
-     */
-    String.prototype.contains = function(substr) { return this.indexOf(substr) != -1; };
-    
     $('a[id^="visibility-options-trigger"]').click(function(){
     	var visibilityOptions = $(this).parent().next();
 		if(visibilityOptions.is(':visible')){


### PR DESCRIPTION
Fixes #3876 

This is a safe way of ensuring that we have a functionality we need in older browsers that may not support ES6 but also use the native (already included) function on newer browsers.

This also helps to prevent confusion by ensuring that all strings have the same behavior rather than it having a certain behavior in some context and then not in some other context.