### PR TITLE
Generic page / tag for FeedbackResults pages.

### DIFF
--- a/src/main/webapp/WEB-INF/tags/instructor/results/byGiverQuestionRecipient.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/results/byGiverQuestionRecipient.tag
@@ -7,9 +7,7 @@
 <%@ attribute name="showAll" type="java.lang.Boolean" required="true" %>
 <%@ attribute name="shouldCollapsed" type="java.lang.Boolean" required="true" %>
 
-<jsp:include page="<%=Const.ViewURIs.INSTRUCTOR_FEEDBACK_RESULTS_TOP%>" />
     <br>
     <c:forEach items="${data.sectionPanels}" var="sectionPanel" varStatus="i">
         <results:sectionPanel showAll="${showAll}" sectionPanel="${sectionPanel.value}" shouldCollapsed="${shouldCollapsed}" sectionIndex="${i.index}" courseId="${data.courseId}" feedbackSessionName="${data.feedbackSessionName}"/>
     </c:forEach>
-<jsp:include page="<%=Const.ViewURIs.INSTRUCTOR_FEEDBACK_RESULTS_BOTTOM%>" />

--- a/src/main/webapp/WEB-INF/tags/instructor/results/byQuestionResults.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/results/byQuestionResults.tag
@@ -8,11 +8,8 @@
 <%@ attribute name="showAll" type="java.lang.Boolean" required="true" %>
 <%@ attribute name="shouldCollapsed" type="java.lang.Boolean" required="true" %>
 
-<jsp:include page="<%=Const.ViewURIs.INSTRUCTOR_FEEDBACK_RESULTS_TOP%>" />
 <br>
 
 <c:forEach items="${data.questionPanels}" var="questionPanel" varStatus="i">
     <results:questionPanel questionIndex="${i.index}" showAll="${showAll}" questionPanel="${questionPanel}" shouldCollapsed="${shouldCollapsed}"/>
 </c:forEach>
-
-<jsp:include page="<%=Const.ViewURIs.INSTRUCTOR_FEEDBACK_RESULTS_BOTTOM%>" />

--- a/src/main/webapp/WEB-INF/tags/instructor/results/resultsPage.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/results/resultsPage.tag
@@ -1,6 +1,21 @@
-<%@ tag description="instructorFeedbackResults - General Page" %>
+<%@ tag description="Generic InstructorFeedbackResults Page" %>
 <%@ tag import="teammates.common.util.Const" %>
-
-<jsp:include page="<%=Const.ViewURIs.INSTRUCTOR_FEEDBACK_RESULTS_TOP%>" />
-<jsp:doBody />
-<jsp:include page="<%=Const.ViewURIs.INSTRUCTOR_FEEDBACK_RESULTS_BOTTOM%>" />
+<%@ taglib tagdir="/WEB-INF/tags/instructor" prefix="ti" %>
+<%@ attribute name="pageTitle" required="true" %>
+<%@ attribute name="bodyTitle" required="true" %>
+<%@ attribute name="data" type="teammates.ui.controller.InstructorFeedbackResultsPageData" required="true" %>
+<%@ attribute name="jsIncludes" %>
+<ti:instructorPage pageTitle="${pageTitle}" bodyTitle="${bodyTitle}">
+    <jsp:attribute name="jsIncludes">
+        <script type="text/javascript" src="/js/instructor.js"></script>
+        <script type="text/javascript" src="/js/instructorFeedbackResults.js"></script>
+        <script type="text/javascript" src="/js/instructorFeedbackResultsAjaxResponseRate.js"></script>
+        <script type="text/javascript" src="/js/additionalQuestionInfo.js"></script>
+        ${jsIncludes}
+    </jsp:attribute>
+    <jsp:body>
+        <jsp:include page="<%=Const.ViewURIs.INSTRUCTOR_FEEDBACK_RESULTS_TOP%>" />
+        <jsp:doBody />
+        <jsp:include page="<%=Const.ViewURIs.INSTRUCTOR_FEEDBACK_RESULTS_BOTTOM%>" />
+    </jsp:body>
+</ti:instructorPage>

--- a/src/main/webapp/WEB-INF/tags/instructor/results/resultsPage.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/results/resultsPage.tag
@@ -1,0 +1,6 @@
+<%@ tag description="instructorFeedbackResults - General Page" %>
+<%@ tag import="teammates.common.util.Const" %>
+
+<jsp:include page="<%=Const.ViewURIs.INSTRUCTOR_FEEDBACK_RESULTS_TOP%>" />
+<jsp:doBody />
+<jsp:include page="<%=Const.ViewURIs.INSTRUCTOR_FEEDBACK_RESULTS_BOTTOM%>" />

--- a/src/main/webapp/jsp/instructorFeedbackResultsByGiverQuestionRecipient.jsp
+++ b/src/main/webapp/jsp/instructorFeedbackResultsByGiverQuestionRecipient.jsp
@@ -1,19 +1,11 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
-<%@ taglib tagdir="/WEB-INF/tags" prefix="t" %>
-<%@ taglib tagdir="/WEB-INF/tags/instructor" prefix="ti" %>
 <%@ taglib tagdir="/WEB-INF/tags/instructor/results" prefix="results" %>
 <c:set var="jsIncludes">    
-    <script type="text/javascript" src="/js/instructor.js"></script>
-    <script type="text/javascript" src="/js/instructorFeedbackResults.js"></script>
     <script type="text/javascript" src="/js/instructorFeedbackResultsAjaxByGQR.js"></script>
-    <script type="text/javascript" src="/js/instructorFeedbackResultsAjaxResponseRate.js"></script>
-    <script type="text/javascript" src="/js/additionalQuestionInfo.js"></script>
 </c:set>
 
-<ti:instructorPage pageTitle="TEAMMATES - Feedback Session Results" bodyTitle="Session Results" jsIncludes="${jsIncludes}">
-    <results:resultsPage>
-        <results:byGiverQuestionRecipient showAll="${data.bundle.complete}" shouldCollapsed="${data.shouldCollapsed}" />
-    </results:resultsPage>    
-</ti:instructorPage>
+<results:resultsPage pageTitle="TEAMMATES - Feedback Session Results" bodyTitle="Session Results" jsIncludes="${jsIncludes}" data="${data}">
+    <results:byGiverQuestionRecipient showAll="${data.bundle.complete}" shouldCollapsed="${data.shouldCollapsed}" />
+</results:resultsPage>

--- a/src/main/webapp/jsp/instructorFeedbackResultsByGiverQuestionRecipient.jsp
+++ b/src/main/webapp/jsp/instructorFeedbackResultsByGiverQuestionRecipient.jsp
@@ -13,5 +13,7 @@
 </c:set>
 
 <ti:instructorPage pageTitle="TEAMMATES - Feedback Session Results" bodyTitle="Session Results" jsIncludes="${jsIncludes}">
-    <results:byGiverQuestionRecipient showAll="${data.bundle.complete}" shouldCollapsed="${data.shouldCollapsed}" />    
+    <results:resultsPage>
+        <results:byGiverQuestionRecipient showAll="${data.bundle.complete}" shouldCollapsed="${data.shouldCollapsed}" />
+    </results:resultsPage>    
 </ti:instructorPage>

--- a/src/main/webapp/jsp/instructorFeedbackResultsByQuestion.jsp
+++ b/src/main/webapp/jsp/instructorFeedbackResultsByQuestion.jsp
@@ -1,19 +1,11 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
-<%@ taglib tagdir="/WEB-INF/tags" prefix="t" %>
-<%@ taglib tagdir="/WEB-INF/tags/instructor" prefix="ti" %>
 <%@ taglib tagdir="/WEB-INF/tags/instructor/results" prefix="results" %>
 <c:set var="jsIncludes">    
-    <script type="text/javascript" src="/js/instructor.js"></script>
-    <script type="text/javascript" src="/js/instructorFeedbackResults.js"></script>
     <script type="text/javascript" src="/js/instructorFeedbackResultsAjaxByQuestion.js"></script>
-    <script type="text/javascript" src="/js/instructorFeedbackResultsAjaxResponseRate.js"></script>
-    <script type="text/javascript" src="/js/additionalQuestionInfo.js"></script>
 </c:set>
 
-<ti:instructorPage pageTitle="TEAMMATES - Feedback Session Results" bodyTitle="Session Results" jsIncludes="${jsIncludes}">
-    <results:resultsPage>
-        <results:byQuestionResults showAll="${data.bundle.complete}" shouldCollapsed="${data.shouldCollapsed}" data="${data}" />
-    </results:resultsPage>    
-</ti:instructorPage>
+<results:resultsPage pageTitle="TEAMMATES - Feedback Session Results" bodyTitle="Session Results" jsIncludes="${jsIncludes}" data="${data}">
+    <results:byQuestionResults showAll="${data.bundle.complete}" shouldCollapsed="${data.shouldCollapsed}" data="${data}" />    
+</results:resultsPage>

--- a/src/main/webapp/jsp/instructorFeedbackResultsByQuestion.jsp
+++ b/src/main/webapp/jsp/instructorFeedbackResultsByQuestion.jsp
@@ -13,5 +13,7 @@
 </c:set>
 
 <ti:instructorPage pageTitle="TEAMMATES - Feedback Session Results" bodyTitle="Session Results" jsIncludes="${jsIncludes}">
-    <results:byQuestionResults showAll="${data.bundle.complete}" shouldCollapsed="${data.shouldCollapsed}" data="${data}" />    
+    <results:resultsPage>
+        <results:byQuestionResults showAll="${data.bundle.complete}" shouldCollapsed="${data.shouldCollapsed}" data="${data}" />
+    </results:resultsPage>    
 </ti:instructorPage>

--- a/src/main/webapp/jsp/instructorFeedbackResultsByRecipientQuestionGiver.jsp
+++ b/src/main/webapp/jsp/instructorFeedbackResultsByRecipientQuestionGiver.jsp
@@ -1,19 +1,11 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
-<%@ taglib tagdir="/WEB-INF/tags" prefix="t" %>
-<%@ taglib tagdir="/WEB-INF/tags/instructor" prefix="ti" %>
 <%@ taglib tagdir="/WEB-INF/tags/instructor/results" prefix="results" %>
 <c:set var="jsIncludes">    
-    <script type="text/javascript" src="/js/instructor.js"></script>
-    <script type="text/javascript" src="/js/instructorFeedbackResults.js"></script>
     <script type="text/javascript" src="/js/instructorFeedbackResultsAjaxByRQG.js"></script>
-    <script type="text/javascript" src="/js/instructorFeedbackResultsAjaxResponseRate.js"></script>
-    <script type="text/javascript" src="/js/additionalQuestionInfo.js"></script>
 </c:set>
 
-<ti:instructorPage pageTitle="TEAMMATES - Feedback Session Results" bodyTitle="Session Results" jsIncludes="${jsIncludes}">
-    <results:resultsPage>
-        <results:byGiverQuestionRecipient showAll="${data.bundle.complete}" shouldCollapsed="${data.shouldCollapsed}" />
-    </results:resultsPage>    
-</ti:instructorPage>
+<results:resultsPage pageTitle="TEAMMATES - Feedback Session Results" bodyTitle="Session Results" jsIncludes="${jsIncludes}" data="${data}">
+    <results:byGiverQuestionRecipient showAll="${data.bundle.complete}" shouldCollapsed="${data.shouldCollapsed}" />    
+</results:resultsPage>

--- a/src/main/webapp/jsp/instructorFeedbackResultsByRecipientQuestionGiver.jsp
+++ b/src/main/webapp/jsp/instructorFeedbackResultsByRecipientQuestionGiver.jsp
@@ -13,5 +13,7 @@
 </c:set>
 
 <ti:instructorPage pageTitle="TEAMMATES - Feedback Session Results" bodyTitle="Session Results" jsIncludes="${jsIncludes}">
-    <results:byGiverQuestionRecipient showAll="${data.bundle.complete}" shouldCollapsed="${data.shouldCollapsed}" />    
+    <results:resultsPage>
+        <results:byGiverQuestionRecipient showAll="${data.bundle.complete}" shouldCollapsed="${data.shouldCollapsed}" />
+    </results:resultsPage>    
 </ti:instructorPage>


### PR DESCRIPTION
There are two methods for this, check and see if 72dcfc5 or 1e6eefa would work better.
The latter allows for common JS file imports, but may be more restrictive.
The `data` passed in is for resultsTop and resultsBottom later.