### PR TITLE
studentEvalResults: the link to the description of the point calculation points to the now defunct spec.html #1554

### DIFF
--- a/src/main/resources/feedbackQuestionContribResultStatsStudentViewAdditionalInfo.html
+++ b/src/main/resources/feedbackQuestionContribResultStatsStudentViewAdditionalInfo.html
@@ -45,4 +45,4 @@ Here are the important things to note:
     </li>
 </ul>
 The actual calculation is a bit complex and the finer details can be found 
-<a href="/dev/spec.html#supplementaryrequirements-pointcalculationscheme">here</a>.
+<a href="https://docs.google.com/document/d/1hjQQHYM3YId0EUSrGnJWG5AeFpDD_G7xg_d--7jg3vU/pub?embedded=true#h.n5u2xs6z9y0g">here</a>.

--- a/src/main/webapp/instructorHelp.html
+++ b/src/main/webapp/instructorHelp.html
@@ -574,7 +574,7 @@
                                     <br>
                                 </div>
                                 In the calculation, we do not allow (a) to affect (b). We use (b) to calculate the average perceived contribution for each student. A more detailed version of this calculation can be found
-                                <a href="https://teammatesv4.appspot.com/dev/spec.html#supplementaryrequirements-pointcalculationscheme">here</a>.
+                                <a href="https://docs.google.com/document/d/1hjQQHYM3YId0EUSrGnJWG5AeFpDD_G7xg_d--7jg3vU/pub?embedded=true#h.n5u2xs6z9y0g">here</a>.
                             </div>
                         </li>
                         <br>
@@ -585,7 +585,7 @@
                             </b>
                             <div class="helpSectionContent">
                                 You can find the details of the contribution calculation scheme
-                                <a href="https://teammatesv4.appspot.com/dev/spec.html#supplementaryrequirements-pointcalculationscheme">here</a>.
+                                <a href="https://docs.google.com/document/d/1hjQQHYM3YId0EUSrGnJWG5AeFpDD_G7xg_d--7jg3vU/pub?embedded=true#h.n5u2xs6z9y0g">here</a>.
                             </div>
                         </li>
                         <br>

--- a/src/test/resources/pages/newlyJoinedInstructorStudentFeedbackResultsPage.html
+++ b/src/test/resources/pages/newlyJoinedInstructorStudentFeedbackResultsPage.html
@@ -173,7 +173,7 @@ Here are the important things to note:
     </li>
 </ul>
 The actual calculation is a bit complex and the finer details can be found 
-<a href="/dev/spec.html#supplementaryrequirements-pointcalculationscheme">here</a>.</span>
+<a href="https://docs.google.com/document/d/1hjQQHYM3YId0EUSrGnJWG5AeFpDD_G7xg_d--7jg3vU/pub?embedded=true#h.n5u2xs6z9y0g">here</a>.</span>
 </span>
     </div>
     <table class="table table-striped">

--- a/src/test/resources/pages/studentFeedbackResultsPageCONTRIB.html
+++ b/src/test/resources/pages/studentFeedbackResultsPageCONTRIB.html
@@ -173,7 +173,7 @@ Here are the important things to note:
     </li>
 </ul>
 The actual calculation is a bit complex and the finer details can be found 
-<a href="/dev/spec.html#supplementaryrequirements-pointcalculationscheme">here</a>.</span>
+<a href="https://docs.google.com/document/d/1hjQQHYM3YId0EUSrGnJWG5AeFpDD_G7xg_d--7jg3vU/pub?embedded=true#h.n5u2xs6z9y0g">here</a>.</span>
 </span>
     </div>
     <table class="table table-striped">


### PR DESCRIPTION
Fixes #1554 
The old issue description referenced `studentEvalResults.jsp`, but I think that has been refactored into smaller bits now. I tracked down the old link to to this html `feedbackQuestionContribResultStatsStudentViewAdditionalInfo.html` and updated the link there to the google docs one. Let me know if I got it wrong, thanks!