### PR TITLE
Remove all warning markers in Eclipse, part 2 #4164

### DIFF
--- a/.settings/com.google.gdt.eclipse.core.prefs
+++ b/.settings/com.google.gdt.eclipse.core.prefs
@@ -1,4 +1,0 @@
-eclipse.preferences.version=1
-jarsExcludedFromWebInfLib=
-warSrcDir=src/main/webapp
-warSrcDirIsOutput=true

--- a/.settings/com.google.gdt.eclipse.core.template.prefs
+++ b/.settings/com.google.gdt.eclipse.core.template.prefs
@@ -1,0 +1,4 @@
+eclipse.preferences.version=1
+jarsExcludedFromWebInfLib=*/src/test/resources/lib/appengine/appengine-api-labs.jar|*/src/test/resources/lib/appengine/appengine-api-stubs.jar|*/src/test/resources/lib/appengine/appengine-api.jar|*/src/test/resources/lib/appengine/appengine-remote-api.jar|*/src/test/resources/lib/appengine/appengine-testing.jar|*/src/test/resources/lib/httpunit/httpunit.jar|*/src/test/resources/lib/javamail/mail.jar|*/src/test/resources/lib/selenium/selenium-server-standalone-2.46.0.jar
+warSrcDir=src/main/webapp
+warSrcDirIsOutput=true

--- a/devdocs/settingUp.md
+++ b/devdocs/settingUp.md
@@ -40,6 +40,8 @@ Important: When a version is specified, please install that version instead of t
     `Web → HTML Files → Editor`, `XML Files → Editor`, and
     `JavaScript → Code Style → Formatter → Edit → Tab Policy → Spaces Only`
     to indent using 4 spaces instead of tabs.
+    * HTML syntax: We prefer not to use the HTML syntax validator provided by Eclipse.
+    To turn it off, go to `Window → Preferences → Validation → HTML Syntax Validator` and uncheck the `Build` option.
 3. Create main config files {These are not under revision control because their 
    content vary from developer to developer}.
    * `src/main/resources/build.properties`<br>

--- a/devdocs/settingUp.md
+++ b/devdocs/settingUp.md
@@ -58,6 +58,7 @@ Important: When a version is specified, please install that version instead of t
    * `.settings/com.google.gdt.eclipse.core.prefs`<br>
    Create it using `com.google.gdt.eclipse.core.template.prefs`.
    Change all `*` in `jarsExcludedFromWebInfLib` to your TEAMMATES project folder, e.g. `C:/TEAMMATES`.
+   For this example, `*/src/test/resources/lib/appengine/appengine-api-labs.jar` becomes `C:/TEAMMATES/src/test/resources/lib/appengine/appengine-api-labs.jar`.
 4. Download [this zip file](http://www.comp.nus.edu.sg/~seer/teammates-libs/libsV5.47.zip)
    containing the required library files and unzip it into
    your project folder. Note that this will overwrite some existing library files,

--- a/devdocs/settingUp.md
+++ b/devdocs/settingUp.md
@@ -55,6 +55,9 @@ Important: When a version is specified, please install that version instead of t
    * `src/main/webapp/WEB-INF/appengine-web.xml`<br>
    Create it using `appengine-web.template.xml`. 
    For now, property values can remain as they are.
+   * `.settings/com.google.gdt.eclipse.core.prefs`<br>
+   Create it using `com.google.gdt.eclipse.core.template.prefs`.
+   Change all `*` in `jarsExcludedFromWebInfLib` to your TEAMMATES project folder, e.g. `C:/TEAMMATES`.
 4. Download [this zip file](http://www.comp.nus.edu.sg/~seer/teammates-libs/libsV5.47.zip)
    containing the required library files and unzip it into
    your project folder. Note that this will overwrite some existing library files,

--- a/devdocs/settingUp.md
+++ b/devdocs/settingUp.md
@@ -57,8 +57,8 @@ Important: When a version is specified, please install that version instead of t
    For now, property values can remain as they are.
    * `.settings/com.google.gdt.eclipse.core.prefs`<br>
    Create it using `com.google.gdt.eclipse.core.template.prefs`.
-   Change all `*` in `jarsExcludedFromWebInfLib` to your TEAMMATES project folder, e.g. `C:/TEAMMATES`.
-   For this example, `*/src/test/resources/lib/appengine/appengine-api-labs.jar` becomes `C:/TEAMMATES/src/test/resources/lib/appengine/appengine-api-labs.jar`.
+   In the newly created `com.google.gdt.eclipse.core.prefs` file, replace all the `*` in the value of `jarsExcludedFromWebInfLib` to your TEAMMATES project folder,
+   e.g. `jarsExcludedFromWebInfLib=*/src/test/resources/lib/appengine/appengine-api-labs.jar` becomes `jarsExcludedFromWebInfLib=C:/TEAMMATES/src/test/resources/lib/appengine/appengine-api-labs.jar` if your TEAMMATES project folder is `C:/TEAMMATES`.
 4. Download [this zip file](http://www.comp.nus.edu.sg/~seer/teammates-libs/libsV5.47.zip)
    containing the required library files and unzip it into
    your project folder. Note that this will overwrite some existing library files,


### PR DESCRIPTION
Following the discussion in #4165 to split into two PRs.
Note that the moment this is merged, the original `.prefs` file will be gone (as part of one of the commits). Just re-create it with the template file and change all the `*` as per the instruction. This only needs to be done once.