### PR TITLE
 Change colour of 'how to interpret' link in student feedback results page #3742 

### DIFF
--- a/src/main/java/teammates/common/datatransfer/FeedbackContributionQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/FeedbackContributionQuestionDetails.java
@@ -201,7 +201,7 @@ public class FeedbackContributionQuestionDetails extends FeedbackQuestionDetails
         int teamClaim = currentUserTeamResults.denormalizedAveragePerceived[currentUserIndex][currentUserIndex];
         
         String contribAdditionalInfo = FeedbackQuestionFormTemplates.populateTemplate(
-                FeedbackQuestionFormTemplates.FEEDBACK_QUESTION_ADDITIONAL_INFO,
+                FeedbackQuestionFormTemplates.CONTRIB_ADDITIONAL_INFO,
                 "${more}", "[how to interpret, etc..]",
                 "${less}", "[less]",
                 "${questionNumber}", Integer.toString(question.questionNumber),

--- a/src/main/java/teammates/common/util/FeedbackQuestionFormTemplates.java
+++ b/src/main/java/teammates/common/util/FeedbackQuestionFormTemplates.java
@@ -40,6 +40,7 @@ public class FeedbackQuestionFormTemplates {
     public static String CONSTSUM_RESULT_RECIPIENT_STATS = FileHelper.readResourseFile("feedbackQuestionConstSumResultStatsRecipientTemplate.html");
     public static String CONSTSUM_RESULT_STATS_RECIPIENTFRAGMENT = FileHelper.readResourseFile("feedbackQuestionConstSumResultStatsRecipientFragment.html");
     
+    public static String CONTRIB_ADDITIONAL_INFO = FileHelper.readResourseFile("feedbackQuestionContribAdditionalInfoTemplate.html");
     public static String CONTRIB_EDIT_FORM = FileHelper.readResourseFile("feedbackQuestionContribEditFormTemplate.html");
     public static String CONTRIB_SUBMISSION_FORM = FileHelper.readResourseFile("feedbackQuestionContribSubmissionFormTemplate.html");
     public static String CONTRIB_RESULT_STATS = FileHelper.readResourseFile("feedbackQuestionContribResultStatsTemplate.html");

--- a/src/main/resources/feedbackQuestionContribAdditionalInfoTemplate.html
+++ b/src/main/resources/feedbackQuestionContribAdditionalInfoTemplate.html
@@ -1,0 +1,5 @@
+&nbsp;<span style=" white-space: normal;">
+    <a href="javascript:;" id="questionAdditionalInfoButton-${questionNumber}-${additionalInfoId}" class="small link-in-dark-bg" onclick="toggleAdditionalQuestionInfo('${questionNumber}-${additionalInfoId}')" data-more="${more}" data-less="${less}">${more}</a>
+    <br>
+    <span id="questionAdditionalInfo-${questionNumber}-${additionalInfoId}" style="display:none;">${questionAdditionalInfo}</span>
+</span>

--- a/src/test/resources/pages/newlyJoinedInstructorStudentFeedbackResultsPage.html
+++ b/src/test/resources/pages/newlyJoinedInstructorStudentFeedbackResultsPage.html
@@ -124,7 +124,7 @@
         <div class="panel panel-primary">
     <div class="panel-heading">
         Comparison of work distribution &nbsp;<span style=" white-space: normal;">
-    <a href="javascript:;" id="questionAdditionalInfoButton-1-contributionInfo" class="color_gray" onclick="toggleAdditionalQuestionInfo('1-contributionInfo')" data-more="[how to interpret, etc..]" data-less="[less]">[how to interpret, etc..]</a>
+    <a href="javascript:;" id="questionAdditionalInfoButton-1-contributionInfo" class="small link-in-dark-bg" onclick="toggleAdditionalQuestionInfo('1-contributionInfo')" data-more="[how to interpret, etc..]" data-less="[less]">[how to interpret, etc..]</a>
     <br>
     <span id="questionAdditionalInfo-1-contributionInfo" style="display:none;"><h4 id="interpret">How do I interpret these results? </h4>
 <ul class="bulletedList">

--- a/src/test/resources/pages/studentFeedbackResultsPageCONTRIB.html
+++ b/src/test/resources/pages/studentFeedbackResultsPageCONTRIB.html
@@ -124,7 +124,7 @@
         <div class="panel panel-primary">
     <div class="panel-heading">
         Comparison of work distribution &nbsp;<span style=" white-space: normal;">
-    <a href="javascript:;" id="questionAdditionalInfoButton-1-contributionInfo" class="color_gray" onclick="toggleAdditionalQuestionInfo('1-contributionInfo')" data-more="[how to interpret, etc..]" data-less="[less]">[how to interpret, etc..]</a>
+    <a href="javascript:;" id="questionAdditionalInfoButton-1-contributionInfo" class="small link-in-dark-bg" onclick="toggleAdditionalQuestionInfo('1-contributionInfo')" data-more="[how to interpret, etc..]" data-less="[less]">[how to interpret, etc..]</a>
     <br>
     <span id="questionAdditionalInfo-1-contributionInfo" style="display:none;"><h4 id="interpret">How do I interpret these results? </h4>
 <ul class="bulletedList">


### PR DESCRIPTION
Fixes #3742 
EDIT (message copied from commit https://github.com/ngzhian/repo/commit/6ec5b680440c6e4c2d986ffd22d99b4289319437)

This is to fix a regression introduced in the previous commit,
which made the "more info" link beside the panel title of a
contribution question move visible, but made the "more info"
link beside the question title itself less visible.