### PR TITLE
 NPE in InstructorCourseStudentDetailsEditSaveAction #4218

### DIFF
--- a/src/main/java/teammates/common/util/Const.java
+++ b/src/main/java/teammates/common/util/Const.java
@@ -875,6 +875,7 @@ public class Const {
         public static final String STUDENT_GOOGLEID_RESET_FAIL = "An error occurred when trying to reset student's google id";
         
         public static final String STUDENT_EDITED = "The student has been edited successfully";
+        public static final String STUDENT_NOT_FOUND = "The student you tried to edit does not exist. If the student was created during the last few minutes, try again in a few more minutes as the student may be being saved.";
         public static final String STUDENT_DELETED = "The student has been removed from the course";
         public static final String STUDENT_EMAIL_CONFLIT = "Trying to update to an email that is already used by: ";
         public static final String STUDENT_PROFILE_EDITED = "Your profile has been edited successfully";

--- a/src/main/java/teammates/ui/controller/InstructorCourseStudentDetailsEditSaveAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorCourseStudentDetailsEditSaveAction.java
@@ -33,8 +33,7 @@ public class InstructorCourseStudentDetailsEditSaveAction extends InstructorCour
         boolean hasSection = logic.hasIndicatedSections(courseId);
         StudentAttributes student = logic.getStudentForEmail(courseId, studentEmail);
         
-        boolean studentNotFound = student == null;
-        if (studentNotFound) {
+        if (student == null) {
             return redirectWithError(Const.StatusMessages.STUDENT_NOT_FOUND,
                                      "Student <span class=\"bold\">" + studentEmail + "</span> in "
                                      + "Course <span class=\"bold\">[" + courseId + "]</span> not found.",

--- a/src/main/java/teammates/ui/controller/InstructorCourseStudentDetailsEditSaveAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorCourseStudentDetailsEditSaveAction.java
@@ -35,7 +35,10 @@ public class InstructorCourseStudentDetailsEditSaveAction extends InstructorCour
         
         boolean studentNotFound = student == null;
         if (studentNotFound) {
-            return redirectWithError(Const.StatusMessages.STUDENT_NOT_FOUND, courseId);
+            return redirectWithError(Const.StatusMessages.STUDENT_NOT_FOUND,
+                                     "Student <span class=\"bold\">" + studentEmail + "</span> in "
+                                     + "Course <span class=\"bold\">[" + courseId + "]</span> not found.",
+                                     courseId);
         }
         
         student.name = getRequestParamValue(Const.ParamsNames.STUDENT_NAME);
@@ -75,8 +78,9 @@ public class InstructorCourseStudentDetailsEditSaveAction extends InstructorCour
         
     }
 
-    private RedirectResult redirectWithError(String errorMessage, String courseId) {
-        statusToUser.add(new StatusMessage(errorMessage, StatusMessageColor.DANGER));
+    private RedirectResult redirectWithError(String errorToUser, String errorToAdmin, String courseId) {
+        statusToUser.add(new StatusMessage(errorToUser, StatusMessageColor.DANGER));
+        statusToAdmin = errorToAdmin;
         isError = true;
         
         RedirectResult result = createRedirectResult(Const.ActionURIs.INSTRUCTOR_COURSE_DETAILS_PAGE);

--- a/src/main/java/teammates/ui/controller/InstructorCourseStudentDetailsEditSaveAction.java
+++ b/src/main/java/teammates/ui/controller/InstructorCourseStudentDetailsEditSaveAction.java
@@ -33,6 +33,11 @@ public class InstructorCourseStudentDetailsEditSaveAction extends InstructorCour
         boolean hasSection = logic.hasIndicatedSections(courseId);
         StudentAttributes student = logic.getStudentForEmail(courseId, studentEmail);
         
+        boolean studentNotFound = student == null;
+        if (studentNotFound) {
+            return redirectWithError(Const.StatusMessages.STUDENT_NOT_FOUND, courseId);
+        }
+        
         student.name = getRequestParamValue(Const.ParamsNames.STUDENT_NAME);
         student.email = getRequestParamValue(Const.ParamsNames.NEW_STUDENT_EMAIL);
         student.team = getRequestParamValue(Const.ParamsNames.TEAM_NAME);
@@ -70,5 +75,13 @@ public class InstructorCourseStudentDetailsEditSaveAction extends InstructorCour
         
     }
 
+    private RedirectResult redirectWithError(String errorMessage, String courseId) {
+        statusToUser.add(new StatusMessage(errorMessage, StatusMessageColor.DANGER));
+        isError = true;
+        
+        RedirectResult result = createRedirectResult(Const.ActionURIs.INSTRUCTOR_COURSE_DETAILS_PAGE);
+        result.addResponseParam(Const.ParamsNames.COURSE_ID, courseId);
+        return result;
+    }
 
 }

--- a/src/test/java/teammates/test/cases/ui/InstructorCourseStudentDetailsEditSaveActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/InstructorCourseStudentDetailsEditSaveActionTest.java
@@ -204,6 +204,41 @@ public class InstructorCourseStudentDetailsEditSaveActionTest extends BaseAction
         AccountsLogic.inst().deleteAccountCascade(student1InCourse1.googleId);
         
         
+        ______TS("Error case, student does not exist");
+        
+        String nonExistentEmailForStudent = "notinuseemail@gmail.tmt";
+        
+        submissionParams = new String[]{
+                Const.ParamsNames.COURSE_ID, instructor1OfCourse1.courseId,
+                Const.ParamsNames.STUDENT_EMAIL, nonExistentEmailForStudent,
+                Const.ParamsNames.STUDENT_NAME, student1InCourse1.name,
+                Const.ParamsNames.NEW_STUDENT_EMAIL, student1InCourse1.email,
+                Const.ParamsNames.COMMENTS, student1InCourse1.comments,
+                Const.ParamsNames.TEAM_NAME, student1InCourse1.team
+        };
+        
+        gaeSimulation.loginAsInstructor(instructorId);
+        a = getAction(submissionParams);
+        RedirectResult redirectResult = getRedirectResult(a);
+        
+        assertEquals(Const.ActionURIs.INSTRUCTOR_COURSE_DETAILS_PAGE +
+                "?error=" + "true" +
+                "&user=" + instructorId +
+                "&courseid=" + instructor1OfCourse1.courseId,
+                redirectResult.getDestinationWithParams());
+        
+        assertEquals(true, redirectResult.isError);
+        assertEquals(Const.StatusMessages.STUDENT_NOT_FOUND, redirectResult.getStatusMessage());
+        
+        expectedLogMessage = "TEAMMATESLOG|||instructorCourseStudentDetailsEditSave|||instructorCourseStudentDetailsEditSave" +
+                "|||true|||Instructor|||Instructor 1 of Course 1|||idOfInstructor1OfCourse1|||instr1@course1.tmt|||" +
+                "Student <span class=\"bold\">" + nonExistentEmailForStudent + "</span> in " +
+                "Course <span class=\"bold\">[" + instructor1OfCourse1.courseId + "]</span> not found." +
+                "|||/page/instructorCourseStudentDetailsEditSave";
+        
+        assertEquals(expectedLogMessage, a.getLogMessage());
+        
+        
         ______TS("Unsuccessful case: test null student email parameter");
         submissionParams = new String[]{
                 Const.ParamsNames.COURSE_ID, instructor1OfCourse1.courseId


### PR DESCRIPTION
Fixes #4218 

A similar problem happens clicking on the "Edit" link pointed at an invalid student.
(e.g. open edit link in new tab, edit student's email, click on edit link in initial tab)

Also, the other buttons reply only with error messages like "The student you tried to view details for does not exist." aside from Delete which returns a success. Should any of their behaviour be changed to be consistent with this one or vice versa (regarding the line about eventual consistency)?

Should either of those be handled in this PR?

(Regarding the delete button, it's due to a method that "Fails silently if no match found." according to its comment.)