### PR TITLE
"For measuring failure rate: user tried to copy session to multiple courses" spotted #4059

### DIFF
--- a/src/main/webapp/js/instructor.js
+++ b/src/main/webapp/js/instructor.js
@@ -149,9 +149,30 @@ function setupFsCopyModal() {
             success: function(data) {
                 $('#courseList').html(data);
                 $('#fscopy_submit').prop('disabled', false);
+                $('#fsCopyModal form').submit(validateFsCopyModalSubmission);
             }
         });
     });
+}
+
+/**
+ * Prevents submission of the fsCopyModal if the same fsname is used in the original course.
+ */
+function validateFsCopyModalSubmission(e) {
+    var $checkedCourses = $('#fsCopyModal [name=copiedcoursesid]:checked');
+    var checkedCoursesId =  $checkedCourses.map(function() {
+        return $(this).val();
+    });
+    var originalCourseId = $('#fsCopyModal [name=courseid]').val();
+
+    var isOriginalCourseSelected = $.inArray(originalCourseId, checkedCoursesId) !== -1;
+
+    var fsName = $('#fsCopyModal #copiedfsname').val();
+    var originalFsName = $("#fsCopyModal input[name='fsname']").val();
+
+    var isSameFsName = fsName === originalFsName;
+
+    return !isOriginalCourseSelected || !isSameFsName
 }
 
 // Student Profile Picture

--- a/src/main/webapp/js/instructor.js
+++ b/src/main/webapp/js/instructor.js
@@ -160,18 +160,17 @@ function setupFsCopyModal() {
  * a destination of copying
  */
 function validateFsCopyModalSubmission(e) {
-    var $checkedCourses = $("#fsCopyModal [name='copiedcoursesid']:checked");
+    var $fsCopyModal = $("#fsCopyModal");
+
+    var $checkedCourses = $fsCopyModal.find("[name='copiedcoursesid']:checked");
     var checkedCoursesId =  $checkedCourses.map(function() {
         return $(this).val();
     });
-    var originalCourseId = $("#fsCopyModal [name='courseid']").val();
-
+    var originalCourseId = $fsCopyModal.find("[name='courseid']").val();
     var isOriginalCourseSelected = $.inArray(originalCourseId, checkedCoursesId) !== -1;
 
-
-    var fsName = $('#fsCopyModal #copiedfsname').val();
-    var originalFsName = $("#fsCopyModal input[name='fsname']").val();
-
+    var fsName = $fsCopyModal.find('#copiedfsname').val();
+    var originalFsName = $fsCopyModal.find("input[name='fsname']").val();
     var isSameFsName = fsName === originalFsName;
 
 

--- a/src/main/webapp/js/instructor.js
+++ b/src/main/webapp/js/instructor.js
@@ -156,23 +156,34 @@ function setupFsCopyModal() {
 }
 
 /**
- * Prevents submission of the fsCopyModal if the same fsname is used in the original course.
+ * Prevents submission of the fsCopyModal if the same fsname is used in the original course, and the original course is 
+ * a destination of copying
  */
 function validateFsCopyModalSubmission(e) {
-    var $checkedCourses = $('#fsCopyModal [name=copiedcoursesid]:checked');
+    var $checkedCourses = $("#fsCopyModal [name='copiedcoursesid']:checked");
     var checkedCoursesId =  $checkedCourses.map(function() {
         return $(this).val();
     });
-    var originalCourseId = $('#fsCopyModal [name=courseid]').val();
+    var originalCourseId = $("#fsCopyModal [name='courseid']").val();
 
     var isOriginalCourseSelected = $.inArray(originalCourseId, checkedCoursesId) !== -1;
+
 
     var fsName = $('#fsCopyModal #copiedfsname').val();
     var originalFsName = $("#fsCopyModal input[name='fsname']").val();
 
     var isSameFsName = fsName === originalFsName;
 
-    return !isOriginalCourseSelected || !isSameFsName
+
+    if (isOriginalCourseSelected && isSameFsName) {
+        var $errorMessage = $('#fs_copy_modal_error');
+        $errorMessage.addClass('alert alert-danger');
+        $errorMessage.text('Please give the feedback session a different name if the destination course and the source course are the same');
+
+        return false;
+    } else {
+        return true;
+    }
 }
 
 // Student Profile Picture

--- a/src/main/webapp/jsp/instructorFeedbackCopyModal.jsp
+++ b/src/main/webapp/jsp/instructorFeedbackCopyModal.jsp
@@ -32,7 +32,7 @@
         </label>
     </div>
 </c:forEach>
-
+<div id="fs_copy_modal_error"></div>
 <input type="hidden" name="<%= Const.ParamsNames.COURSE_ID %>" value="${data.courseId}">
 <input type="hidden" name="<%= Const.ParamsNames.FEEDBACK_SESSION_NAME %>" value="${data.fsName}">
 <input type="hidden" name="<%= Const.ParamsNames.CURRENT_PAGE %>" value="${data.currentPage}">

--- a/src/test/java/teammates/test/cases/ui/browsertests/InstructorFeedbackEditCopyUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/InstructorFeedbackEditCopyUiTest.java
@@ -1,5 +1,7 @@
 package teammates.test.cases.ui.browsertests;
 
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertTrue;
 import org.openqa.selenium.By;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -48,22 +50,32 @@ public class InstructorFeedbackEditCopyUiTest extends BaseUiTestCase {
         feedbackEditPage.verifyStatus(Const.StatusMessages.FEEDBACK_SESSION_COPY_NONESELECTED);
         
         
-        ______TS("Copying fails due to fs with same name in course selected");
+        ______TS("Copying fails due to fs with same name getting copied to the original course");
         feedbackEditPage.clickFsCopyButton();
         feedbackEditPage.waitForModalToLoad();
         feedbackEditPage.fillCopyToOtherCoursesForm(feedbackSessionName);
         
         feedbackEditPage.clickFsCopySubmitButton();
         
-        String error = String.format(Const.StatusMessages.FEEDBACK_SESSION_COPY_ALREADYEXISTS,
-                                     feedbackSessionName, testData.courses.get("course").id);
-        feedbackEditPage.verifyStatus(error);
+        assertTrue(feedbackEditPage.isFsCopyModalErrorMessageVisible());
+        String copyErrorMessage = feedbackEditPage.getFsCopyModalError();
+        String expectedErrorMessage = "Please give the feedback session a different name if the " 
+                                    + "destination course and the source course are the same";
+        assertEquals(expectedErrorMessage, copyErrorMessage);
 
-        // Full HTML verification already done in InstructorFeedbackEditPageUiTest
-        feedbackEditPage.verifyHtmlMainContent("/instructorFeedbackEditCopyFail.html");
+        
+        feedbackEditPage.resetCoursesCheckbox();
+        feedbackEditPage.selectFsCopyModalCourse("FeedbackEditCopy.CS2104");
+        
+        feedbackEditPage.clickFsCopySubmitButton();
+        assertTrue(feedbackEditPage.isFsCopyModalErrorMessageVisible());
+        copyErrorMessage = feedbackEditPage.getFsCopyModalError();
+        assertEquals(expectedErrorMessage, copyErrorMessage);
         
         
         ______TS("Copying fails due to fs with invalid name");
+        feedbackEditPage = getFeedbackEditPage();
+        
         feedbackEditPage.clickFsCopyButton();
         feedbackEditPage.waitForModalToLoad();
         feedbackEditPage.fillCopyToOtherCoursesForm("Invalid name | for feedback session");
@@ -90,6 +102,19 @@ public class InstructorFeedbackEditCopyUiTest extends BaseUiTestCase {
         // Full HTML verification already done in InstructorFeedbackEditPageUiTest
         feedbackEditPage.verifyHtmlMainContent("/instructorFeedbackEditCopySuccess.html");
         
+        
+        ______TS("Copying fails due to fs with same name in course selected");
+        feedbackEditPage = getFeedbackEditPage();
+        feedbackEditPage.clickFsCopyButton();
+        feedbackEditPage.waitForModalToLoad();
+        
+        feedbackEditPage.fillFsCopyModalName("New name!");
+        feedbackEditPage.selectFsCopyModalCourse("FeedbackEditCopy.CS2105");
+        
+        feedbackEditPage.clickFsCopySubmitButton();
+
+        // Full HTML verification already done in InstructorFeedbackEditPageUiTest
+        feedbackEditPage.verifyHtmlMainContent("/instructorFeedbackEditCopyFail.html");
     }
 
 

--- a/src/test/java/teammates/test/cases/ui/browsertests/InstructorFeedbackEditCopyUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/InstructorFeedbackEditCopyUiTest.java
@@ -41,7 +41,7 @@ public class InstructorFeedbackEditCopyUiTest extends BaseUiTestCase {
         
         ______TS("Submit empty course list");
         feedbackEditPage.clickFsCopyButton();
-        feedbackEditPage.waitForModalToLoad();
+        feedbackEditPage.fsCopyToModal.waitForModalToLoad();
 
         // Full HTML verification already done in InstructorFeedbackEditPageUiTest
         feedbackEditPage.verifyHtmlMainContent("/instructorFeedbackEditCopyPage.html");
@@ -52,33 +52,29 @@ public class InstructorFeedbackEditCopyUiTest extends BaseUiTestCase {
         
         ______TS("Copying fails due to fs with same name getting copied to the original course");
         feedbackEditPage.clickFsCopyButton();
-        feedbackEditPage.waitForModalToLoad();
-        feedbackEditPage.fillCopyToOtherCoursesForm(feedbackSessionName);
+        feedbackEditPage.fsCopyToModal.waitForModalToLoad();
+        feedbackEditPage.fsCopyToModal.fillFormWithAllCoursesSelected(feedbackSessionName);
         
         feedbackEditPage.clickFsCopySubmitButton();
         
-        assertTrue(feedbackEditPage.isFsCopyModalErrorMessageVisible());
-        String copyErrorMessage = feedbackEditPage.getFsCopyModalError();
-        String expectedErrorMessage = "Please give the feedback session a different name if the " 
-                                    + "destination course and the source course are the same";
-        assertEquals(expectedErrorMessage, copyErrorMessage);
-
+        assertTrue(feedbackEditPage.fsCopyToModal.isErrorMessageVisible());
+        feedbackEditPage.fsCopyToModal.verifyErrorMessage();
         
-        feedbackEditPage.resetCoursesCheckbox();
-        feedbackEditPage.selectFsCopyModalCourse("FeedbackEditCopy.CS2104");
+        
+        feedbackEditPage.fsCopyToModal.resetCoursesCheckbox();
+        feedbackEditPage.fsCopyToModal.checkCourse("FeedbackEditCopy.CS2104");
         
         feedbackEditPage.clickFsCopySubmitButton();
-        assertTrue(feedbackEditPage.isFsCopyModalErrorMessageVisible());
-        copyErrorMessage = feedbackEditPage.getFsCopyModalError();
-        assertEquals(expectedErrorMessage, copyErrorMessage);
+        assertTrue(feedbackEditPage.fsCopyToModal.isErrorMessageVisible());
+        feedbackEditPage.fsCopyToModal.verifyErrorMessage();
         
         
         ______TS("Copying fails due to fs with invalid name");
         feedbackEditPage = getFeedbackEditPage();
         
         feedbackEditPage.clickFsCopyButton();
-        feedbackEditPage.waitForModalToLoad();
-        feedbackEditPage.fillCopyToOtherCoursesForm("Invalid name | for feedback session");
+        feedbackEditPage.fsCopyToModal.waitForModalToLoad();
+        feedbackEditPage.fsCopyToModal.fillFormWithAllCoursesSelected("Invalid name | for feedback session");
         
         feedbackEditPage.clickFsCopySubmitButton();
         
@@ -91,8 +87,8 @@ public class InstructorFeedbackEditCopyUiTest extends BaseUiTestCase {
         
         ______TS("Successful case");
         feedbackEditPage.clickFsCopyButton();
-        feedbackEditPage.waitForModalToLoad();
-        feedbackEditPage.fillCopyToOtherCoursesForm("New name!");
+        feedbackEditPage.fsCopyToModal.waitForModalToLoad();
+        feedbackEditPage.fsCopyToModal.fillFormWithAllCoursesSelected("New name!");
         
         feedbackEditPage.clickFsCopySubmitButton();
         
@@ -106,10 +102,10 @@ public class InstructorFeedbackEditCopyUiTest extends BaseUiTestCase {
         ______TS("Copying fails due to fs with same name in course selected");
         feedbackEditPage = getFeedbackEditPage();
         feedbackEditPage.clickFsCopyButton();
-        feedbackEditPage.waitForModalToLoad();
+        feedbackEditPage.fsCopyToModal.waitForModalToLoad();
         
-        feedbackEditPage.fillFsCopyModalName("New name!");
-        feedbackEditPage.selectFsCopyModalCourse("FeedbackEditCopy.CS2105");
+        feedbackEditPage.fsCopyToModal.fillFsName("New name!");
+        feedbackEditPage.fsCopyToModal.checkCourse("FeedbackEditCopy.CS2105");
         
         feedbackEditPage.clickFsCopySubmitButton();
 

--- a/src/test/java/teammates/test/cases/ui/browsertests/InstructorFeedbackPageUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/InstructorFeedbackPageUiTest.java
@@ -487,9 +487,9 @@ public class InstructorFeedbackPageUiTest extends BaseUiTestCase {
         
         ______TS("Submit empty course list: Feedbacks Page");
         
-        feedbackPage.clickFsCopyButton(courseId, feedbackSessionName);
-        feedbackPage.waitForModalToLoad();
-        feedbackPage.clickFsCopySubmitButton();
+        feedbackPage.fsCopyToModal.clickCopyButtonOnTable(courseId, feedbackSessionName);
+        feedbackPage.fsCopyToModal.waitForModalToLoad();
+        feedbackPage.fsCopyToModal.clickSubmitButton();
         feedbackPage.verifyStatus(Const.StatusMessages.FEEDBACK_SESSION_COPY_NONESELECTED);
         
         // Go back to previous page because 'copy feedback session' redirects to the 'FeedbackEdit' page.
@@ -498,27 +498,25 @@ public class InstructorFeedbackPageUiTest extends BaseUiTestCase {
         
         ______TS("Copying fails due to fs with same name in course selected: Feedbacks Page");
         
-        feedbackPage.clickFsCopyButton(courseId, feedbackSessionName);
-        feedbackPage.waitForModalToLoad();
-        feedbackPage.fillCopyToOtherCoursesForm(feedbackSessionName);
+        feedbackPage.fsCopyToModal.clickCopyButtonOnTable(courseId, feedbackSessionName);
+        feedbackPage.fsCopyToModal.waitForModalToLoad();
+        feedbackPage.fsCopyToModal.fillFormWithAllCoursesSelected(feedbackSessionName);
         
-        feedbackPage.clickFsCopySubmitButton();
+        feedbackPage.fsCopyToModal.clickSubmitButton();
         
-        String error = String.format(Const.StatusMessages.FEEDBACK_SESSION_COPY_ALREADYEXISTS,
-                                     feedbackSessionName, courseId);
+        assertTrue(feedbackPage.fsCopyToModal.isErrorMessageVisible());
+        feedbackPage.fsCopyToModal.verifyErrorMessage();
         
-        feedbackPage.verifyStatus(error);
         
         feedbackPage.goToPreviousPage(InstructorFeedbacksPage.class);
         
-        
         ______TS("Copying fails due to fs with invalid name: Feedbacks Page");
         
-        feedbackPage.clickFsCopyButton(courseId, feedbackSessionName);
-        feedbackPage.waitForModalToLoad();
-        feedbackPage.fillCopyToOtherCoursesForm("Invalid name | for feedback session");
+        feedbackPage.fsCopyToModal.clickCopyButtonOnTable(courseId, feedbackSessionName);
+        feedbackPage.fsCopyToModal.waitForModalToLoad();
+        feedbackPage.fsCopyToModal.fillFormWithAllCoursesSelected("Invalid name | for feedback session");
         
-        feedbackPage.clickFsCopySubmitButton();
+        feedbackPage.fsCopyToModal.clickSubmitButton();
         
         feedbackPage.verifyStatus(
                 "\"Invalid name | for feedback session\" is not acceptable to TEAMMATES as "
@@ -530,11 +528,11 @@ public class InstructorFeedbackPageUiTest extends BaseUiTestCase {
         
         ______TS("Successful case: Feedbacks Page");
         
-        feedbackPage.clickFsCopyButton(courseId, feedbackSessionName);
-        feedbackPage.waitForModalToLoad();
-        feedbackPage.fillCopyToOtherCoursesForm("New name!");
+        feedbackPage.fsCopyToModal.clickCopyButtonOnTable(courseId, feedbackSessionName);
+        feedbackPage.fsCopyToModal.waitForModalToLoad();
+        feedbackPage.fsCopyToModal.fillFormWithAllCoursesSelected("New name!");
         
-        feedbackPage.clickFsCopySubmitButton();
+        feedbackPage.fsCopyToModal.clickSubmitButton();
         
         feedbackPage.verifyStatus(Const.StatusMessages.FEEDBACK_SESSION_COPIED);
         

--- a/src/test/java/teammates/test/cases/ui/browsertests/InstructorHomePageUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/InstructorHomePageUiTest.java
@@ -340,40 +340,47 @@ public class InstructorHomePageUiTest extends BaseUiTestCase {
         
         ______TS("Submit empty course list: Home Page");
         
-        homePage.clickFsCopyButton(courseId, feedbackSessionName);
-        homePage.waitForModalToLoad();
-        homePage.clickFsCopySubmitButton();
+        homePage.fsCopyModal.clickCopyButtonOnTable(courseId, feedbackSessionName);
+        homePage.fsCopyModal.waitForModalToLoad();
+        homePage.fsCopyModal.clickSubmitButton();
         homePage.verifyStatus(Const.StatusMessages.FEEDBACK_SESSION_COPY_NONESELECTED);
         
         ______TS("Copying fails due to fs with same name in course selected: Home Page");
         
-        homePage.clickFsCopyButton(courseId, feedbackSessionName);
-        homePage.waitForModalToLoad();
-        homePage.fillCopyToOtherCoursesForm(feedbackSessionName);
+        homePage.fsCopyModal.clickCopyButtonOnTable(courseId, feedbackSessionName);
+        homePage.fsCopyModal.waitForModalToLoad();
+        homePage.fsCopyModal.fillFormWithAllCoursesSelected(feedbackSessionName);
+        homePage.fsCopyModal.clickSubmitButton();
         
-        homePage.clickFsCopySubmitButton();
+        assertTrue(homePage.fsCopyModal.isErrorMessageVisible());
+        homePage.fsCopyModal.verifyErrorMessage();
         
-        String error = String.format(Const.StatusMessages.FEEDBACK_SESSION_COPY_ALREADYEXISTS, feedbackSessionName, courseId);
+        
+        String secondFeedbackSessionName = "Second Feedback Session";
+        String error = String.format(Const.StatusMessages.FEEDBACK_SESSION_COPY_ALREADYEXISTS, secondFeedbackSessionName, courseId);
+        homePage.fsCopyModal.waitForModalToLoad();
+        homePage.fsCopyModal.fillFormWithAllCoursesSelected(secondFeedbackSessionName);
+        homePage.fsCopyModal.clickSubmitButton();
         
         homePage.verifyStatus(error);
         
         ______TS("Copying fails due to fs with invalid name: Home Page");
         
-        homePage.clickFsCopyButton(courseId, feedbackSessionName);
-        homePage.waitForModalToLoad();
-        homePage.fillCopyToOtherCoursesForm("Invalid name | for feedback session");
+        homePage.fsCopyModal.clickCopyButtonOnTable(courseId, feedbackSessionName);
+        homePage.fsCopyModal.waitForModalToLoad();
+        homePage.fsCopyModal.fillFormWithAllCoursesSelected("Invalid name | for feedback session");
         
-        homePage.clickFsCopySubmitButton();
+        homePage.fsCopyModal.clickSubmitButton();
         
         homePage.verifyStatus("\"Invalid name | for feedback session\" is not acceptable to TEAMMATES as feedback session name because it contains invalid characters. All feedback session name must start with an alphanumeric character, and cannot contain any vertical bar (|) or percent sign (%).");
         
         ______TS("Successful case: Home Page");
         
-        homePage.clickFsCopyButton(courseId, feedbackSessionName);
-        homePage.waitForModalToLoad();
-        homePage.fillCopyToOtherCoursesForm("New name!");
+        homePage.fsCopyModal.clickCopyButtonOnTable(courseId, feedbackSessionName);
+        homePage.fsCopyModal.waitForModalToLoad();
+        homePage.fsCopyModal.fillFormWithAllCoursesSelected("New name!");
         
-        homePage.clickFsCopySubmitButton();
+        homePage.fsCopyModal.clickSubmitButton();
         
         homePage.verifyStatus(Const.StatusMessages.FEEDBACK_SESSION_COPIED);
         

--- a/src/test/java/teammates/test/pageobjects/InstructorCopyFsToModal.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorCopyFsToModal.java
@@ -1,0 +1,106 @@
+package teammates.test.pageobjects;
+
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertNotNull;
+
+import java.util.List;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import teammates.common.util.Const;
+
+/**
+ * Utility class for handling the modal for copying a feedback session to other courses 
+ *
+ */
+public class InstructorCopyFsToModal extends AppPage {
+    
+    public InstructorCopyFsToModal(Browser browser) {
+        super(browser);
+    }
+    
+    @Override
+    protected boolean containsExpectedPageContents() {
+        return getPageSource().contains("Copy this feedback session to other courses");
+    }
+    
+    public void waitForModalToLoad() {
+        waitForElementPresence(By.id(Const.ParamsNames.COPIED_FEEDBACK_SESSION_NAME));
+    }
+    
+    public void fillFormWithAllCoursesSelected(String newFsName) {
+        WebElement fsCopyModal = browser.driver.findElement(By.id("fsCopyModal"));
+        List<WebElement> coursesCheckBoxes = fsCopyModal.findElements(By.name(Const.ParamsNames.COPIED_COURSES_ID));
+        for (WebElement e : coursesCheckBoxes) {
+            markCheckBoxAsChecked(e);
+        }
+        
+        WebElement fsNameInput = fsCopyModal.findElement(By.id(Const.ParamsNames.COPIED_FEEDBACK_SESSION_NAME));
+        fillTextBox(fsNameInput, newFsName);
+    }
+    
+    public void resetCoursesCheckbox() {
+        WebElement fsCopyModal = browser.driver.findElement(By.id("fsCopyModal"));
+        List<WebElement> coursesCheckBoxes = fsCopyModal.findElements(By.name(Const.ParamsNames.COPIED_COURSES_ID));
+        for (WebElement e : coursesCheckBoxes) {
+            markCheckBoxAsUnchecked(e);
+        }
+    }
+    
+    public void fillFsName(String fsName) {
+        WebElement fsCopyModal = browser.driver.findElement(By.id("fsCopyModal"));
+        WebElement fsNameInput = fsCopyModal.findElement(By.id(Const.ParamsNames.COPIED_FEEDBACK_SESSION_NAME));
+        fillTextBox(fsNameInput, fsName);
+    }
+    
+    public void checkCourse(String courseId) {
+        WebElement fsCopyModal = browser.driver.findElement(By.id("fsCopyModal"));
+        WebElement courseCheckBox = 
+                fsCopyModal.findElement(
+                        By.xpath("//input[@name='copiedcoursesid' and @value='" + courseId + "']"));
+        
+        assertNotNull(courseCheckBox);
+        markCheckBoxAsChecked(courseCheckBox);
+    }
+    
+    public boolean isErrorMessageVisible() {
+        WebElement copyModalErrorMessage = browser.driver.findElement(By.id("fs_copy_modal_error"));
+        return copyModalErrorMessage.isDisplayed();
+    }
+    
+    public void verifyErrorMessage() {
+        String copyErrorMessage = getFsCopyModalError();
+        String expectedErrorMessage = "Please give the feedback session a different name if the " 
+                                    + "destination course and the source course are the same";
+        assertEquals(expectedErrorMessage, copyErrorMessage);
+    }
+    
+    private String getFsCopyModalError() {
+        WebElement copyModalErrorMessage = browser.driver.findElement(By.id("fs_copy_modal_error"));
+        return copyModalErrorMessage.getText();
+    }
+
+    public void clickSubmitButton() {
+        WebElement fsCopySubmitButton = browser.driver.findElement(By.id("fscopy_submit"));
+        
+        fsCopySubmitButton.click();
+    }
+
+    /**
+     * On InstructorHome and InstructorFeedbacks, this clicks on the 'copy' button on the 
+     * table that displays the feedback sessions
+     * @param courseId
+     * @param feedbackSessionName
+     */
+    public void clickCopyButtonOnTable(String courseId, String feedbackSessionName) {
+        By fsCopyButtonElement = By.id("button_fscopy" + "-" + courseId + "-" + feedbackSessionName);
+        
+        // give it some time to load as it is loaded via AJAX
+        waitForElementPresence(fsCopyButtonElement);
+        
+        WebElement fsCopyButton = browser.driver.findElement(fsCopyButtonElement);
+        
+        fsCopyButton.click();
+    }
+}

--- a/src/test/java/teammates/test/pageobjects/InstructorFeedbackEditPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorFeedbackEditPage.java
@@ -1,5 +1,6 @@
 package teammates.test.pageobjects;
 
+import static org.testng.AssertJUnit.assertNotNull;
 import java.text.DateFormatSymbols;
 import java.util.Calendar;
 import java.util.Date;
@@ -132,6 +133,9 @@ public class InstructorFeedbackEditPage extends AppPage {
     
     @FindBy(id = "button_fscopy")
     private WebElement fscopyButton;
+    
+    @FindBy(id = "fs_copy_modal_error")
+    private WebElement fscopyErrorMessage;
     
     @FindBy(id = "fscopy_submit")
     private WebElement fscopySubmitButton;
@@ -380,6 +384,37 @@ public class InstructorFeedbackEditPage extends AppPage {
         
         WebElement fsNameInput = fsCopyModal.findElement(By.id(Const.ParamsNames.COPIED_FEEDBACK_SESSION_NAME));
         fillTextBox(fsNameInput, newName);
+    }
+    
+    public void resetCoursesCheckbox() {
+        WebElement fsCopyModal = browser.driver.findElement(By.id("fsCopyModal"));
+        List<WebElement> coursesCheckBoxes = fsCopyModal.findElements(By.name(Const.ParamsNames.COPIED_COURSES_ID));
+        for (WebElement e : coursesCheckBoxes) {
+            markCheckBoxAsUnchecked(e);
+        }
+    }
+    
+    public void fillFsCopyModalName(String fsName) {
+        WebElement fsCopyModal = browser.driver.findElement(By.id("fsCopyModal"));
+        WebElement fsNameInput = fsCopyModal.findElement(By.id(Const.ParamsNames.COPIED_FEEDBACK_SESSION_NAME));
+        fillTextBox(fsNameInput, fsName);
+    }
+    
+    public void selectFsCopyModalCourse(String courseId) {
+        WebElement fsCopyModal = browser.driver.findElement(By.id("fsCopyModal"));
+        WebElement courseCheckBox = 
+                fsCopyModal.findElement(
+                        By.xpath("//input[@name='copiedcoursesid' and @value='" + courseId + "']"));
+        assertNotNull(courseCheckBox);
+        markCheckBoxAsChecked(courseCheckBox);
+    }
+    
+    public boolean isFsCopyModalErrorMessageVisible() {
+        return fscopyErrorMessage.isDisplayed();
+    }
+    
+    public String getFsCopyModalError() {
+        return fscopyErrorMessage.getText();
     }
     
     public WebElement getDeleteSessionLink() {

--- a/src/test/java/teammates/test/pageobjects/InstructorFeedbackEditPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorFeedbackEditPage.java
@@ -155,9 +155,11 @@ public class InstructorFeedbackEditPage extends AppPage {
     @FindBy(id = "questiongetlink-1")
     private WebElement getLinkButton;
     
+    public InstructorCopyFsToModal fsCopyToModal;
     
     public InstructorFeedbackEditPage(Browser browser) {
         super(browser);
+        fsCopyToModal = new InstructorCopyFsToModal(browser);
     }
 
     @Override
@@ -371,51 +373,7 @@ public class InstructorFeedbackEditPage extends AppPage {
         addMsqOtherOptionCheckboxForNewQuestion.click();
     }
     
-    public void waitForModalToLoad() {
-        waitForElementPresence(By.id(Const.ParamsNames.COPIED_FEEDBACK_SESSION_NAME));
-    }
     
-    public void fillCopyToOtherCoursesForm(String newName) {
-        WebElement fsCopyModal = browser.driver.findElement(By.id("fsCopyModal"));
-        List<WebElement> coursesCheckBoxes = fsCopyModal.findElements(By.name(Const.ParamsNames.COPIED_COURSES_ID));
-        for (WebElement e : coursesCheckBoxes) {
-            markCheckBoxAsChecked(e);
-        }
-        
-        WebElement fsNameInput = fsCopyModal.findElement(By.id(Const.ParamsNames.COPIED_FEEDBACK_SESSION_NAME));
-        fillTextBox(fsNameInput, newName);
-    }
-    
-    public void resetCoursesCheckbox() {
-        WebElement fsCopyModal = browser.driver.findElement(By.id("fsCopyModal"));
-        List<WebElement> coursesCheckBoxes = fsCopyModal.findElements(By.name(Const.ParamsNames.COPIED_COURSES_ID));
-        for (WebElement e : coursesCheckBoxes) {
-            markCheckBoxAsUnchecked(e);
-        }
-    }
-    
-    public void fillFsCopyModalName(String fsName) {
-        WebElement fsCopyModal = browser.driver.findElement(By.id("fsCopyModal"));
-        WebElement fsNameInput = fsCopyModal.findElement(By.id(Const.ParamsNames.COPIED_FEEDBACK_SESSION_NAME));
-        fillTextBox(fsNameInput, fsName);
-    }
-    
-    public void selectFsCopyModalCourse(String courseId) {
-        WebElement fsCopyModal = browser.driver.findElement(By.id("fsCopyModal"));
-        WebElement courseCheckBox = 
-                fsCopyModal.findElement(
-                        By.xpath("//input[@name='copiedcoursesid' and @value='" + courseId + "']"));
-        assertNotNull(courseCheckBox);
-        markCheckBoxAsChecked(courseCheckBox);
-    }
-    
-    public boolean isFsCopyModalErrorMessageVisible() {
-        return fscopyErrorMessage.isDisplayed();
-    }
-    
-    public String getFsCopyModalError() {
-        return fscopyErrorMessage.getText();
-    }
     
     public WebElement getDeleteSessionLink() {
         return fsDeleteLink;

--- a/src/test/java/teammates/test/pageobjects/InstructorFeedbacksPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorFeedbacksPage.java
@@ -109,9 +109,12 @@ public class InstructorFeedbacksPage extends AppPage {
     @FindBy(id = "button_sortid")
     private WebElement sortByIdIcon;
     
+    public InstructorCopyFsToModal fsCopyToModal;
+    
 
     public InstructorFeedbacksPage(Browser browser) {
         super(browser);
+        fsCopyToModal = new InstructorCopyFsToModal(browser);
     }
 
     @Override
@@ -555,41 +558,5 @@ public class InstructorFeedbacksPage extends AppPage {
         browser.driver.findElement(locator).click();
         waitForPageToLoad();
         return changePageType(destinationPageType);
-    }
-    
-    public void clickFsCopyButton(String courseId, String feedbackSessionName) {
-        By fsCopyButtonElement = By.id("button_fscopy" + "-" + courseId + "-" + feedbackSessionName);
-        
-        // give it some time to load as it is loaded via AJAX
-        waitForElementPresence(fsCopyButtonElement);
-        
-        WebElement fsCopyButton = browser.driver.findElement(fsCopyButtonElement);
-        
-        fsCopyButton.click();
-    }
-    
-    public void waitForModalToLoad() {
-        waitForElementPresence(By.id(Const.ParamsNames.COPIED_FEEDBACK_SESSION_NAME));
-    }
-    
-    public void clickFsCopySubmitButton() {
-        WebElement fsCopySubmitButton = browser.driver.findElement(By.id("fscopy_submit"));
-        
-        fsCopySubmitButton.click();
-    }
-    
-    public void fillCopyToOtherCoursesForm(String newName) {
-        WebElement fsCopyModal = browser.driver.findElement(By.id("fsCopyModal"));
-        List<WebElement> coursesCheckBoxes =
-                fsCopyModal.findElements(By.name(Const.ParamsNames.COPIED_COURSES_ID));
-        
-        for (WebElement e : coursesCheckBoxes) {
-            markCheckBoxAsChecked(e);
-        }
-        
-        WebElement fsNameInput =
-                fsCopyModal.findElement(By.id(Const.ParamsNames.COPIED_FEEDBACK_SESSION_NAME));
-        
-        fillTextBox(fsNameInput, newName);
     }
 }

--- a/src/test/java/teammates/test/pageobjects/InstructorHomePage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorHomePage.java
@@ -7,7 +7,6 @@ import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 
-import teammates.common.util.Const;
 import teammates.common.util.ThreadHelper;
 import teammates.common.util.Url;
 
@@ -30,8 +29,15 @@ public class InstructorHomePage extends AppPage {
     @FindBy(id = "sortByDate")
     private WebElement sortByDateButton;
     
+    public InstructorCopyFsToModal fsCopyModal;
+    
     public InstructorHomePage(Browser browser){
         super(browser);
+        if (browser.driver.findElements(By.id("fsCopyModal")).size() != 0) {
+            // initialize fsCopyModal only if the element is present
+            // the modal will not be present if the instructor's account has not been created
+            fsCopyModal = new InstructorCopyFsToModal(browser);
+        }
     }
 
     @Override
@@ -322,34 +328,5 @@ public class InstructorHomePage extends AppPage {
         if (!isElementPresent(locator))
             return "";
         return browser.driver.findElement(locator).getText();
-    }
-    
-    public void clickFsCopyButton(String courseId, String feedbackSessionName) {
-        WebElement fsCopyButton = browser.driver.findElement(By.id("button_fscopy" + "-" + courseId + "-" + feedbackSessionName));
-        
-        fsCopyButton.click();
-    }
-    
-    public void waitForModalToLoad() {
-        waitForElementPresence(By.id(Const.ParamsNames.COPIED_FEEDBACK_SESSION_NAME));
-    }
-    
-    public void clickFsCopySubmitButton() {
-        WebElement fsCopySubmitButton = browser.driver.findElement(By.id("fscopy_submit"));
-        
-        fsCopySubmitButton.click();
-    }
-    
-    public void fillCopyToOtherCoursesForm(String newName) {
-        WebElement fsCopyModal = browser.driver.findElement(By.id("fsCopyModal"));
-        List<WebElement> coursesCheckBoxes = fsCopyModal.findElements(By.name(Const.ParamsNames.COPIED_COURSES_ID));
-        
-        for (WebElement e : coursesCheckBoxes) {
-            markCheckBoxAsChecked(e);
-        }
-        
-        WebElement fsNameInput = fsCopyModal.findElement(By.id(Const.ParamsNames.COPIED_FEEDBACK_SESSION_NAME));
-        
-        fillTextBox(fsNameInput, newName);
     }
 }

--- a/src/test/resources/pages/instructorFeedbackEditCopyFail.html
+++ b/src/test/resources/pages/instructorFeedbackEditCopyFail.html
@@ -906,7 +906,7 @@
 
     
         <div id="statusMessage" class="alert alert-danger">
-            A feedback session with the name "First Session" already exists in the following course(s): FeedbackEditCopy.CS2104.
+            A feedback session with the name "New name!" already exists in the following course(s): FeedbackEditCopy.CS2105.
         </div>
         <script type="text/javascript" src="/js/statusMessage.js"></script>
     
@@ -1954,7 +1954,26 @@
                             </tr>
                         </thead>
                         
-                            <tbody><tr style="cursor:pointer;">
+                            <tbody>
+                            <tr style="cursor:pointer;">
+                              <td>
+                                 <input type="checkbox"/>
+                                                               </td>
+                              <td>
+                                 FeedbackEditCopy.CS2103
+                              </td>
+                              <td>
+                                 New name!
+                              </td>
+                              <td>
+                                 Essay question
+                              </td>
+                              <td>
+                                 student self feedback
+                              </td>
+                              <input type="hidden" value="{*}"/>
+                                                         </tr>
+                                                         <tr style="cursor:pointer;">
                                     <td><input type="checkbox"></td>
                                     <td>FeedbackEditCopy.CS2104</td>
                                     <td>First Session</td>
@@ -1962,7 +1981,42 @@
                                     <td>student self feedback</td>
                                     <input value="{*}" type="hidden">
                             </tr>
-                        
+                        <tr style="cursor:pointer;">
+                              <td>
+                                 <input type="checkbox"/>
+                                                               </td>
+                              <td>
+                                 FeedbackEditCopy.CS2104
+                              </td>
+                              <td>
+                                 New name!
+                              </td>
+                              <td>
+                                 Essay question
+                              </td>
+                              <td>
+                                 student self feedback
+                              </td>
+                              <input type="hidden" value="{*}"/>
+                                                         </tr>
+                           <tr style="cursor:pointer;">
+                              <td>
+                                 <input type="checkbox"/>
+                                                               </td>
+                              <td>
+                                 FeedbackEditCopy.CS2105
+                              </td>
+                              <td>
+                                 New name!
+                              </td>
+                              <td>
+                                 Essay question
+                              </td>
+                              <td>
+                                 student self feedback
+                              </td>
+                              <input type="hidden" value="{*}"/>
+                                                         </tr>
                     </tbody></table>
                     <input name="fsname" value="First Session" type="hidden">
                     <input name="user" value="FeedbackEditCopyinstructor" type="hidden">

--- a/src/test/resources/pages/instructorFeedbackEditCopyPage.html
+++ b/src/test/resources/pages/instructorFeedbackEditCopyPage.html
@@ -972,7 +972,8 @@
             
         </label>
     </div>
-
+<div id="fs_copy_modal_error">
+                        </div>
 
 <input name="courseid" value="FeedbackEditCopy.CS2104" type="hidden">
 <input name="fsname" value="First Session" type="hidden">


### PR DESCRIPTION
Fixes #4059 

Added javascript validation. If the instructor now tries to copy the feedback session with the same name back to the original course:

![errorinmodal](https://cloud.githubusercontent.com/assets/2216119/9287661/6a12ad1c-4353-11e5-9b02-527e9ee755b8.PNG)

