### PR TITLE
StudentHomePageDataTest fails very often in package/full run #4254

### DIFF
--- a/src/test/java/teammates/test/cases/ui/pagedata/StudentHomePageDataTest.java
+++ b/src/test/java/teammates/test/cases/ui/pagedata/StudentHomePageDataTest.java
@@ -147,7 +147,7 @@ public class StudentHomePageDataTest {
         awaitingSession = createFeedbackSession("awaiting session", 1, 2, 1);
         publishedSession = createFeedbackSession("published session", -1, -1, -1);
         closedSession = createFeedbackSession("closed session", -2, -1, 1);
-        submittedClosedSession = createFeedbackSession("submitted closed session", -1, 0, 1);
+        submittedClosedSession = createFeedbackSession("submitted closed session", -2, -1, 1);
         
         // Submission status
         Map<FeedbackSessionAttributes, Boolean> sessionSubmissionStatusMap = new HashMap<>();


### PR DESCRIPTION
Fixes #4254 
This is the cause:
![shpdtestfailcause](https://cloud.githubusercontent.com/assets/7261051/9733477/2a7e7cee-565e-11e5-9c10-f602c7ec8753.png)
The "0" there indicates that the feedback session closes 0 hours before now (i.e, _now_). 
However, putting 0 there is dangerous because for the feedback session to be considered closed, the time at the point of the comparison has to be _after_ the set closing time. The difference needed is only one millisecond, however, the program execution happens very fast and often it doesn't take even one millisecond from the point the closing time is set to the point the comparison is made, which fails the test.