### PR TITLE
Instructor Course Details Page shows table header with no body if there are no students #3933

### DIFF
--- a/src/main/java/teammates/ui/controller/InstructorCourseDetailsPageAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorCourseDetailsPageAction.java
@@ -49,7 +49,7 @@ public class InstructorCourseDetailsPageAction extends Action {
         
         data.init(instructor, courseDetails, instructors, students);
         
-        if (students.size() == 0) {
+        if (students.isEmpty()) {
             statusToUser.add(Const.StatusMessages.INSTRUCTOR_COURSE_EMPTY);
         }
         

--- a/src/main/java/teammates/ui/controller/InstructorCourseDetailsPageAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorCourseDetailsPageAction.java
@@ -49,6 +49,10 @@ public class InstructorCourseDetailsPageAction extends Action {
         
         data.init(instructor, courseDetails, instructors, students);
         
+        if (students.size() == 0) {
+            statusToUser.add(Const.StatusMessages.INSTRUCTOR_COURSE_EMPTY);
+        }
+        
         statusToAdmin = "instructorCourseDetails Page Load<br>" 
                         + "Viewing Course Details for Course <span class=\"bold\">[" + courseId + "]</span>";
         

--- a/src/main/webapp/WEB-INF/tags/instructor/course/studentsTable.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/course/studentsTable.tag
@@ -67,4 +67,9 @@
             <% out.flush(); %>
         </c:if>
     </c:forEach>
+    <c:if test="${empty studentsTable.rows}">
+        <tr>
+            <td colspan="5"><center><b>No student is enrolled.</b></center></td>
+        </tr>
+    </c:if>
 </table>

--- a/src/main/webapp/WEB-INF/tags/instructor/course/studentsTable.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/course/studentsTable.tag
@@ -69,7 +69,13 @@
     </c:forEach>
     <c:if test="${empty studentsTable.rows}">
         <tr>
-            <td colspan="5"><center><b>No student is enrolled.</b></center></td>
+            <c:if test="${hasSection}">
+                <td></td>
+            </c:if>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
         </tr>
     </c:if>
 </table>

--- a/src/test/java/teammates/test/cases/ui/InstructorCourseDetailsPageActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/InstructorCourseDetailsPageActionTest.java
@@ -73,7 +73,7 @@ public class InstructorCourseDetailsPageActionTest extends BaseActionTest {
         assertEquals(Const.ViewURIs.INSTRUCTOR_COURSE_DETAILS + "?error=false&user=idOfInstructor4", 
                      pageResult.getDestinationWithParams());
         assertEquals(false, pageResult.isError);
-        assertEquals("", pageResult.getStatusMessage());
+        assertEquals(Const.StatusMessages.INSTRUCTOR_COURSE_EMPTY, pageResult.getStatusMessage());
         
         pageData = (InstructorCourseDetailsPageData) pageResult.data;
         assertEquals(1, pageData.getInstructors().size());

--- a/src/test/resources/pages/InstructorCourseDetailsEmptyCourse.html
+++ b/src/test/resources/pages/InstructorCourseDetailsEmptyCourse.html
@@ -438,8 +438,8 @@
         <div class="alert alert-warning" id="statusMessage">
                There are no students in this course
             </div>
-            <script type="text&#x2f;javascript">
-               document.getElementById(&#39;statusMessage&#39;).scrollIntoView();
+            <script type="text/javascript">
+               document.getElementById('statusMessage').scrollIntoView();
             </script>
     
 

--- a/src/test/resources/pages/InstructorCourseDetailsEmptyCourse.html
+++ b/src/test/resources/pages/InstructorCourseDetailsEmptyCourse.html
@@ -435,7 +435,12 @@
 
     
     
-        <div style="display: none;" id="statusMessage"></div>
+        <div class="alert alert-warning" id="statusMessage">
+               There are no students in this course
+            </div>
+            <script type="text&#x2f;javascript">
+               document.getElementById(&#39;statusMessage&#39;).scrollIntoView();
+            </script>
     
 
     <br />
@@ -466,7 +471,10 @@
         </tr>
     </thead>
     <tr>
-        <td colspan="5"><center><b>No student is enrolled.</b></center></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
     </tr>
     
 </table>

--- a/src/test/resources/pages/InstructorCourseDetailsEmptyCourse.html
+++ b/src/test/resources/pages/InstructorCourseDetailsEmptyCourse.html
@@ -465,7 +465,9 @@
             </th>
         </tr>
     </thead>
-    
+    <tr>
+        <td colspan="5"><center><b>No student is enrolled.</b></center></td>
+    </tr>
     
 </table>
     <br />


### PR DESCRIPTION
Fix #3933

@damithc Does this look good to you?

![empty table](https://cloud.githubusercontent.com/assets/8078323/8591075/e315c7c2-2660-11e5-85e5-2d23bb365651.png)
