### PR TITLE
Remove unused params in js #3895

### DIFF
--- a/src/main/webapp/js/instructorCourseDetails.js
+++ b/src/main/webapp/js/instructorCourseDetails.js
@@ -49,10 +49,8 @@ function submitFormAjax() {
  * Functions to trigger registration key sending to a specific student in the
  * course.
  * Currently no confirmation dialog is shown.
- * @param courseID
- * @param email
  */
-function toggleSendRegistrationKey(courseID, email) {
+function toggleSendRegistrationKey() {
     return confirm("Usually, there is no need to use this feature because TEAMMATES " 
                    + "sends an automatic invite to students at the opening time of each" 
                    + " session. Send a join request anyway?");


### PR DESCRIPTION
Fixes #3895 
The place where `toggleSendRegistrationKey` is called is in `InstructorCourseDetailsPageData`, and is called without any params. This change removes the unused params in the `toggleSendRegistrationKey` javascript function.