### PR TITLE
InstructorResults: filter by section options missing "Not in a section" option #4057

### DIFF
--- a/src/main/java/teammates/ui/template/InstructorFeedbackResultsFilterPanel.java
+++ b/src/main/java/teammates/ui/template/InstructorFeedbackResultsFilterPanel.java
@@ -58,6 +58,10 @@ public class InstructorFeedbackResultsFilterPanel {
     public boolean isAllSectionsSelected() {
         return isAllSectionsSelected;
     }
+    
+    public boolean isNoneSectionSelected() {
+        return "None".equals(selectedSection);
+    }
 
     public String getSelectedSection() {
         return selectedSection;

--- a/src/main/webapp/WEB-INF/tags/instructor/results/filterPanel.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/results/filterPanel.tag
@@ -80,6 +80,9 @@
                                             ${section}
                                         </option>
                                     </c:forEach>
+                                    <option value="None"<c:if test="${filterPanel.noneSectionSelected}"> selected="selected"</c:if>>
+                                        Not in a section
+                                    </option>
                                 </select>
                             </div>
                         </div>

--- a/src/test/java/teammates/test/cases/ui/browsertests/InstructorFeedbackResultsPageUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/InstructorFeedbackResultsPageUiTest.java
@@ -395,6 +395,11 @@ public class InstructorFeedbackResultsPageUiTest extends BaseUiTestCase {
         resultsPage.filterResponsesForSection("Section B");
         resultsPage.verifyHtmlMainContent("/instructorFeedbackResultsFilteredBySectionB.html");
 
+        ______TS("Typical case: filter by 'Not in a section', no responses");
+
+        resultsPage.filterResponsesForSection("Not in a section");
+        resultsPage.verifyHtmlMainContent("/instructorFeedbackResultsFilteredByNoSection.html");
+
         resultsPage.filterResponsesForAllSections();
 
     }

--- a/src/test/java/teammates/test/cases/ui/browsertests/InstructorFeedbackResultsPageUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/InstructorFeedbackResultsPageUiTest.java
@@ -395,11 +395,18 @@ public class InstructorFeedbackResultsPageUiTest extends BaseUiTestCase {
         resultsPage.filterResponsesForSection("Section B");
         resultsPage.verifyHtmlMainContent("/instructorFeedbackResultsFilteredBySectionB.html");
 
-        ______TS("Typical case: filter by 'Not in a section', no responses");
+        ______TS("Typical case: filter by 'Not in a section'");
 
         resultsPage.filterResponsesForSection("Not in a section");
         resultsPage.verifyHtmlMainContent("/instructorFeedbackResultsFilteredByNoSection.html");
+        
+        
+        ______TS("Verify that 'Not in a section' has a section panel on a non-question view");
+        resultsPage.displayByRecipientGiverQuestion();
+        assertTrue(resultsPage.isSectionPanelExist("Not in a section"));
+        assertFalse(resultsPage.isSectionPanelExist("Section A"));
 
+        resultsPage.displayByQuestion();
         resultsPage.filterResponsesForAllSections();
 
     }

--- a/src/test/java/teammates/test/pageobjects/InstructorFeedbackResultsPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorFeedbackResultsPage.java
@@ -426,4 +426,15 @@ public class InstructorFeedbackResultsPage extends AppPage {
         ThreadHelper.waitFor(1000);
     }
 
+    public boolean isSectionPanelExist(String section) {
+        List<WebElement> panels = browser.driver.findElements(By.cssSelector("div[id^='panelHeading-']"));
+        for (WebElement panel : panels) {
+            String panelSectionName = panel.findElement(By.className("panel-heading-text")).getText();
+            if (panelSectionName.equals(section)) {
+                return true;
+            }
+        }
+        return false;
+    }
+    
 }

--- a/src/test/resources/pages/instructorFeedbackResultsAddComment.html
+++ b/src/test/resources/pages/instructorFeedbackResultsAddComment.html
@@ -219,6 +219,9 @@
                            <option value="Section B">
                               Section B
                            </option>
+                           <option value="None">
+                              Not in a section
+                           </option>
                         </select>
                      </div>
                   </div>

--- a/src/test/resources/pages/instructorFeedbackResultsAjaxByGQR.html
+++ b/src/test/resources/pages/instructorFeedbackResultsAjaxByGQR.html
@@ -219,6 +219,9 @@
                            <option value="Section B">
                               Section B
                            </option>
+                           <option value="None">
+                              Not in a section
+                           </option>
                         </select>
                      </div>
                   </div>

--- a/src/test/resources/pages/instructorFeedbackResultsAjaxByGRQ.html
+++ b/src/test/resources/pages/instructorFeedbackResultsAjaxByGRQ.html
@@ -219,6 +219,9 @@
                            <option value="Section B">
                               Section B
                            </option>
+                           <option value="None">
+                              Not in a section
+                           </option>
                         </select>
                      </div>
                   </div>

--- a/src/test/resources/pages/instructorFeedbackResultsAjaxByQuestion.html
+++ b/src/test/resources/pages/instructorFeedbackResultsAjaxByQuestion.html
@@ -230,6 +230,9 @@
                                             Section B
                                         </option>
                                     
+                                    <option value="None">
+                                        Not in a section
+                                    </option>
                                 </select>
                             </div>
                         </div>
@@ -257,6 +260,7 @@
 </form>
 
 <br>
+
 
 
 
@@ -1478,7 +1482,11 @@
 
 
 
+
+
+
     <div class="panel panel-warning">
+        
         <div style="cursor: pointer;" id="panelHeading-11" data-target="#panelBodyCollapse-11" class="panel-heading ajax_response_rate_submit">
             <form style="display:none;" id="responseRate" class="responseRateForm" action="/page/instructorFeedbackResultsPage">
                 <input name="courseid" value="CFResultsUiT.CS2104" type="hidden">

--- a/src/test/resources/pages/instructorFeedbackResultsAjaxByQuestionViewForHelperOne.html
+++ b/src/test/resources/pages/instructorFeedbackResultsAjaxByQuestionViewForHelperOne.html
@@ -228,6 +228,9 @@
                                             Section B
                                         </option>
                                     
+                                    <option value="None">
+                                        Not in a section
+                                    </option>
                                 </select>
                             </div>
                         </div>
@@ -255,6 +258,7 @@
 </form>
 
 <br>
+
 
 
 
@@ -888,7 +892,11 @@
 
 
 
+
+
+
     <div class="panel panel-warning">
+        
         <div style="cursor: pointer;" id="panelHeading-11" data-target="#panelBodyCollapse-11" class="panel-heading ajax_response_rate_submit">
             <form style="display:none;" id="responseRate" class="responseRateForm" action="/page/instructorFeedbackResultsPage">
                 <input name="courseid" value="CFResultsUiT.CS2104" type="hidden">

--- a/src/test/resources/pages/instructorFeedbackResultsAjaxByQuestionViewForHelperTwo.html
+++ b/src/test/resources/pages/instructorFeedbackResultsAjaxByQuestionViewForHelperTwo.html
@@ -228,6 +228,9 @@
                                             Section B
                                         </option>
                                     
+                                    <option value="None">
+                                        Not in a section
+                                    </option>
                                 </select>
                             </div>
                         </div>
@@ -255,6 +258,7 @@
 </form>
 
 <br>
+
 
 
 
@@ -1408,7 +1412,11 @@
 
 
 
+
+
+
     <div class="panel panel-warning">
+        
         <div style="cursor: pointer;" id="panelHeading-11" data-target="#panelBodyCollapse-11" class="panel-heading ajax_response_rate_submit">
             <form style="display:none;" id="responseRate" class="responseRateForm" action="/page/instructorFeedbackResultsPage">
                 <input name="courseid" value="CFResultsUiT.CS2104" type="hidden">

--- a/src/test/resources/pages/instructorFeedbackResultsAjaxByRGQ.html
+++ b/src/test/resources/pages/instructorFeedbackResultsAjaxByRGQ.html
@@ -219,6 +219,9 @@
                            <option value="Section B">
                               Section B
                            </option>
+                           <option value="None">
+                              Not in a section
+                           </option>
                         </select>
                      </div>
                   </div>

--- a/src/test/resources/pages/instructorFeedbackResultsAjaxByRQG.html
+++ b/src/test/resources/pages/instructorFeedbackResultsAjaxByRQG.html
@@ -219,6 +219,9 @@
                            <option value="Section B">
                               Section B
                            </option>
+                           <option value="None">
+                              Not in a section
+                           </option>
                         </select>
                      </div>
                   </div>

--- a/src/test/resources/pages/instructorFeedbackResultsDeleteComment.html
+++ b/src/test/resources/pages/instructorFeedbackResultsDeleteComment.html
@@ -219,6 +219,9 @@
                            <option value="Section B">
                               Section B
                            </option>
+                           <option value="None">
+                              Not in a section
+                           </option>
                         </select>
                      </div>
                   </div>

--- a/src/test/resources/pages/instructorFeedbackResultsFilteredByNoSection.html
+++ b/src/test/resources/pages/instructorFeedbackResultsFilteredByNoSection.html
@@ -1,0 +1,730 @@
+<div class="container" id="mainContent">
+   <div id="topOfPage">
+   </div>
+   <h1>
+      Session Results
+   </h1>
+   <br/>
+      <div class="well well-plain padding-0">
+      <div class="form-horizontal">
+         <div class="panel-heading">
+            <div class="row">
+               <div class="col-sm-4">
+                  <div class="form-group">
+                     <label class="col-sm-2 control-label">
+                        Course ID:
+                     </label>
+                     <div class="col-sm-10">
+                        <p class="form-control-static">
+                           CFResultsUiT.CS2104
+                        </p>
+                     </div>
+                  </div>
+                  <div class="form-group">
+                     <label class="col-sm-2 control-label">
+                        Session:
+                     </label>
+                     <div class="col-sm-10">
+                        <p class="form-control-static">
+                           First Session
+                           <a href="&#x2f;page&#x2f;instructorFeedbackEditPage?courseid=CFResultsUiT.CS2104&amp;fsname=First+Session&amp;user=CFResultsUiT.instr">
+                              [Edit]
+                           </a>
+                        </p>
+                     </div>
+                  </div>
+               </div>
+               <div class="col-sm-6">
+                  <div class="form-group">
+                     <label class="col-sm-4 control-label">
+                        Session duration:
+                     </label>
+                     <div class="col-sm-8">
+                        <p class="form-control-static">
+                           Sun, 01 Apr 2012, 23:59   
+                           <b>
+                              to
+                           </b>
+                              Sat, 30 Apr 2016, 23:59
+                        </p>
+                     </div>
+                  </div>
+                  <div class="form-group">
+                     <label class="col-sm-4 control-label">
+                        Results visible from:
+                     </label>
+                     <div class="col-sm-8">
+                        <p class="form-control-static">
+                           Tue, 01 May 2012, 23:59
+                        </p>
+                     </div>
+                  </div>
+               </div>
+               <div class="col-sm-2">
+                  <div class="form-group">
+                     <div class="col-sm-12">
+                        <form action="&#x2f;page&#x2f;instructorFeedbackResultsDownload" method="post">
+                           <div id="feedbackDataButtons">
+                              <input class="btn btn-primary btn-block" id="button_download" name="fruploaddownloadbtn" type="submit" value="Download Results"/>
+                                                         </div>
+                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
+                                                      <input name="fsname" type="hidden" value="First Session"/>
+                                                      <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
+                                                      <input name="sectionname" type="hidden" value="None"/>
+                                                   </form>
+                        <br/>
+                                                <div>
+                           <a class="btn btn-primary btn-block btn-tm-actions session-unpublish-for-test" data-original-title="Make responses no longer visible" data-placement="top" data-toggle="tooltip" href="&#x2f;page&#x2f;instructorFeedbackUnpublish?courseid=CFResultsUiT.CS2104&amp;fsname=First+Session&amp;next=%2Fpage%2FinstructorFeedbacksPage%3Fuser%3DCFResultsUiT.instr&amp;user=CFResultsUiT.instr" onclick="return toggleUnpublishEvaluation(&#39;First Session&#39;);" title="">
+                              Unpublish Results
+                           </a>
+                        </div>
+                     </div>
+                  </div>
+               </div>
+            </div>
+            <div class="row">
+               <span class="help-block align-center">
+                  Non-English characters not displayed properly in the downloaded file?
+                  <span class="btn-link" data-target="#fsResultsTableWindow" data-toggle="modal" onclick="submitFormAjax()">
+                     click here
+                  </span>
+               </span>
+            </div>
+         </div>
+      </div>
+   </div>
+   <form id="csvToHtmlForm">
+      <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
+            <input name="fsname" type="hidden" value="First Session"/>
+            <input name="user" type="hidden" value="CFResultsUiT.instr"/>
+            <input name="frgroupbysection" type="hidden" value="None"/>
+            <input name="csvtohtmltable" type="hidden" value="true"/>
+         </form>
+   <div class="modal fade align-center" id="fsResultsTableWindow">
+      <div class="modal-dialog modal-lg">
+         <div class="modal-content">
+            <div class="modal-header">
+               <span class="help-block" style="display:inline;">
+                  Tips: After selecting the table,
+                  <kbd>
+                     Ctrl + C
+                  </kbd>
+                  to COPY and
+                  <kbd>
+                     Ctrl + V
+                  </kbd>
+                  to PASTE to your Excel Workbook.
+               </span>
+                    
+               <button class="btn btn-default" data-dismiss="modal" type="button">
+                  Close
+               </button>
+               <button class="btn btn-primary" onclick="selectElementContents(document.getElementById(&#39;fsModalTable&#39;));" type="button">
+                  Select Table
+               </button>
+            </div>
+            <div class="modal-body">
+               <div class="table-responsive">
+                  <div id="fsModalTable">
+                  </div>
+                  <br/>
+                                    <div id="ajaxStatus">
+                  </div>
+               </div>
+            </div>
+            <div class="modal-footer">
+            </div>
+         </div>
+      </div>
+   </div>
+   <form action="&#x2f;page&#x2f;instructorFeedbackResultsPage?courseid=CFResultsUiT.CS2104&amp;fsname=First+Session&amp;user=CFResultsUiT.instr" class="form-horizontal" method="post" role="form">
+      <div class="panel panel-info margin-0">
+         <div class="panel-body">
+            <div class="row">
+               <div class="col-sm-5" data-original-title="View results in different formats" data-toggle="tooltip" title="">
+                  <div class="form-group">
+                     <label class="col-sm-2 control-label" for="viewSelect">
+                        View:
+                     </label>
+                     <div class="col-sm-10">
+                        <select class="form-control" id="viewSelect" name="frsorttype" onchange="this.form.submit()">
+                           <option selected="selected" value="question">
+                              Group by - Question
+                           </option>
+                           <option value="giver-recipient-question">
+                              Group by - Giver &gt; Recipient &gt; Question
+                           </option>
+                           <option value="recipient-giver-question">
+                              Group by - Recipient &gt; Giver &gt; Question
+                           </option>
+                           <option value="giver-question-recipient">
+                              Group by - Giver &gt; Question &gt; Recipient
+                           </option>
+                           <option value="recipient-question-giver">
+                              Group by - Recipient &gt; Question &gt; Giver
+                           </option>
+                        </select>
+                     </div>
+                  </div>
+               </div>
+               <div class="col-sm-5" data-original-title="Filter the results in the current view" data-toggle="tooltip" title="">
+                  <div class="form-group">
+                     <label class="col-sm-2 control-label" for="viewSelect">
+                        Filter:
+                     </label>
+                     <div class="col-sm-10">
+                        <div class="input-group">
+                           <input class="form-control" id="results-search-box" onchange="updateResultsFilter()" placeholder="Type keywords from the question to filter" type="text"/>
+                                                      <a class="input-group-addon btn btn-default">
+                              <span class="glyphicon glyphicon-search">
+                              </span>
+                           </a>
+                        </div>
+                     </div>
+                  </div>
+               </div>
+               <div class="col-sm-2 pull-right">
+                  <div class="col-sm-12" data-original-title="Group results in the current view by team" data-toggle="tooltip" title="">
+                     <div class="checkbox padding-top-0 min-height-0">
+                        <label class="text-strike">
+                           <input id="frgroupbyteam" name="frgroupbyteam" type="checkbox"/>
+                                                      Group by Teams
+                        </label>
+                     </div>
+                  </div>
+                  <div class="col-sm-12" data-original-title="Show statistics" data-toggle="tooltip" title="">
+                     <div class="checkbox padding-top-0 min-height-0">
+                        <label>
+                           <input checked="checked" id="show-stats-checkbox" name="frshowstats" type="checkbox"/>
+                                                      Show Statistics
+                        </label>
+                     </div>
+                  </div>
+               </div>
+            </div>
+            <div class="row">
+               <div class="col-sm-5" data-original-title="View results by sections" data-toggle="tooltip" title="">
+                  <div class="form-group">
+                     <label class="col-sm-2 control-label" for="sectionSelect">
+                        Section:
+                     </label>
+                     <div class="col-sm-10">
+                        <select class="form-control" id="sectionSelect" name="frgroupbysection" onchange="this.form.submit()">
+                           <option value="All">
+                              All
+                           </option>
+                           <option value="Section A">
+                              Section A
+                           </option>
+                           <option value="Section B">
+                              Section B
+                           </option>
+                           <option selected="selected" value="None">
+                              Not in a section
+                           </option>
+                        </select>
+                     </div>
+                  </div>
+               </div>
+               <div class="col-sm-7 pull-right" style="padding-top:8px;">
+                  <a class="btn btn-default btn-xs pull-right" data-original-title="Collapse all panels. You can also click on the panel heading to toggle each one individually." data-toggle="tooltip" id="collapse-panels-button" onclick="toggleCollapse(this)" title="">
+                     Collapse Questions
+                  </a>
+               </div>
+            </div>
+         </div>
+      </div>
+      <input name="fsname" type="hidden" value="First Session"/>
+            <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
+            <input name="user" type="hidden" value="CFResultsUiT.instr"/>
+         </form>
+   <br/>
+      <div id="statusMessage" style="display: none;">
+   </div>
+   <br/>
+      <br/>
+      <div class="panel panel-info">
+      <div class="panel-heading" data-target="#panelBodyCollapse-1" id="panelHeading-1" style="cursor: pointer;">
+         <form action="&#x2f;page&#x2f;instructorFeedbackResultsPage" class="seeMoreForm-1" id="seeMore-1" style="display:none;">
+            <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
+                        <input name="fsname" type="hidden" value="First Session"/>
+                        <input name="user" type="hidden" value="CFResultsUiT.instr"/>
+                        <input name="frgroupbyteam" type="hidden" value="null"/>
+                        <input name="frsorttype" type="hidden" value="question"/>
+                        <input id="showStats-1" name="frshowstats" type="hidden" value="on"/>
+                        <input name="questionnum" type="hidden" value="1"/>
+                        <input name="frgroupbysection" type="hidden" value="None"/>
+                     </form>
+         <div class="display-icon pull-right">
+            <span class="glyphicon pull-right glyphicon-chevron-up">
+            </span>
+         </div>
+         <strong>
+            Question 1:
+         </strong>
+         <div class="inline panel-heading-text">
+            <span class="text-preserve-space">
+               Rate 3 other students&#39; products
+            </span>
+         </div>
+      </div>
+      <div class="panel-collapse collapse in" id="panelBodyCollapse-1" style="height: auto;">
+         <div class="panel-body" id="questionBody-0">
+            <div class="col-sm-12">
+               <i class="text-muted">
+                  There are no responses for this question.
+               </i>
+            </div>
+         </div>
+      </div>
+   </div>
+   <div class="panel panel-info">
+      <div class="panel-heading" data-target="#panelBodyCollapse-2" id="panelHeading-2" style="cursor: pointer;">
+         <form action="&#x2f;page&#x2f;instructorFeedbackResultsPage" class="seeMoreForm-2" id="seeMore-2" style="display:none;">
+            <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
+                        <input name="fsname" type="hidden" value="First Session"/>
+                        <input name="user" type="hidden" value="CFResultsUiT.instr"/>
+                        <input name="frgroupbyteam" type="hidden" value="null"/>
+                        <input name="frsorttype" type="hidden" value="question"/>
+                        <input id="showStats-2" name="frshowstats" type="hidden" value="on"/>
+                        <input name="questionnum" type="hidden" value="2"/>
+                        <input name="frgroupbysection" type="hidden" value="None"/>
+                     </form>
+         <div class="display-icon pull-right">
+            <span class="glyphicon pull-right glyphicon-chevron-up">
+            </span>
+         </div>
+         <strong>
+            Question 2:
+         </strong>
+         <div class="inline panel-heading-text">
+            <span class="text-preserve-space">
+               What is the best selling point of your product?
+            </span>
+         </div>
+      </div>
+      <div class="panel-collapse collapse in" id="panelBodyCollapse-2" style="height: auto;">
+         <div class="panel-body" id="questionBody-1">
+            <div class="col-sm-12">
+               <i class="text-muted">
+                  There are no responses for this question.
+               </i>
+            </div>
+         </div>
+      </div>
+   </div>
+   <div class="panel panel-info">
+      <div class="panel-heading" data-target="#panelBodyCollapse-3" id="panelHeading-3" style="cursor: pointer;">
+         <form action="&#x2f;page&#x2f;instructorFeedbackResultsPage" class="seeMoreForm-3" id="seeMore-3" style="display:none;">
+            <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
+                        <input name="fsname" type="hidden" value="First Session"/>
+                        <input name="user" type="hidden" value="CFResultsUiT.instr"/>
+                        <input name="frgroupbyteam" type="hidden" value="null"/>
+                        <input name="frsorttype" type="hidden" value="question"/>
+                        <input id="showStats-3" name="frshowstats" type="hidden" value="on"/>
+                        <input name="questionnum" type="hidden" value="3"/>
+                        <input name="frgroupbysection" type="hidden" value="None"/>
+                     </form>
+         <div class="display-icon pull-right">
+            <span class="glyphicon pull-right glyphicon-chevron-up">
+            </span>
+         </div>
+         <strong>
+            Question 3:
+         </strong>
+         <div class="inline panel-heading-text">
+            <span class="text-preserve-space">
+               My comments on the class
+            </span>
+         </div>
+      </div>
+      <div class="panel-collapse collapse in" id="panelBodyCollapse-3" style="height: auto;">
+         <div class="panel-body padding-0" id="questionBody-2">
+            <div class="resultStatistics">
+            </div>
+            <div class="table-responsive">
+               <table class="table table-striped table-bordered dataTable margin-0">
+                  <thead class="background-color-medium-gray text-color-gray font-weight-normal">
+                     <tr>
+                        <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,1)" style="width: 15%;">
+                           Giver
+                           <span class="icon-sort unsorted">
+                           </span>
+                        </th>
+                        <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                           Team
+                           <span class="icon-sort unsorted">
+                           </span>
+                        </th>
+                        <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,3)" style="width: 15%;">
+                           Recipient
+                           <span class="icon-sort unsorted">
+                           </span>
+                        </th>
+                        <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,4)" style="width: 15%;">
+                           Team
+                           <span class="icon-sort unsorted">
+                           </span>
+                        </th>
+                        <th class="button-sort-none" id="button_sortFeedback" onclick="toggleSort(this,5)">
+                           Feedback
+                           <span class="icon-sort unsorted">
+                           </span>
+                        </th>
+                        <th>
+                           Actions
+                        </th>
+                     </tr>
+                  </thead>
+                  <thead>
+                  </thead>
+                  <tbody>
+                     <tr>
+                        <td class="middlealign">
+                           <div class="profile-pic-icon-hover" data-link="&#x2f;page&#x2f;studentProfilePic?studentemail={*}&amp;courseid={*}&amp;user=CFResultsUiT.instr" data-original-title="" title="">
+                              Teammates Test
+                              <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                                                         </div>
+                        </td>
+                        <td class="middlealign">
+                           Instructors
+                        </td>
+                        <td class="middlealign">
+                           -
+                        </td>
+                        <td class="middlealign">
+                           -
+                        </td>
+                        <td class="text-preserve-space">
+                           This is for nobody specific.
+                        </td>
+                        <td>
+                           <form action="&#x2f;page&#x2f;instructorEditStudentFeedbackPage?user=CFResultsUiT.instr" class="inline" method="post" target="_blank">
+                              <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
+                                                            <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
+                                                            <input name="fsname" type="hidden" value="First Session"/>
+                                                            <input name="moderatedquestion" type="hidden" value="3"/>
+                                                            <input name="moderatedstudent" type="hidden" value="CFResultsUiT.instr@gmail.tmt"/>
+                                                         </form>
+                        </td>
+                     </tr>
+                  </tbody>
+               </table>
+            </div>
+         </div>
+      </div>
+   </div>
+   <div class="panel panel-info">
+      <div class="panel-heading" data-target="#panelBodyCollapse-4" id="panelHeading-4" style="cursor: pointer;">
+         <form action="&#x2f;page&#x2f;instructorFeedbackResultsPage" class="seeMoreForm-4" id="seeMore-4" style="display:none;">
+            <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
+                        <input name="fsname" type="hidden" value="First Session"/>
+                        <input name="user" type="hidden" value="CFResultsUiT.instr"/>
+                        <input name="frgroupbyteam" type="hidden" value="null"/>
+                        <input name="frsorttype" type="hidden" value="question"/>
+                        <input id="showStats-4" name="frshowstats" type="hidden" value="on"/>
+                        <input name="questionnum" type="hidden" value="4"/>
+                        <input name="frgroupbysection" type="hidden" value="None"/>
+                     </form>
+         <div class="display-icon pull-right">
+            <span class="glyphicon pull-right glyphicon-chevron-up">
+            </span>
+         </div>
+         <strong>
+            Question 4:
+         </strong>
+         <div class="inline panel-heading-text">
+            <span class="text-preserve-space">
+               Give feedback to 3 other teams.
+            </span>
+         </div>
+      </div>
+      <div class="panel-collapse collapse in" id="panelBodyCollapse-4" style="height: auto;">
+         <div class="panel-body" id="questionBody-3">
+            <div class="col-sm-12">
+               <i class="text-muted">
+                  There are no responses for this question.
+               </i>
+            </div>
+         </div>
+      </div>
+   </div>
+   <div class="panel panel-info">
+      <div class="panel-heading" data-target="#panelBodyCollapse-5" id="panelHeading-5" style="cursor: pointer;">
+         <form action="&#x2f;page&#x2f;instructorFeedbackResultsPage" class="seeMoreForm-5" id="seeMore-5" style="display:none;">
+            <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
+                        <input name="fsname" type="hidden" value="First Session"/>
+                        <input name="user" type="hidden" value="CFResultsUiT.instr"/>
+                        <input name="frgroupbyteam" type="hidden" value="null"/>
+                        <input name="frsorttype" type="hidden" value="question"/>
+                        <input id="showStats-5" name="frshowstats" type="hidden" value="on"/>
+                        <input name="questionnum" type="hidden" value="5"/>
+                        <input name="frgroupbysection" type="hidden" value="None"/>
+                     </form>
+         <div class="display-icon pull-right">
+            <span class="glyphicon pull-right glyphicon-chevron-up">
+            </span>
+         </div>
+         <strong>
+            Question 5:
+         </strong>
+         <div class="inline panel-heading-text">
+            <span class="text-preserve-space">
+               Give feedback to your team mates
+            </span>
+         </div>
+      </div>
+      <div class="panel-collapse collapse in" id="panelBodyCollapse-5" style="height: auto;">
+         <div class="panel-body" id="questionBody-4">
+            <div class="col-sm-12">
+               <i class="text-muted">
+                  There are no responses for this question.
+               </i>
+            </div>
+         </div>
+      </div>
+   </div>
+   <div class="panel panel-info">
+      <div class="panel-heading" data-target="#panelBodyCollapse-6" id="panelHeading-6" style="cursor: pointer;">
+         <form action="&#x2f;page&#x2f;instructorFeedbackResultsPage" class="seeMoreForm-6" id="seeMore-6" style="display:none;">
+            <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
+                        <input name="fsname" type="hidden" value="First Session"/>
+                        <input name="user" type="hidden" value="CFResultsUiT.instr"/>
+                        <input name="frgroupbyteam" type="hidden" value="null"/>
+                        <input name="frsorttype" type="hidden" value="question"/>
+                        <input id="showStats-6" name="frshowstats" type="hidden" value="on"/>
+                        <input name="questionnum" type="hidden" value="6"/>
+                        <input name="frgroupbysection" type="hidden" value="None"/>
+                     </form>
+         <div class="display-icon pull-right">
+            <span class="glyphicon pull-right glyphicon-chevron-up">
+            </span>
+         </div>
+         <strong>
+            Question 6:
+         </strong>
+         <div class="inline panel-heading-text">
+            <span class="text-preserve-space">
+               This question should be hidden.
+            </span>
+         </div>
+      </div>
+      <div class="panel-collapse collapse in" id="panelBodyCollapse-6" style="height: auto;">
+         <div class="panel-body" id="questionBody-5">
+            <div class="col-sm-12">
+               <i class="text-muted">
+                  There are no responses for this question.
+               </i>
+            </div>
+         </div>
+      </div>
+   </div>
+   <div class="panel panel-info">
+      <div class="panel-heading" data-target="#panelBodyCollapse-7" id="panelHeading-7" style="cursor: pointer;">
+         <form action="&#x2f;page&#x2f;instructorFeedbackResultsPage" class="seeMoreForm-7" id="seeMore-7" style="display:none;">
+            <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
+                        <input name="fsname" type="hidden" value="First Session"/>
+                        <input name="user" type="hidden" value="CFResultsUiT.instr"/>
+                        <input name="frgroupbyteam" type="hidden" value="null"/>
+                        <input name="frsorttype" type="hidden" value="question"/>
+                        <input id="showStats-7" name="frshowstats" type="hidden" value="on"/>
+                        <input name="questionnum" type="hidden" value="7"/>
+                        <input name="frgroupbysection" type="hidden" value="None"/>
+                     </form>
+         <div class="display-icon pull-right">
+            <span class="glyphicon pull-right glyphicon-chevron-up">
+            </span>
+         </div>
+         <strong>
+            Question 7:
+         </strong>
+         <div class="inline panel-heading-text">
+            <span class="text-preserve-space">
+               What is your extra feature? 
+               <span style=" white-space: normal;">
+                  <a class="color_gray" data-less="[less]" data-more="[more]" href="javascript:;" id="questionAdditionalInfoButton-7-" onclick="toggleAdditionalQuestionInfo(&#39;7-&#39;)">
+                     [more]
+                  </a>
+                  <br/>
+                                    <span id="questionAdditionalInfo-7-" style="display:none;">
+                     Multiple-choice (single answer) question options:
+                     <ul style="list-style-type: disc;margin-left: 20px;">
+                        <li>
+                           FlexiCommand
+                        </li>
+                        <li>
+                           PowerSearch
+                        </li>
+                        <li>
+                           GoodUI
+                        </li>
+                        <li>
+                           Google Integration
+                        </li>
+                     </ul>
+                  </span>
+               </span>
+            </span>
+         </div>
+      </div>
+      <div class="panel-collapse collapse in" id="panelBodyCollapse-7" style="height: auto;">
+         <div class="panel-body" id="questionBody-6">
+            <div class="col-sm-12">
+               <i class="text-muted">
+                  There are no responses for this question.
+               </i>
+            </div>
+         </div>
+      </div>
+   </div>
+   <div class="panel panel-info">
+      <div class="panel-heading" data-target="#panelBodyCollapse-8" id="panelHeading-8" style="cursor: pointer;">
+         <form action="&#x2f;page&#x2f;instructorFeedbackResultsPage" class="seeMoreForm-8" id="seeMore-8" style="display:none;">
+            <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
+                        <input name="fsname" type="hidden" value="First Session"/>
+                        <input name="user" type="hidden" value="CFResultsUiT.instr"/>
+                        <input name="frgroupbyteam" type="hidden" value="null"/>
+                        <input name="frsorttype" type="hidden" value="question"/>
+                        <input id="showStats-8" name="frshowstats" type="hidden" value="on"/>
+                        <input name="questionnum" type="hidden" value="8"/>
+                        <input name="frgroupbysection" type="hidden" value="None"/>
+                     </form>
+         <div class="display-icon pull-right">
+            <span class="glyphicon pull-right glyphicon-chevron-up">
+            </span>
+         </div>
+         <strong>
+            Question 8:
+         </strong>
+         <div class="inline panel-heading-text">
+            <span class="text-preserve-space">
+               What is your extra feature? 
+               <span style=" white-space: normal;">
+                  <a class="color_gray" data-less="[less]" data-more="[more]" href="javascript:;" id="questionAdditionalInfoButton-8-" onclick="toggleAdditionalQuestionInfo(&#39;8-&#39;)">
+                     [more]
+                  </a>
+                  <br/>
+                                    <span id="questionAdditionalInfo-8-" style="display:none;">
+                     Multiple-choice (multiple answers) question options:
+                     <ul style="list-style-type: disc;margin-left: 20px;">
+                        <li>
+                           FlexiCommand
+                        </li>
+                        <li>
+                           PowerSearch
+                        </li>
+                        <li>
+                           GoodUI
+                        </li>
+                        <li>
+                           Google Integration
+                        </li>
+                     </ul>
+                  </span>
+               </span>
+            </span>
+         </div>
+      </div>
+      <div class="panel-collapse collapse in" id="panelBodyCollapse-8" style="height: auto;">
+         <div class="panel-body" id="questionBody-7">
+            <div class="col-sm-12">
+               <i class="text-muted">
+                  There are no responses for this question.
+               </i>
+            </div>
+         </div>
+      </div>
+   </div>
+   <div class="panel panel-info">
+      <div class="panel-heading" data-target="#panelBodyCollapse-9" id="panelHeading-9" style="cursor: pointer;">
+         <form action="&#x2f;page&#x2f;instructorFeedbackResultsPage" class="seeMoreForm-9" id="seeMore-9" style="display:none;">
+            <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
+                        <input name="fsname" type="hidden" value="First Session"/>
+                        <input name="user" type="hidden" value="CFResultsUiT.instr"/>
+                        <input name="frgroupbyteam" type="hidden" value="null"/>
+                        <input name="frsorttype" type="hidden" value="question"/>
+                        <input id="showStats-9" name="frshowstats" type="hidden" value="on"/>
+                        <input name="questionnum" type="hidden" value="9"/>
+                        <input name="frgroupbysection" type="hidden" value="None"/>
+                     </form>
+         <div class="display-icon pull-right">
+            <span class="glyphicon pull-right glyphicon-chevron-up">
+            </span>
+         </div>
+         <strong>
+            Question 9:
+         </strong>
+         <div class="inline panel-heading-text">
+            <span class="text-preserve-space">
+               Who do you think is the most hardworking student? 
+               <span style=" white-space: normal;">
+                  <a class="color_gray" data-less="[less]" data-more="[more]" href="javascript:;" id="questionAdditionalInfoButton-9-" onclick="toggleAdditionalQuestionInfo(&#39;9-&#39;)">
+                     [more]
+                  </a>
+                  <br/>
+                                    <span id="questionAdditionalInfo-9-" style="display:none;">
+                     Multiple-choice (single answer) question options:
+                     <br/>
+                                          The options for this question is automatically generated from the list of all students in this course.
+                  </span>
+               </span>
+            </span>
+         </div>
+      </div>
+      <div class="panel-collapse collapse in" id="panelBodyCollapse-9" style="height: auto;">
+         <div class="panel-body" id="questionBody-8">
+            <div class="col-sm-12">
+               <i class="text-muted">
+                  There are no responses for this question.
+               </i>
+            </div>
+         </div>
+      </div>
+   </div>
+   <div class="panel panel-info">
+      <div class="panel-heading" data-target="#panelBodyCollapse-10" id="panelHeading-10" style="cursor: pointer;">
+         <form action="&#x2f;page&#x2f;instructorFeedbackResultsPage" class="seeMoreForm-10" id="seeMore-10" style="display:none;">
+            <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
+                        <input name="fsname" type="hidden" value="First Session"/>
+                        <input name="user" type="hidden" value="CFResultsUiT.instr"/>
+                        <input name="frgroupbyteam" type="hidden" value="null"/>
+                        <input name="frsorttype" type="hidden" value="question"/>
+                        <input id="showStats-10" name="frshowstats" type="hidden" value="on"/>
+                        <input name="questionnum" type="hidden" value="10"/>
+                        <input name="frgroupbysection" type="hidden" value="None"/>
+                     </form>
+         <div class="display-icon pull-right">
+            <span class="glyphicon pull-right glyphicon-chevron-up">
+            </span>
+         </div>
+         <strong>
+            Question 10:
+         </strong>
+         <div class="inline panel-heading-text">
+            <span class="text-preserve-space">
+               Which team do you think has the best feature? 
+               <span style=" white-space: normal;">
+                  <a class="color_gray" data-less="[less]" data-more="[more]" href="javascript:;" id="questionAdditionalInfoButton-10-" onclick="toggleAdditionalQuestionInfo(&#39;10-&#39;)">
+                     [more]
+                  </a>
+                  <br/>
+                                    <span id="questionAdditionalInfo-10-" style="display:none;">
+                     Multiple-choice (single answer) question options:
+                     <br/>
+                                          The options for this question is automatically generated from the list of all teams in this course.
+                  </span>
+               </span>
+            </span>
+         </div>
+      </div>
+      <div class="panel-collapse collapse in" id="panelBodyCollapse-10" style="height: auto;">
+         <div class="panel-body" id="questionBody-9">
+            <div class="col-sm-12">
+               <i class="text-muted">
+                  There are no responses for this question.
+               </i>
+            </div>
+         </div>
+      </div>
+   </div>
+</div>

--- a/src/test/resources/pages/instructorFeedbackResultsFilteredBySectionA.html
+++ b/src/test/resources/pages/instructorFeedbackResultsFilteredBySectionA.html
@@ -219,6 +219,9 @@
                            <option value="Section B">
                               Section B
                            </option>
+                           <option value="None">
+                              Not in a section
+                           </option>
                         </select>
                      </div>
                   </div>

--- a/src/test/resources/pages/instructorFeedbackResultsFilteredBySectionB.html
+++ b/src/test/resources/pages/instructorFeedbackResultsFilteredBySectionB.html
@@ -219,6 +219,9 @@
                            <option selected="selected" value="Section B">
                               Section B
                            </option>
+                           <option value="None">
+                              Not in a section
+                           </option>
                         </select>
                      </div>
                   </div>

--- a/src/test/resources/pages/instructorFeedbackResultsPageOpen.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageOpen.html
@@ -518,7 +518,6 @@
 
 
 
-
     
     
         <div style="display: none;" id="statusMessage"></div>
@@ -4755,11 +4754,7 @@
 
 
 
-
-
-
     <div class="panel panel-warning">
-        
         <div class="panel-heading ajax_response_rate_auto" data-target="#panelBodyCollapse-11" id="panelHeading-11" style="cursor: pointer;">
             <form action="/page/instructorFeedbackResultsPage" class="responseRateForm" id="responseRate" style="display:none;">
                 <input type="hidden" value="CFResultsUiT.CS2104" name="courseid" />
@@ -4920,4 +4915,4 @@
 </div>
 
 
-<div class="tooltip fade top in" style="top: {*}px; left: {*}px; display: block;"><div class="tooltip-arrow"></div><div class="tooltip-inner">Filter the results in the current view</div></div></body></html>
+<div class="tooltip fade top in" style="top: {*}px; left: {*}px; display: block;"><div class="tooltip-arrow"></div><div class="tooltip-inner">View results by sections</div></div></body></html>

--- a/src/test/resources/pages/instructorFeedbackResultsPageOpen.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageOpen.html
@@ -483,6 +483,9 @@
                                             Section B
                                         </option>
                                     
+                                    <option value="None">
+                                        Not in a section
+                                    </option>
                                 </select>
                             </div>
                         </div>
@@ -508,6 +511,7 @@
 </form>
 
 <br />
+
 
 
 
@@ -4751,7 +4755,11 @@
 
 
 
+
+
+
     <div class="panel panel-warning">
+        
         <div class="panel-heading ajax_response_rate_auto" data-target="#panelBodyCollapse-11" id="panelHeading-11" style="cursor: pointer;">
             <form action="/page/instructorFeedbackResultsPage" class="responseRateForm" id="responseRate" style="display:none;">
                 <input type="hidden" value="CFResultsUiT.CS2104" name="courseid" />
@@ -4912,4 +4920,4 @@
 </div>
 
 
-<div class="tooltip fade top in" style="top: {*}px; left: {*}px; display: block;"><div class="tooltip-arrow"></div><div class="tooltip-inner">View results by sections</div></div></body></html>
+<div class="tooltip fade top in" style="top: {*}px; left: {*}px; display: block;"><div class="tooltip-arrow"></div><div class="tooltip-inner">Filter the results in the current view</div></div></body></html>

--- a/src/test/resources/pages/instructorFeedbackResultsPageOpenViewForHelperTwo.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageOpenViewForHelperTwo.html
@@ -216,6 +216,9 @@
                            <option value="Section B">
                               Section B
                            </option>
+                           <option value="None">
+                              Not in a section
+                           </option>
                         </select>
                      </div>
                   </div>

--- a/src/test/resources/pages/instructorFeedbackResultsSortGiverQuestionRecipient.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortGiverQuestionRecipient.html
@@ -219,6 +219,9 @@
                            <option value="Section B">
                               Section B
                            </option>
+                           <option value="None">
+                              Not in a section
+                           </option>
                         </select>
                      </div>
                   </div>

--- a/src/test/resources/pages/instructorFeedbackResultsSortGiverQuestionRecipientTeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortGiverQuestionRecipientTeam.html
@@ -219,6 +219,9 @@
                            <option value="Section B">
                               Section B
                            </option>
+                           <option value="None">
+                              Not in a section
+                           </option>
                         </select>
                      </div>
                   </div>

--- a/src/test/resources/pages/instructorFeedbackResultsSortGiverRecipientQuestion.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortGiverRecipientQuestion.html
@@ -219,6 +219,9 @@
                            <option value="Section B">
                               Section B
                            </option>
+                           <option value="None">
+                              Not in a section
+                           </option>
                         </select>
                      </div>
                   </div>

--- a/src/test/resources/pages/instructorFeedbackResultsSortGiverRecipientQuestionTeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortGiverRecipientQuestionTeam.html
@@ -219,6 +219,9 @@
                            <option value="Section B">
                               Section B
                            </option>
+                           <option value="None">
+                              Not in a section
+                           </option>
                         </select>
                      </div>
                   </div>

--- a/src/test/resources/pages/instructorFeedbackResultsSortQuestion.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortQuestion.html
@@ -219,6 +219,9 @@
                            <option value="Section B">
                               Section B
                            </option>
+                           <option value="None">
+                              Not in a section
+                           </option>
                         </select>
                      </div>
                   </div>

--- a/src/test/resources/pages/instructorFeedbackResultsSortQuestionSearch.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortQuestionSearch.html
@@ -219,6 +219,9 @@
                            <option value="Section B">
                               Section B
                            </option>
+                           <option value="None">
+                              Not in a section
+                           </option>
                         </select>
                      </div>
                   </div>

--- a/src/test/resources/pages/instructorFeedbackResultsSortRecipientGiverQuestion.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortRecipientGiverQuestion.html
@@ -219,6 +219,9 @@
                            <option value="Section B">
                               Section B
                            </option>
+                           <option value="None">
+                              Not in a section
+                           </option>
                         </select>
                      </div>
                   </div>

--- a/src/test/resources/pages/instructorFeedbackResultsSortRecipientGiverQuestionTeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortRecipientGiverQuestionTeam.html
@@ -219,6 +219,9 @@
                            <option value="Section B">
                               Section B
                            </option>
+                           <option value="None">
+                              Not in a section
+                           </option>
                         </select>
                      </div>
                   </div>

--- a/src/test/resources/pages/instructorFeedbackResultsSortRecipientQuestionGiver.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortRecipientQuestionGiver.html
@@ -219,6 +219,9 @@
                            <option value="Section B">
                               Section B
                            </option>
+                           <option value="None">
+                              Not in a section
+                           </option>
                         </select>
                      </div>
                   </div>

--- a/src/test/resources/pages/instructorFeedbackResultsSortRecipientQuestionGiverTeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortRecipientQuestionGiverTeam.html
@@ -219,6 +219,9 @@
                            <option value="Section B">
                               Section B
                            </option>
+                           <option value="None">
+                              Not in a section
+                           </option>
                         </select>
                      </div>
                   </div>

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionGiverQuestionRecipient.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionGiverQuestionRecipient.html
@@ -219,6 +219,9 @@
                            <option value="Section B">
                               Section B
                            </option>
+                           <option value="None">
+                              Not in a section
+                           </option>
                         </select>
                      </div>
                   </div>

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionGiverQuestionRecipientTeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionGiverQuestionRecipientTeam.html
@@ -219,6 +219,9 @@
                            <option value="Section B">
                               Section B
                            </option>
+                           <option value="None">
+                              Not in a section
+                           </option>
                         </select>
                      </div>
                   </div>

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionGiverRecipientQuestion.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionGiverRecipientQuestion.html
@@ -219,6 +219,9 @@
                            <option value="Section B">
                               Section B
                            </option>
+                           <option value="None">
+                              Not in a section
+                           </option>
                         </select>
                      </div>
                   </div>

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionGiverRecipientQuestionTeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionGiverRecipientQuestionTeam.html
@@ -219,6 +219,9 @@
                            <option value="Section B">
                               Section B
                            </option>
+                           <option value="None">
+                              Not in a section
+                           </option>
                         </select>
                      </div>
                   </div>

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionQuestion.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionQuestion.html
@@ -219,6 +219,9 @@
                            <option value="Section B">
                               Section B
                            </option>
+                           <option value="None">
+                              Not in a section
+                           </option>
                         </select>
                      </div>
                   </div>

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionRecipientGiverQuestion.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionRecipientGiverQuestion.html
@@ -219,6 +219,9 @@
                            <option value="Section B">
                               Section B
                            </option>
+                           <option value="None">
+                              Not in a section
+                           </option>
                         </select>
                      </div>
                   </div>

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionRecipientGiverQuestionTeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionRecipientGiverQuestionTeam.html
@@ -219,6 +219,9 @@
                            <option value="Section B">
                               Section B
                            </option>
+                           <option value="None">
+                              Not in a section
+                           </option>
                         </select>
                      </div>
                   </div>

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionRecipientQuestionGiver.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionRecipientQuestionGiver.html
@@ -219,6 +219,9 @@
                            <option value="Section B">
                               Section B
                            </option>
+                           <option value="None">
+                              Not in a section
+                           </option>
                         </select>
                      </div>
                   </div>

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionRecipientQuestionGiverTeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionRecipientQuestionGiverTeam.html
@@ -219,6 +219,9 @@
                            <option value="Section B">
                               Section B
                            </option>
+                           <option value="None">
+                              Not in a section
+                           </option>
                         </select>
                      </div>
                   </div>


### PR DESCRIPTION
Fixes #4057.

The question view might not display all the expected responses between students and instructors because of #4125, which should be fixed there. 
@yj-soh, assigning this to you since you migrated the filter panel to jstl