### PR TITLE
 Sanitization problem in feedback instructions #4199 

### DIFF
--- a/src/main/java/teammates/common/datatransfer/FeedbackSessionAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/FeedbackSessionAttributes.java
@@ -132,7 +132,7 @@ public class FeedbackSessionAttributes extends EntityAttributes implements Sessi
     }
     
     public String getInstructionsString() {
-        return instructions.getValue();
+        return Sanitizer.sanitizeForHtml(instructions.getValue());
     }
 
     @Override

--- a/src/main/webapp/WEB-INF/tags/instructor/feedbacks/feedbackSessionsForm.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/feedbacks/feedbackSessionsForm.tag
@@ -127,7 +127,7 @@
                                     rows="4" cols="100%"
                                     name="<%= Const.ParamsNames.FEEDBACK_SESSION_INSTRUCTIONS %>"
                                     id="<%= Const.ParamsNames.FEEDBACK_SESSION_INSTRUCTIONS %>"
-                                    placeholder="e.g. Please answer all the given questions."><c:out value="${fsForm.instructions}"/></textarea>
+                                    placeholder="e.g. Please answer all the given questions.">${fsForm.instructions}</textarea>
                             </div>
                         </div>
                     </div>

--- a/src/main/webapp/WEB-INF/tags/student/feedbackSubmissionEdit/feedbackSessionDetailsPanel.tag
+++ b/src/main/webapp/WEB-INF/tags/student/feedbackSubmissionEdit/feedbackSessionDetailsPanel.tag
@@ -38,7 +38,7 @@
                     <label class="col-sm-2 control-label">Instructions:</label>
                     <div class="col-sm-10">                   
                         <%-- Note: When an element has class text-preserve-space, do not insert HTML spaces --%>
-                        <p class="form-control-static text-preserve-space"><c:out value="${feedbackSession.instructionsString}"/></p>
+                        <p class="form-control-static text-preserve-space">${feedbackSession.instructionsString}</p>
                     </div>
                 </div>             
             </div>


### PR DESCRIPTION
Fixes #4199 

`getInstructionsString()` is used only from the front-end, never from the back-end side.

@taniach @kanghj 
Is there any particular requirement for the `<c:out>` sanitization over `Sanitizer.sanitizeForHtml()` here?

@taniach 
On a related topic, should the `feedbackSubmissionEdit` tagdir be under `student`?