### PR TITLE
Instructor Home page: show a message when a course has no sessions/evals, instead of having no panel body. #2346

### DIFF
--- a/src/main/webapp/WEB-INF/tags/instructor/home/courseTable.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/home/courseTable.tag
@@ -21,7 +21,7 @@
         <tr>
             <td>
                 <span class="col-md-12 text-muted">
-                    You have not created any sessions yet.
+                    This course does not have any sessions yet.
                 </span>
             </td>
             <td></td>

--- a/src/main/webapp/WEB-INF/tags/instructor/home/courseTable.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/home/courseTable.tag
@@ -17,14 +17,14 @@
             <th class="no-print">Action(s)</th>
         </tr>
     </thead>
-	<c:if test="${empty sessionRows}">
-		<tr>
-			<td></td>
-			<td></td>
-			<td></td>
-			<td></td>
-		</tr>
-	</c:if>
+    <c:if test="${empty sessionRows}">
+        <tr>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+        </tr>
+    </c:if>
     <c:forEach items="${sessionRows}" var="sessionRow" varStatus="i">
         <tr id="session${i.index}">
             <td>

--- a/src/main/webapp/WEB-INF/tags/instructor/home/courseTable.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/home/courseTable.tag
@@ -20,7 +20,7 @@
     <c:if test="${empty sessionRows}">
         <tr>
             <td>
-                <span class="col-md-12 text-muted">
+                <span class="text-muted">
                     This course does not have any sessions yet.
                 </span>
             </td>

--- a/src/main/webapp/WEB-INF/tags/instructor/home/courseTable.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/home/courseTable.tag
@@ -17,6 +17,14 @@
             <th class="no-print">Action(s)</th>
         </tr>
     </thead>
+	<c:if test="${empty sessionRows}">
+		<tr>
+			<td></td>
+			<td></td>
+			<td></td>
+			<td></td>
+		</tr>
+	</c:if>
     <c:forEach items="${sessionRows}" var="sessionRow" varStatus="i">
         <tr id="session${i.index}">
             <td>

--- a/src/main/webapp/WEB-INF/tags/instructor/home/courseTable.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/home/courseTable.tag
@@ -19,7 +19,11 @@
     </thead>
     <c:if test="${empty sessionRows}">
         <tr>
-            <td></td>
+            <td>
+                <span class="col-md-12 text-muted">
+                    You have not created any sessions yet.
+                </span>
+            </td>
             <td></td>
             <td></td>
             <td></td>

--- a/src/main/webapp/jsp/instructorHome.jsp
+++ b/src/main/webapp/jsp/instructorHome.jsp
@@ -23,9 +23,7 @@
         <br />
         <c:forEach items="${data.courseTables}" var="courseTable" varStatus="i">
             <home:coursePanel courseTable="${courseTable}" index="${i.index}">
-                <c:if test="${not empty courseTable.rows}">
-                    <home:courseTable sessionRows="${courseTable.rows}" />
-                </c:if>
+                <home:courseTable sessionRows="${courseTable.rows}" />
             </home:coursePanel>
         </c:forEach>
         <ti:copyModal />

--- a/src/test/resources/pages/InstructorHomeHTML.html
+++ b/src/test/resources/pages/InstructorHomeHTML.html
@@ -176,6 +176,9 @@
             <tbody>
                <tr>
                   <td>
+                  <span class="col-md-12 text-muted">
+                    This course does not have any sessions yet.
+                </span>
                   </td>
                   <td>
                   </td>

--- a/src/test/resources/pages/InstructorHomeHTML.html
+++ b/src/test/resources/pages/InstructorHomeHTML.html
@@ -152,7 +152,40 @@
             </div>
         </div>
     </div>
-    
+    <table class="table-responsive table table-striped table-bordered">
+            <thead>
+               <tr>
+                  <th class="button-sort-none" id="button_sortname" onclick="toggleSort(this,1);">
+                     Session Name
+                     <span class="icon-sort unsorted">
+                     </span>
+                  </th>
+                  <th>
+                     Status
+                  </th>
+                  <th>
+                     <span data-original-title="Number of students submitted &#x2f; Class size" data-placement="top" data-toggle="tooltip" title="">
+                        Response Rate
+                     </span>
+                  </th>
+                  <th class="no-print">
+                     Action(s)
+                  </th>
+               </tr>
+            </thead>
+            <tbody>
+               <tr>
+                  <td>
+                  </td>
+                  <td>
+                  </td>
+                  <td>
+                  </td>
+                  <td>
+                  </td>
+               </tr>
+            </tbody>
+         </table>
                 
             
 </div>

--- a/src/test/resources/pages/InstructorHomeHTML.html
+++ b/src/test/resources/pages/InstructorHomeHTML.html
@@ -176,7 +176,7 @@
             <tbody>
                <tr>
                   <td>
-                  <span class="col-md-12 text-muted">
+                  <span class="text-muted">
                     This course does not have any sessions yet.
                 </span>
                   </td>

--- a/src/test/resources/pages/InstructorHomeHTMLResponseRateFail.html
+++ b/src/test/resources/pages/InstructorHomeHTMLResponseRateFail.html
@@ -176,6 +176,9 @@
             <tbody>
                <tr>
                   <td>
+                  <span class="col-md-12 text-muted">
+                    This course does not have any sessions yet.
+                </span>
                   </td>
                   <td>
                   </td>

--- a/src/test/resources/pages/InstructorHomeHTMLResponseRateFail.html
+++ b/src/test/resources/pages/InstructorHomeHTMLResponseRateFail.html
@@ -152,7 +152,40 @@
             </div>
         </div>
     </div>
-    
+    <table class="table-responsive table table-striped table-bordered">
+            <thead>
+               <tr>
+                  <th class="button-sort-none" id="button_sortname" onclick="toggleSort(this,1);">
+                     Session Name
+                     <span class="icon-sort unsorted">
+                     </span>
+                  </th>
+                  <th>
+                     Status
+                  </th>
+                  <th>
+                     <span data-original-title="Number of students submitted &#x2f; Class size" data-placement="top" data-toggle="tooltip" title="">
+                        Response Rate
+                     </span>
+                  </th>
+                  <th class="no-print">
+                     Action(s)
+                  </th>
+               </tr>
+            </thead>
+            <tbody>
+               <tr>
+                  <td>
+                  </td>
+                  <td>
+                  </td>
+                  <td>
+                  </td>
+                  <td>
+                  </td>
+               </tr>
+            </tbody>
+         </table>
                 
             
 </div>

--- a/src/test/resources/pages/InstructorHomeHTMLResponseRateFail.html
+++ b/src/test/resources/pages/InstructorHomeHTMLResponseRateFail.html
@@ -176,7 +176,7 @@
             <tbody>
                <tr>
                   <td>
-                  <span class="col-md-12 text-muted">
+                  <span class="text-muted">
                     This course does not have any sessions yet.
                 </span>
                   </td>

--- a/src/test/resources/pages/InstructorHomeHTMLSortByDate.html
+++ b/src/test/resources/pages/InstructorHomeHTMLSortByDate.html
@@ -176,6 +176,9 @@
             <tbody>
                <tr>
                   <td>
+                  <span class="col-md-12 text-muted">
+                    This course does not have any sessions yet.
+                </span>
                   </td>
                   <td>
                   </td>

--- a/src/test/resources/pages/InstructorHomeHTMLSortByDate.html
+++ b/src/test/resources/pages/InstructorHomeHTMLSortByDate.html
@@ -152,7 +152,40 @@
             </div>
         </div>
     </div>
-    
+    <table class="table-responsive table table-striped table-bordered">
+            <thead>
+               <tr>
+                  <th class="button-sort-none" id="button_sortname" onclick="toggleSort(this,1);">
+                     Session Name
+                     <span class="icon-sort unsorted">
+                     </span>
+                  </th>
+                  <th>
+                     Status
+                  </th>
+                  <th>
+                     <span data-original-title="Number of students submitted &#x2f; Class size" data-placement="top" data-toggle="tooltip" title="">
+                        Response Rate
+                     </span>
+                  </th>
+                  <th class="no-print">
+                     Action(s)
+                  </th>
+               </tr>
+            </thead>
+            <tbody>
+               <tr>
+                  <td>
+                  </td>
+                  <td>
+                  </td>
+                  <td>
+                  </td>
+                  <td>
+                  </td>
+               </tr>
+            </tbody>
+         </table>
                 
             
 </div>

--- a/src/test/resources/pages/InstructorHomeHTMLSortByDate.html
+++ b/src/test/resources/pages/InstructorHomeHTMLSortByDate.html
@@ -176,7 +176,7 @@
             <tbody>
                <tr>
                   <td>
-                  <span class="col-md-12 text-muted">
+                  <span class="text-muted">
                     This course does not have any sessions yet.
                 </span>
                   </td>

--- a/src/test/resources/pages/InstructorHomeHTMLSortById.html
+++ b/src/test/resources/pages/InstructorHomeHTMLSortById.html
@@ -176,6 +176,9 @@
             <tbody>
                <tr>
                   <td>
+                    <span class="col-md-12 text-muted">
+                    This course does not have any sessions yet.
+                </span>
                   </td>
                   <td>
                   </td>

--- a/src/test/resources/pages/InstructorHomeHTMLSortById.html
+++ b/src/test/resources/pages/InstructorHomeHTMLSortById.html
@@ -152,7 +152,40 @@
             </div>
         </div>
     </div>
-    
+    <table class="table-responsive table table-striped table-bordered">
+            <thead>
+               <tr>
+                  <th class="button-sort-none" id="button_sortname" onclick="toggleSort(this,1);">
+                     Session Name
+                     <span class="icon-sort unsorted">
+                     </span>
+                  </th>
+                  <th>
+                     Status
+                  </th>
+                  <th>
+                     <span data-original-title="Number of students submitted &#x2f; Class size" data-placement="top" data-toggle="tooltip" title="">
+                        Response Rate
+                     </span>
+                  </th>
+                  <th class="no-print">
+                     Action(s)
+                  </th>
+               </tr>
+            </thead>
+            <tbody>
+               <tr>
+                  <td>
+                  </td>
+                  <td>
+                  </td>
+                  <td>
+                  </td>
+                  <td>
+                  </td>
+               </tr>
+            </tbody>
+         </table>
                 
             
 </div>

--- a/src/test/resources/pages/InstructorHomeHTMLSortById.html
+++ b/src/test/resources/pages/InstructorHomeHTMLSortById.html
@@ -176,7 +176,7 @@
             <tbody>
                <tr>
                   <td>
-                    <span class="col-md-12 text-muted">
+                    <span class="text-muted">
                     This course does not have any sessions yet.
                 </span>
                   </td>

--- a/src/test/resources/pages/InstructorHomeHTMLSortByName.html
+++ b/src/test/resources/pages/InstructorHomeHTMLSortByName.html
@@ -545,7 +545,7 @@
             <tbody>
                <tr>
                   <td>
-                  <span class="col-md-12 text-muted">
+                  <span class="text-muted">
                     This course does not have any sessions yet.
                 </span>
                   </td>

--- a/src/test/resources/pages/InstructorHomeHTMLSortByName.html
+++ b/src/test/resources/pages/InstructorHomeHTMLSortByName.html
@@ -545,6 +545,9 @@
             <tbody>
                <tr>
                   <td>
+                  <span class="col-md-12 text-muted">
+                    This course does not have any sessions yet.
+                </span>
                   </td>
                   <td>
                   </td>

--- a/src/test/resources/pages/InstructorHomeHTMLSortByName.html
+++ b/src/test/resources/pages/InstructorHomeHTMLSortByName.html
@@ -521,7 +521,40 @@
             </div>
         </div>
     </div>
-    
+    <table class="table-responsive table table-striped table-bordered">
+            <thead>
+               <tr>
+                  <th class="button-sort-none" id="button_sortname" onclick="toggleSort(this,1);">
+                     Session Name
+                     <span class="icon-sort unsorted">
+                     </span>
+                  </th>
+                  <th>
+                     Status
+                  </th>
+                  <th>
+                     <span data-original-title="Number of students submitted &#x2f; Class size" data-placement="top" data-toggle="tooltip" title="">
+                        Response Rate
+                     </span>
+                  </th>
+                  <th class="no-print">
+                     Action(s)
+                  </th>
+               </tr>
+            </thead>
+            <tbody>
+               <tr>
+                  <td>
+                  </td>
+                  <td>
+                  </td>
+                  <td>
+                  </td>
+                  <td>
+                  </td>
+               </tr>
+            </tbody>
+         </table>
                 
             
 </div>

--- a/src/test/resources/pages/InstructorHomeHTMLWithHelperView.html
+++ b/src/test/resources/pages/InstructorHomeHTMLWithHelperView.html
@@ -176,6 +176,9 @@
             <tbody>
                <tr>
                   <td>
+                  <span class="col-md-12 text-muted">
+                    This course does not have any sessions yet.
+                </span>
                   </td>
                   <td>
                   </td>

--- a/src/test/resources/pages/InstructorHomeHTMLWithHelperView.html
+++ b/src/test/resources/pages/InstructorHomeHTMLWithHelperView.html
@@ -152,7 +152,40 @@
             </div>
         </div>
     </div>
-    
+    <table class="table-responsive table table-striped table-bordered">
+            <thead>
+               <tr>
+                  <th class="button-sort-none" id="button_sortname" onclick="toggleSort(this,1);">
+                     Session Name
+                     <span class="icon-sort unsorted">
+                     </span>
+                  </th>
+                  <th>
+                     Status
+                  </th>
+                  <th>
+                     <span data-original-title="Number of students submitted &#x2f; Class size" data-placement="top" data-toggle="tooltip" title="">
+                        Response Rate
+                     </span>
+                  </th>
+                  <th class="no-print">
+                     Action(s)
+                  </th>
+               </tr>
+            </thead>
+            <tbody>
+               <tr>
+                  <td>
+                  </td>
+                  <td>
+                  </td>
+                  <td>
+                  </td>
+                  <td>
+                  </td>
+               </tr>
+            </tbody>
+         </table>
                 
             
 </div>

--- a/src/test/resources/pages/InstructorHomeHTMLWithHelperView.html
+++ b/src/test/resources/pages/InstructorHomeHTMLWithHelperView.html
@@ -176,7 +176,7 @@
             <tbody>
                <tr>
                   <td>
-                  <span class="col-md-12 text-muted">
+                  <span class="text-muted">
                     This course does not have any sessions yet.
                 </span>
                   </td>

--- a/src/test/resources/pages/InstructorHomeNewInstructorWithSampleCourse.html
+++ b/src/test/resources/pages/InstructorHomeNewInstructorWithSampleCourse.html
@@ -122,7 +122,40 @@
             </div>
         </div>
     </div>
-    
+    <table class="table-responsive table table-striped table-bordered">
+            <thead>
+               <tr>
+                  <th class="button-sort-none" id="button_sortname" onclick="toggleSort(this,1);">
+                     Session Name
+                     <span class="icon-sort unsorted">
+                     </span>
+                  </th>
+                  <th>
+                     Status
+                  </th>
+                  <th>
+                     <span data-original-title="Number of students submitted &#x2f; Class size" data-placement="top" data-toggle="tooltip" title="">
+                        Response Rate
+                     </span>
+                  </th>
+                  <th class="no-print">
+                     Action(s)
+                  </th>
+               </tr>
+            </thead>
+            <tbody>
+               <tr>
+                  <td>
+                  </td>
+                  <td>
+                  </td>
+                  <td>
+                  </td>
+                  <td>
+                  </td>
+               </tr>
+            </tbody>
+         </table>
                 
             
 </div>

--- a/src/test/resources/pages/InstructorHomeNewInstructorWithSampleCourse.html
+++ b/src/test/resources/pages/InstructorHomeNewInstructorWithSampleCourse.html
@@ -146,6 +146,9 @@
             <tbody>
                <tr>
                   <td>
+                  <span class="col-md-12 text-muted">
+                    This course does not have any sessions yet.
+                </span>
                   </td>
                   <td>
                   </td>

--- a/src/test/resources/pages/InstructorHomeNewInstructorWithSampleCourse.html
+++ b/src/test/resources/pages/InstructorHomeNewInstructorWithSampleCourse.html
@@ -146,7 +146,7 @@
             <tbody>
                <tr>
                   <td>
-                  <span class="col-md-12 text-muted">
+                  <span class="text-muted">
                     This course does not have any sessions yet.
                 </span>
                   </td>

--- a/src/test/resources/pages/instructorHomeHTMLResponseRatePass.html
+++ b/src/test/resources/pages/instructorHomeHTMLResponseRatePass.html
@@ -176,6 +176,9 @@
             <tbody>
                <tr>
                   <td>
+                  <span class="col-md-12 text-muted">
+                    This course does not have any sessions yet.
+                </span>
                   </td>
                   <td>
                   </td>

--- a/src/test/resources/pages/instructorHomeHTMLResponseRatePass.html
+++ b/src/test/resources/pages/instructorHomeHTMLResponseRatePass.html
@@ -152,7 +152,40 @@
             </div>
         </div>
     </div>
-    
+    <table class="table-responsive table table-striped table-bordered">
+            <thead>
+               <tr>
+                  <th class="button-sort-none" id="button_sortname" onclick="toggleSort(this,1);">
+                     Session Name
+                     <span class="icon-sort unsorted">
+                     </span>
+                  </th>
+                  <th>
+                     Status
+                  </th>
+                  <th>
+                     <span data-original-title="Number of students submitted &#x2f; Class size" data-placement="top" data-toggle="tooltip" title="">
+                        Response Rate
+                     </span>
+                  </th>
+                  <th class="no-print">
+                     Action(s)
+                  </th>
+               </tr>
+            </thead>
+            <tbody>
+               <tr>
+                  <td>
+                  </td>
+                  <td>
+                  </td>
+                  <td>
+                  </td>
+                  <td>
+                  </td>
+               </tr>
+            </tbody>
+         </table>
                 
             
 </div>

--- a/src/test/resources/pages/instructorHomeHTMLResponseRatePass.html
+++ b/src/test/resources/pages/instructorHomeHTMLResponseRatePass.html
@@ -176,7 +176,7 @@
             <tbody>
                <tr>
                   <td>
-                  <span class="col-md-12 text-muted">
+                  <span class="text-muted">
                     This course does not have any sessions yet.
                 </span>
                   </td>


### PR DESCRIPTION
fixed #2346
@damithc This is what it looks like now. Is that okay?

![instructorhome](https://cloud.githubusercontent.com/assets/8078323/8666948/6a55e82c-2a33-11e5-9f57-dc5d96ccfede.png)

This is what it was before #3917
