### PR TITLE
Remove unnecessary System.out.printlns from Java files #3942

### DIFF
--- a/src/main/java/teammates/common/util/FieldValidator.java
+++ b/src/main/java/teammates/common/util/FieldValidator.java
@@ -805,7 +805,6 @@ public class FieldValidator {
         String sanitizedValue = Sanitizer.sanitizeForHtml(value);
         
         if (value.isEmpty()) {
-            System.out.println(String.format(GOOGLE_ID_ERROR_MESSAGE, value, REASON_EMPTY));
             return String.format(GOOGLE_ID_ERROR_MESSAGE, value, REASON_EMPTY);
         } else if (!isTrimmed(value)) {
             return String.format(WHITESPACE_ONLY_OR_EXTRA_WHITESPACE_ERROR_MESSAGE, "googleID");

--- a/src/main/java/teammates/common/util/Url.java
+++ b/src/main/java/teammates/common/util/Url.java
@@ -123,10 +123,4 @@ public class Url {
         return urlString;
     }
 
-    public static void main(String[] args) {
-        System.out.println(new Url("http://teammates.com/page/instructorHome?user=abc").get(Const.ParamsNames.USER_ID));
-        System.out.println(new Url("http://teammates.com/page/instructorHome?user=abc&course=course1").get(Const.ParamsNames.USER_ID));
-        System.out.println(new Url ("http://teammates.com/page/instructorHome?error=true&user=abc&course=course1").get(Const.ParamsNames.USER_ID));
-    }
-
 }

--- a/src/test/java/teammates/test/cases/common/SessionAttributesTest.java
+++ b/src/test/java/teammates/test/cases/common/SessionAttributesTest.java
@@ -51,7 +51,6 @@ public class SessionAttributesTest extends BaseTestCase {
         
         Collections.sort(testList, SessionAttributes.ASCENDING_ORDER);
         for(int i = 0; i < testList.size(); i++){
-            System.out.println(i);
             AssertJUnit.assertEquals(expected.get(i), testList.get(i));
         }
         
@@ -65,7 +64,6 @@ public class SessionAttributesTest extends BaseTestCase {
         
         Collections.sort(testList, SessionAttributes.DESCENDING_ORDER);
         for(int i = 0; i < testList.size(); i++){
-            System.out.println(i);
             AssertJUnit.assertEquals(expected.get(i), testList.get(i));
         }
     }

--- a/src/test/java/teammates/test/cases/logic/FeedbackSessionsLogicTest.java
+++ b/src/test/java/teammates/test/cases/logic/FeedbackSessionsLogicTest.java
@@ -1189,8 +1189,6 @@ public class FeedbackSessionsLogicTest extends BaseComponentUsingTaskQueueTestCa
                 session.feedbackSessionName, session.courseId, instructor.email);
         
 
-        System.out.println(export);
-        
         /*This is how the export should look like
         =======================================
         Course,"FSQTT.idOfTypicalCourse1"
@@ -1265,8 +1263,6 @@ public class FeedbackSessionsLogicTest extends BaseComponentUsingTaskQueueTestCa
         export = fsLogic.getFeedbackSessionResultsSummaryAsCsv(
                 session.feedbackSessionName, session.courseId, instructor.email);
 
-        System.out.println(export);
-        
         /*This is how the export should look like
         =======================================
         Course,"FSQTT.idOfTypicalCourse1"
@@ -1344,8 +1340,6 @@ public class FeedbackSessionsLogicTest extends BaseComponentUsingTaskQueueTestCa
         export = fsLogic.getFeedbackSessionResultsSummaryAsCsv(
                 session.feedbackSessionName, session.courseId, instructor.email);
         
-        System.out.println(export);
-        
         /*This is how the export should look like
         =======================================
         Course,"FSQTT.idOfTypicalCourse1"
@@ -1421,8 +1415,6 @@ public class FeedbackSessionsLogicTest extends BaseComponentUsingTaskQueueTestCa
         
         export = fsLogic.getFeedbackSessionResultsSummaryAsCsv(
                 session.feedbackSessionName, session.courseId, instructor.email);
-        
-        System.out.println(export);
         
         /*This is how the export should look like
         =======================================
@@ -1537,7 +1529,6 @@ public class FeedbackSessionsLogicTest extends BaseComponentUsingTaskQueueTestCa
                 session.feedbackSessionName, session.courseId, instructor.email);
         
         exportLines = export.split(Const.EOL);
-        System.out.println(export);
         assertEquals(22, exportLines.length);
         assertEquals(exportLines[0], "Course,\"" + session.courseId + "\"");
         assertEquals(exportLines[1], "Session Name,\"" + session.feedbackSessionName + "\"");
@@ -1549,8 +1540,6 @@ public class FeedbackSessionsLogicTest extends BaseComponentUsingTaskQueueTestCa
         
         export = fsLogic.getFeedbackSessionResultsSummaryAsCsv(
                 session.feedbackSessionName, session.courseId, instructor.email);
-        
-        System.out.println(export);
         
         /*This is how the export should look like
         =======================================
@@ -1618,8 +1607,6 @@ public class FeedbackSessionsLogicTest extends BaseComponentUsingTaskQueueTestCa
         
         export = fsLogic.getFeedbackSessionResultsSummaryAsCsv(
                 session.feedbackSessionName, session.courseId, instructor.email);
-        
-        System.out.println(export);
         
         /*This is how the export should look like
         =======================================

--- a/src/test/java/teammates/test/cases/logic/FeedbackSessionsLogicTest.java
+++ b/src/test/java/teammates/test/cases/logic/FeedbackSessionsLogicTest.java
@@ -1189,6 +1189,8 @@ public class FeedbackSessionsLogicTest extends BaseComponentUsingTaskQueueTestCa
                 session.feedbackSessionName, session.courseId, instructor.email);
         
 
+        System.out.println(export);
+        
         /*This is how the export should look like
         =======================================
         Course,"FSQTT.idOfTypicalCourse1"
@@ -1263,6 +1265,8 @@ public class FeedbackSessionsLogicTest extends BaseComponentUsingTaskQueueTestCa
         export = fsLogic.getFeedbackSessionResultsSummaryAsCsv(
                 session.feedbackSessionName, session.courseId, instructor.email);
 
+        System.out.println(export);
+        
         /*This is how the export should look like
         =======================================
         Course,"FSQTT.idOfTypicalCourse1"
@@ -1340,6 +1344,8 @@ public class FeedbackSessionsLogicTest extends BaseComponentUsingTaskQueueTestCa
         export = fsLogic.getFeedbackSessionResultsSummaryAsCsv(
                 session.feedbackSessionName, session.courseId, instructor.email);
         
+        System.out.println(export);
+        
         /*This is how the export should look like
         =======================================
         Course,"FSQTT.idOfTypicalCourse1"
@@ -1415,6 +1421,8 @@ public class FeedbackSessionsLogicTest extends BaseComponentUsingTaskQueueTestCa
         
         export = fsLogic.getFeedbackSessionResultsSummaryAsCsv(
                 session.feedbackSessionName, session.courseId, instructor.email);
+        
+        System.out.println(export);
         
         /*This is how the export should look like
         =======================================
@@ -1529,6 +1537,7 @@ public class FeedbackSessionsLogicTest extends BaseComponentUsingTaskQueueTestCa
                 session.feedbackSessionName, session.courseId, instructor.email);
         
         exportLines = export.split(Const.EOL);
+        System.out.println(export);
         assertEquals(22, exportLines.length);
         assertEquals(exportLines[0], "Course,\"" + session.courseId + "\"");
         assertEquals(exportLines[1], "Session Name,\"" + session.feedbackSessionName + "\"");
@@ -1540,6 +1549,8 @@ public class FeedbackSessionsLogicTest extends BaseComponentUsingTaskQueueTestCa
         
         export = fsLogic.getFeedbackSessionResultsSummaryAsCsv(
                 session.feedbackSessionName, session.courseId, instructor.email);
+        
+        System.out.println(export);
         
         /*This is how the export should look like
         =======================================
@@ -1607,6 +1618,8 @@ public class FeedbackSessionsLogicTest extends BaseComponentUsingTaskQueueTestCa
         
         export = fsLogic.getFeedbackSessionResultsSummaryAsCsv(
                 session.feedbackSessionName, session.courseId, instructor.email);
+        
+        System.out.println(export);
         
         /*This is how the export should look like
         =======================================

--- a/src/test/java/teammates/test/cases/ui/InstructorFeedbackResultsDownloadActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/InstructorFeedbackResultsDownloadActionTest.java
@@ -172,7 +172,6 @@ public class InstructorFeedbackResultsDownloadActionTest extends BaseActionTest 
         full testing of file content is 
         in FeedbackSessionsLogicTest.testGetFeedbackSessionResultsSummaryAsCsv()
         */
-        // System.out.println(fileContent); // commented out. why do we need this?
         
         String[] exportLines = fileContent.split(Const.EOL);
         assertEquals("Course,\"" + session.courseId + "\"", 

--- a/src/test/java/teammates/test/cases/ui/InstructorFeedbackResultsDownloadActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/InstructorFeedbackResultsDownloadActionTest.java
@@ -135,6 +135,7 @@ public class InstructorFeedbackResultsDownloadActionTest extends BaseActionTest 
         full testing of file content is 
         in FeedbackSessionsLogicTest.testGetFeedbackSessionResultsSummaryAsCsv()
         */
+        System.out.println(fileContent);
 
         String[] exportLines = fileContent.split(Const.EOL);
         assertEquals("Course,\"" + session.courseId + "\"",
@@ -172,6 +173,7 @@ public class InstructorFeedbackResultsDownloadActionTest extends BaseActionTest 
         full testing of file content is 
         in FeedbackSessionsLogicTest.testGetFeedbackSessionResultsSummaryAsCsv()
         */
+        System.out.println(fileContent);
         
         String[] exportLines = fileContent.split(Const.EOL);
         assertEquals("Course,\"" + session.courseId + "\"", 
@@ -210,6 +212,7 @@ public class InstructorFeedbackResultsDownloadActionTest extends BaseActionTest 
         full testing of file content is 
         in FeedbackSessionsLogicTest.testGetFeedbackSessionResultsSummaryAsCsv()
         */
+        System.out.println(fileContent);
         
         String[] exportLines = fileContent.split(Const.EOL);
         assertEquals("Course,\"" + session.courseId + "\"", 

--- a/src/test/java/teammates/test/cases/ui/InstructorFeedbackSubmissionEditPageActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/InstructorFeedbackSubmissionEditPageActionTest.java
@@ -113,10 +113,6 @@ public class InstructorFeedbackSubmissionEditPageActionTest extends BaseActionTe
         a = getAction(submissionParams);
         RedirectResult rr = (RedirectResult) a.executeAndPostProcess();
 
-        System.out.println(rr.getDestinationWithParams());
-        System.out.println(rr.isError);
-        System.out.println(rr.getStatusMessage());
-
         assertEquals(Const.ActionURIs.INSTRUCTOR_HOME_PAGE + "?error=false"
                      + "&" + Const.ParamsNames.USER_ID + "=" + instructor.googleId,
                      rr.getDestinationWithParams());

--- a/src/test/java/teammates/test/cases/ui/browsertests/InstructorFeedbackEditPageUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/InstructorFeedbackEditPageUiTest.java
@@ -448,16 +448,6 @@ public class InstructorFeedbackEditPageUiTest extends BaseUiTestCase {
         assertNull(BackDoor.getFeedbackSession(courseId, feedbackSessionName));
     }
 
-    public static void printTestClassHeader() {
-        print("[============================="
-              + Thread.currentThread().getStackTrace()[2].getClassName()
-              + "=============================]");
-    }
-
-    protected static void print(String message) {
-        System.out.println(message);
-    }
-
     private static InstructorFeedbackEditPage getFeedbackEditPage() {
         Url feedbackPageLink = createUrl(Const.ActionURIs.INSTRUCTOR_FEEDBACK_EDIT_PAGE)
                                     .withUserId(instructorId)


### PR DESCRIPTION
Fixes #3942 
Also added some `System.out.println`s for the ones to check for file content.