### PR TITLE
Live/staging tests not compatible with new google login page #4094

### DIFF
--- a/src/test/java/teammates/test/pageobjects/GoogleLoginPage.java
+++ b/src/test/java/teammates/test/pageobjects/GoogleLoginPage.java
@@ -92,7 +92,7 @@ public class GoogleLoginPage extends LoginPage {
     private void submitCredentials(String username, String password) {
         fillTextBox(usernameTextBox, username);
         click(By.id("next"));
-        waitForElementPresence(By.id("Passwd"));
+        waitForElementVisibility(passwordTextBox);
         fillTextBox(passwordTextBox, password);
         
         if (staySignedCheckbox.isSelected()) {

--- a/src/test/java/teammates/test/pageobjects/GoogleLoginPage.java
+++ b/src/test/java/teammates/test/pageobjects/GoogleLoginPage.java
@@ -91,6 +91,8 @@ public class GoogleLoginPage extends LoginPage {
 
     private void submitCredentials(String username, String password) {
         fillTextBox(usernameTextBox, username);
+        click(By.id("next"));
+        waitForElementPresence(By.id("Passwd"));
         fillTextBox(passwordTextBox, password);
         
         if (staySignedCheckbox.isSelected()) {


### PR DESCRIPTION
Fixes #4094.

Tested on a few ui tests on staging. The first time it tries to login, google will want to authenticate by sending your mobile phone an SMS, so it's best to run one ui test first.

Might also need to allow access to less secure apps, but this has been around for a while already so it shouldn't be a problem now. https://www.google.com/settings/security/lesssecureapps