### PR TITLE
instructorSessionResults: there is no way to recover from failed ajax calls #4276

### DIFF
--- a/src/main/webapp/js/instructor.js
+++ b/src/main/webapp/js/instructor.js
@@ -154,7 +154,6 @@ function setupFsCopyModal() {
     });
 }
 
-
 // Student Profile Picture
 //--------------------------------------------------------------------------
 

--- a/src/main/webapp/js/instructor.js
+++ b/src/main/webapp/js/instructor.js
@@ -156,6 +156,10 @@ function setupFsCopyModal() {
 
 // For ajax failure handling
 
+/**
+ * Given an element, replaces the HTML content of the element with an error message prompting 
+ * the user to retry.
+ */
 function displayAjaxRetryMessage($element) {
     var ajaxErrorStart = '<div class="ajax-error">';
     var warningSign = '<span class="glyphicon glyphicon-warning-sign"></span>';

--- a/src/main/webapp/js/instructor.js
+++ b/src/main/webapp/js/instructor.js
@@ -154,6 +154,18 @@ function setupFsCopyModal() {
     });
 }
 
+// For ajax failure handling
+
+function displayAjaxRetryMessage($element) {
+    var ajaxErrorStart = '<div class="ajax-error">';
+    var warningSign = '<span class="glyphicon glyphicon-warning-sign"></span>';
+    var errorMsg = '[ Failed to load. Click here to retry. ]';
+    errorMsg = '<strong style="margin-left: 1em; margin-right: 1em;">' + errorMsg + '</strong>';
+    var chevronDown = '<span class="glyphicon glyphicon-chevron-down"></span>';
+    var ajaxErrorEnd = '</div>';
+    $element.html(ajaxErrorStart + warningSign + errorMsg + chevronDown + ajaxErrorEnd);
+}
+
 // Student Profile Picture
 //--------------------------------------------------------------------------
 

--- a/src/main/webapp/js/instructor.js
+++ b/src/main/webapp/js/instructor.js
@@ -154,21 +154,6 @@ function setupFsCopyModal() {
     });
 }
 
-// For ajax failure handling
-
-/**
- * Given an element, replaces the HTML content of the element with an error message prompting 
- * the user to retry.
- */
-function displayAjaxRetryMessage($element) {
-    var ajaxErrorStart = '<div class="ajax-error">';
-    var warningSign = '<span class="glyphicon glyphicon-warning-sign"></span>';
-    var errorMsg = '[ Failed to load. Click here to retry. ]';
-    errorMsg = '<strong style="margin-left: 1em; margin-right: 1em;">' + errorMsg + '</strong>';
-    var chevronDown = '<span class="glyphicon glyphicon-chevron-down"></span>';
-    var ajaxErrorEnd = '</div>';
-    $element.html(ajaxErrorStart + warningSign + errorMsg + chevronDown + ajaxErrorEnd);
-}
 
 // Student Profile Picture
 //--------------------------------------------------------------------------

--- a/src/main/webapp/js/instructorFeedbackResults.js
+++ b/src/main/webapp/js/instructorFeedbackResults.js
@@ -252,6 +252,22 @@ function bindCollapseEvents(panels, numPanels) {
     return numPanels;
 }
 
+/**
+ * For ajax error handling. 
+ * Given an element, replaces the HTML content of the element with an error message prompting 
+ * the user to retry.
+ */
+function displayAjaxRetryMessage($element) {
+    var ajaxErrorStart = '<div class="ajax-error">';
+    var warningSign = '<span class="glyphicon glyphicon-warning-sign"></span>';
+    var errorMsg = '[ Failed to load. Click here to retry. ]';
+    errorMsg = '<strong style="margin-left: 1em; margin-right: 1em;">' + errorMsg + '</strong>';
+    var chevronDown = '<span class="glyphicon glyphicon-chevron-down"></span>';
+    var ajaxErrorEnd = '</div>';
+    $element.html(ajaxErrorStart + warningSign + errorMsg + chevronDown + ajaxErrorEnd);
+}
+
+
 window.onload = function() {
     var participantPanelType = 'div.panel.panel-primary,div.panel.panel-default';
 

--- a/src/main/webapp/js/instructorFeedbackResults.js
+++ b/src/main/webapp/js/instructorFeedbackResults.js
@@ -254,10 +254,10 @@ function bindCollapseEvents(panels, numPanels) {
 
 /**
  * For ajax error handling. 
- * Given an element, replaces the HTML content of the element with an error message prompting 
+ * Given an element in the panel heading, replaces the HTML content of the element with an error message prompting 
  * the user to retry.
  */
-function displayAjaxRetryMessage($element) {
+function displayAjaxRetryMessageForPanelHeading($element) {
     var ajaxErrorStart = '<div class="ajax-error">';
     var warningSign = '<span class="glyphicon glyphicon-warning-sign"></span>';
     var errorMsg = '[ Failed to load. Click here to retry. ]';

--- a/src/main/webapp/js/instructorFeedbackResultsAjaxByGQR.js
+++ b/src/main/webapp/js/instructorFeedbackResultsAjaxByGQR.js
@@ -25,7 +25,13 @@ $(document).ready(function() {
                 displayIcon.html('<img height="25" width="25" src="/images/ajax-preload.gif">')
             },
             error: function() {
-
+                var ajaxErrorStart = '<div class="ajax-error">';
+                var warningSign = '<span class="glyphicon glyphicon-warning-sign"></span>';
+                var errorMsg = '[ Failed to load. Click here to retry. ]';
+                errorMsg = '<strong style="margin-left: 1em; margin-right: 1em;">' + errorMsg + '</strong>';
+                var chevronDown = '<span class="glyphicon glyphicon-chevron-down"></span>';
+                var ajaxErrorEnd = '</div>';
+                displayIcon.html(ajaxErrorStart + warningSign + errorMsg + chevronDown + ajaxErrorEnd);
             },
             success: function(data) {
                 if (numPanels == 0) {

--- a/src/main/webapp/js/instructorFeedbackResultsAjaxByGQR.js
+++ b/src/main/webapp/js/instructorFeedbackResultsAjaxByGQR.js
@@ -25,7 +25,7 @@ $(document).ready(function() {
                 displayIcon.html('<img height="25" width="25" src="/images/ajax-preload.gif">')
             },
             error: function() {
-                displayAjaxRetryMessage(displayIcon);
+                displayAjaxRetryMessageForPanelHeading(displayIcon);
             },
             success: function(data) {
                 if (numPanels == 0) {

--- a/src/main/webapp/js/instructorFeedbackResultsAjaxByGQR.js
+++ b/src/main/webapp/js/instructorFeedbackResultsAjaxByGQR.js
@@ -25,13 +25,7 @@ $(document).ready(function() {
                 displayIcon.html('<img height="25" width="25" src="/images/ajax-preload.gif">')
             },
             error: function() {
-                var ajaxErrorStart = '<div class="ajax-error">';
-                var warningSign = '<span class="glyphicon glyphicon-warning-sign"></span>';
-                var errorMsg = '[ Failed to load. Click here to retry. ]';
-                errorMsg = '<strong style="margin-left: 1em; margin-right: 1em;">' + errorMsg + '</strong>';
-                var chevronDown = '<span class="glyphicon glyphicon-chevron-down"></span>';
-                var ajaxErrorEnd = '</div>';
-                displayIcon.html(ajaxErrorStart + warningSign + errorMsg + chevronDown + ajaxErrorEnd);
+                displayAjaxRetryMessage(displayIcon);
             },
             success: function(data) {
                 if (numPanels == 0) {

--- a/src/main/webapp/js/instructorFeedbackResultsAjaxByGRQ.js
+++ b/src/main/webapp/js/instructorFeedbackResultsAjaxByGRQ.js
@@ -25,7 +25,13 @@ $(document).ready(function() {
                 displayIcon.html('<img height="25" width="25" src="/images/ajax-preload.gif">')
             },
             error: function() {
-
+                var ajaxErrorStart = '<div class="ajax-error">';
+                var warningSign = '<span class="glyphicon glyphicon-warning-sign"></span>';
+                var errorMsg = '[ Failed to load. Click here to retry. ]';
+                errorMsg = '<strong style="margin-left: 1em; margin-right: 1em;">' + errorMsg + '</strong>';
+                var chevronDown = '<span class="glyphicon glyphicon-chevron-down"></span>';
+                var ajaxErrorEnd = '</div>';
+                displayIcon.html(ajaxErrorStart + warningSign + errorMsg + chevronDown + ajaxErrorEnd);
             },
             success: function(data) {
                 if (numPanels == 0) {

--- a/src/main/webapp/js/instructorFeedbackResultsAjaxByGRQ.js
+++ b/src/main/webapp/js/instructorFeedbackResultsAjaxByGRQ.js
@@ -25,7 +25,7 @@ $(document).ready(function() {
                 displayIcon.html('<img height="25" width="25" src="/images/ajax-preload.gif">')
             },
             error: function() {
-                displayAjaxRetryMessage(displayIcon);
+                displayAjaxRetryMessageForPanelHeading(displayIcon);
             },
             success: function(data) {
                 if (numPanels == 0) {

--- a/src/main/webapp/js/instructorFeedbackResultsAjaxByGRQ.js
+++ b/src/main/webapp/js/instructorFeedbackResultsAjaxByGRQ.js
@@ -25,13 +25,7 @@ $(document).ready(function() {
                 displayIcon.html('<img height="25" width="25" src="/images/ajax-preload.gif">')
             },
             error: function() {
-                var ajaxErrorStart = '<div class="ajax-error">';
-                var warningSign = '<span class="glyphicon glyphicon-warning-sign"></span>';
-                var errorMsg = '[ Failed to load. Click here to retry. ]';
-                errorMsg = '<strong style="margin-left: 1em; margin-right: 1em;">' + errorMsg + '</strong>';
-                var chevronDown = '<span class="glyphicon glyphicon-chevron-down"></span>';
-                var ajaxErrorEnd = '</div>';
-                displayIcon.html(ajaxErrorStart + warningSign + errorMsg + chevronDown + ajaxErrorEnd);
+                displayAjaxRetryMessage(displayIcon);
             },
             success: function(data) {
                 if (numPanels == 0) {

--- a/src/main/webapp/js/instructorFeedbackResultsAjaxByQuestion.js
+++ b/src/main/webapp/js/instructorFeedbackResultsAjaxByQuestion.js
@@ -21,7 +21,7 @@ $(document).ready(function() {
                 displayIcon.html('<img height="25" width="25" src="/images/ajax-preload.gif">');
             },
             error: function() {
-                displayAjaxRetryMessage(displayIcon);
+                displayAjaxRetryMessageForPanelHeading(displayIcon);
             },
             success: function(data) {
                 var appendedQuestion = $(data).find('#questionBody-0').html();

--- a/src/main/webapp/js/instructorFeedbackResultsAjaxByQuestion.js
+++ b/src/main/webapp/js/instructorFeedbackResultsAjaxByQuestion.js
@@ -21,7 +21,13 @@ $(document).ready(function() {
                 displayIcon.html('<img height="25" width="25" src="/images/ajax-preload.gif">');
             },
             error: function() {
-                // TODO handle errors!
+                var ajaxErrorStart = '<div class="ajax-error">';
+                var warningSign = '<span class="glyphicon glyphicon-warning-sign"></span>';
+                var errorMsg = '[ Failed to load. Click here to retry. ]';
+                errorMsg = '<strong style="margin-left: 1em; margin-right: 1em;">' + errorMsg + '</strong>';
+                var chevronDown = '<span class="glyphicon glyphicon-chevron-down"></span>';
+                var ajaxErrorEnd = '</div>';
+                displayIcon.html(ajaxErrorStart + warningSign + errorMsg + chevronDown + ajaxErrorEnd);
             },
             success: function(data) {
                 var appendedQuestion = $(data).find('#questionBody-0').html();

--- a/src/main/webapp/js/instructorFeedbackResultsAjaxByQuestion.js
+++ b/src/main/webapp/js/instructorFeedbackResultsAjaxByQuestion.js
@@ -21,13 +21,7 @@ $(document).ready(function() {
                 displayIcon.html('<img height="25" width="25" src="/images/ajax-preload.gif">');
             },
             error: function() {
-                var ajaxErrorStart = '<div class="ajax-error">';
-                var warningSign = '<span class="glyphicon glyphicon-warning-sign"></span>';
-                var errorMsg = '[ Failed to load. Click here to retry. ]';
-                errorMsg = '<strong style="margin-left: 1em; margin-right: 1em;">' + errorMsg + '</strong>';
-                var chevronDown = '<span class="glyphicon glyphicon-chevron-down"></span>';
-                var ajaxErrorEnd = '</div>';
-                displayIcon.html(ajaxErrorStart + warningSign + errorMsg + chevronDown + ajaxErrorEnd);
+                displayAjaxRetryMessage(displayIcon);
             },
             success: function(data) {
                 var appendedQuestion = $(data).find('#questionBody-0').html();

--- a/src/main/webapp/js/instructorFeedbackResultsAjaxByRGQ.js
+++ b/src/main/webapp/js/instructorFeedbackResultsAjaxByRGQ.js
@@ -25,7 +25,13 @@ $(document).ready(function() {
                 displayIcon.html('<img height="25" width="25" src="/images/ajax-preload.gif">')
             },
             error: function() {
-
+                var ajaxErrorStart = '<div class="ajax-error">';
+                var warningSign = '<span class="glyphicon glyphicon-warning-sign"></span>';
+                var errorMsg = '[ Failed to load. Click here to retry. ]';
+                errorMsg = '<strong style="margin-left: 1em; margin-right: 1em;">' + errorMsg + '</strong>';
+                var chevronDown = '<span class="glyphicon glyphicon-chevron-down"></span>';
+                var ajaxErrorEnd = '</div>';
+                displayIcon.html(ajaxErrorStart + warningSign + errorMsg + chevronDown + ajaxErrorEnd);
             },
             success: function(data) {
                 if (numPanels == 0) {

--- a/src/main/webapp/js/instructorFeedbackResultsAjaxByRGQ.js
+++ b/src/main/webapp/js/instructorFeedbackResultsAjaxByRGQ.js
@@ -25,7 +25,7 @@ $(document).ready(function() {
                 displayIcon.html('<img height="25" width="25" src="/images/ajax-preload.gif">')
             },
             error: function() {
-                displayAjaxRetryMessage(displayIcon);
+                displayAjaxRetryMessageForPanelHeading(displayIcon);
             },
             success: function(data) {
                 if (numPanels == 0) {

--- a/src/main/webapp/js/instructorFeedbackResultsAjaxByRGQ.js
+++ b/src/main/webapp/js/instructorFeedbackResultsAjaxByRGQ.js
@@ -25,13 +25,7 @@ $(document).ready(function() {
                 displayIcon.html('<img height="25" width="25" src="/images/ajax-preload.gif">')
             },
             error: function() {
-                var ajaxErrorStart = '<div class="ajax-error">';
-                var warningSign = '<span class="glyphicon glyphicon-warning-sign"></span>';
-                var errorMsg = '[ Failed to load. Click here to retry. ]';
-                errorMsg = '<strong style="margin-left: 1em; margin-right: 1em;">' + errorMsg + '</strong>';
-                var chevronDown = '<span class="glyphicon glyphicon-chevron-down"></span>';
-                var ajaxErrorEnd = '</div>';
-                displayIcon.html(ajaxErrorStart + warningSign + errorMsg + chevronDown + ajaxErrorEnd);
+                displayAjaxRetryMessage(displayIcon);
             },
             success: function(data) {
                 if (numPanels == 0) {

--- a/src/main/webapp/js/instructorFeedbackResultsAjaxByRQG.js
+++ b/src/main/webapp/js/instructorFeedbackResultsAjaxByRQG.js
@@ -25,7 +25,13 @@ $(document).ready(function() {
                 displayIcon.html('<img height="25" width="25" src="/images/ajax-preload.gif">')
             },
             error: function() {
-
+                var ajaxErrorStart = '<div class="ajax-error">';
+                var warningSign = '<span class="glyphicon glyphicon-warning-sign"></span>';
+                var errorMsg = '[ Failed to load. Click here to retry. ]';
+                errorMsg = '<strong style="margin-left: 1em; margin-right: 1em;">' + errorMsg + '</strong>';
+                var chevronDown = '<span class="glyphicon glyphicon-chevron-down"></span>';
+                var ajaxErrorEnd = '</div>';
+                displayIcon.html(ajaxErrorStart + warningSign + errorMsg + chevronDown + ajaxErrorEnd);
             },
             success: function(data) {
                 if (numPanels == 0) {

--- a/src/main/webapp/js/instructorFeedbackResultsAjaxByRQG.js
+++ b/src/main/webapp/js/instructorFeedbackResultsAjaxByRQG.js
@@ -25,7 +25,7 @@ $(document).ready(function() {
                 displayIcon.html('<img height="25" width="25" src="/images/ajax-preload.gif">')
             },
             error: function() {
-                displayAjaxRetryMessage(displayIcon);
+                displayAjaxRetryMessageForPanelHeading(displayIcon);
             },
             success: function(data) {
                 if (numPanels == 0) {

--- a/src/main/webapp/js/instructorFeedbackResultsAjaxByRQG.js
+++ b/src/main/webapp/js/instructorFeedbackResultsAjaxByRQG.js
@@ -25,13 +25,7 @@ $(document).ready(function() {
                 displayIcon.html('<img height="25" width="25" src="/images/ajax-preload.gif">')
             },
             error: function() {
-                var ajaxErrorStart = '<div class="ajax-error">';
-                var warningSign = '<span class="glyphicon glyphicon-warning-sign"></span>';
-                var errorMsg = '[ Failed to load. Click here to retry. ]';
-                errorMsg = '<strong style="margin-left: 1em; margin-right: 1em;">' + errorMsg + '</strong>';
-                var chevronDown = '<span class="glyphicon glyphicon-chevron-down"></span>';
-                var ajaxErrorEnd = '</div>';
-                displayIcon.html(ajaxErrorStart + warningSign + errorMsg + chevronDown + ajaxErrorEnd);
+                displayAjaxRetryMessage(displayIcon);
             },
             success: function(data) {
                 if (numPanels == 0) {

--- a/src/main/webapp/js/instructorFeedbackResultsAjaxResponseRate.js
+++ b/src/main/webapp/js/instructorFeedbackResultsAjaxResponseRate.js
@@ -20,7 +20,7 @@ $(document).ready(function() {
                 // submitButton.html('<img src="/images/ajax-loader.gif">');
             },
             error: function() {
-
+                displayAjaxRetryMessageForPanelHeading(displayIcon);
             },
             success: function(data) {
                 $(panelCollapse[0]).html(getAppendedResponseRateData(data));

--- a/src/test/java/teammates/test/cases/ui/browsertests/InstructorFeedbackResultsPageUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/InstructorFeedbackResultsPageUiTest.java
@@ -356,8 +356,7 @@ public class InstructorFeedbackResultsPageUiTest extends BaseUiTestCase {
         
         resultsPage.clickAjaxPanel(0);
         resultsPage.verifyHtmlAjax("/instructorFeedbackResultsAjaxByGQR.html");
-        
-        
+                
         ______TS("Typical case: test view photo for view by giver > question > recipient");
         
         resultsPage.removeNavBar();

--- a/src/test/java/teammates/test/cases/ui/browsertests/InstructorFeedbackResultsPageUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/InstructorFeedbackResultsPageUiTest.java
@@ -295,6 +295,13 @@ public class InstructorFeedbackResultsPageUiTest extends BaseUiTestCase {
 
         resultsPage.clickAjaxPanel(0);
         resultsPage.verifyHtmlAjax("/instructorFeedbackResultsAjaxByQuestion.html");
+        
+        ______TS("Failure case: Ajax error");
+        
+        // Change fs name so that the ajax request will fail
+        resultsPage.changeFsNameInAjaxForm(1, "invalidFsName");
+        resultsPage.clickAjaxPanel(1);
+        resultsPage.waitForAjaxError(1);
 
         ______TS("Typical case: test view photo for view by questions");
 

--- a/src/test/java/teammates/test/cases/ui/browsertests/InstructorFeedbackResultsPageUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/InstructorFeedbackResultsPageUiTest.java
@@ -344,12 +344,19 @@ public class InstructorFeedbackResultsPageUiTest extends BaseUiTestCase {
 
         resultsPage.hoverClickAndViewStudentPhotoOnHeading(6, "profile_picture_default.png");
         
+        ______TS("Failure case: ajax error for giver > recipient > question");
+        // Change fs name so that the ajax request will fail
+        resultsPage.changeFsNameInAjaxForm(1, "invalidFsName");
+        resultsPage.clickAjaxPanel(1);
+        resultsPage.waitForAjaxError(1);
+        
         ______TS("Typical case: ajax for view by giver > question > recipient");
         
         resultsPage = loginToInstructorFeedbackResultsPageWithViewType("CFResultsUiT.instr", "Open Session", true, "giver-question-recipient");
         
         resultsPage.clickAjaxPanel(0);
         resultsPage.verifyHtmlAjax("/instructorFeedbackResultsAjaxByGQR.html");
+        
         
         ______TS("Typical case: test view photo for view by giver > question > recipient");
         

--- a/src/test/java/teammates/test/cases/ui/browsertests/InstructorFeedbackResultsPageUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/InstructorFeedbackResultsPageUiTest.java
@@ -293,15 +293,19 @@ public class InstructorFeedbackResultsPageUiTest extends BaseUiTestCase {
         resultsPage = loginToInstructorFeedbackResultsPageWithViewType("CFResultsUiT.instr",
                                                                        "Open Session", true, "question");
 
-        resultsPage.clickAjaxPanel(0);
+        resultsPage.clickAjaxLoadResponsesPanel(0);
         resultsPage.verifyHtmlAjax("/instructorFeedbackResultsAjaxByQuestion.html");
         
         ______TS("Failure case: Ajax error");
         
         // Change fs name so that the ajax request will fail
-        resultsPage.changeFsNameInAjaxForm(1, "invalidFsName");
-        resultsPage.clickAjaxPanel(1);
+        resultsPage.changeFsNameInAjaxLoadResponsesForm(1, "invalidFsName");
+        resultsPage.clickAjaxLoadResponsesPanel(1);
         resultsPage.waitForAjaxError(1);
+        
+        resultsPage.changeFsNameInNoResponsePanelForm("InvalidFsName");
+        resultsPage.clickAjaxNoResponsePanel();
+        resultsPage.waitForAjaxErrorOnNoResponsePanel();
 
         ______TS("Typical case: test view photo for view by questions");
 
@@ -314,7 +318,7 @@ public class InstructorFeedbackResultsPageUiTest extends BaseUiTestCase {
         resultsPage = loginToInstructorFeedbackResultsPageWithViewType("CFResultsUiT.helper1",
                                                                        "Open Session", true, "question");
 
-        resultsPage.clickAjaxPanel(0);
+        resultsPage.clickAjaxLoadResponsesPanel(0);
 
         resultsPage.verifyHtmlAjax("/instructorFeedbackResultsAjaxByQuestionViewForHelperOne.html");
         
@@ -322,7 +326,7 @@ public class InstructorFeedbackResultsPageUiTest extends BaseUiTestCase {
         resultsPage = loginToInstructorFeedbackResultsPageWithViewType("CFResultsUiT.helper2",
                                         "Open Session", true, "question");
 
-        resultsPage.clickAjaxPanel(0);
+        resultsPage.clickAjaxLoadResponsesPanel(0);
         resultsPage.verifyHtmlAjax("/instructorFeedbackResultsAjaxByQuestionViewForHelperTwo.html");
 
         ______TS("Typical case: ajax for view by giver > recipient > question");
@@ -330,7 +334,7 @@ public class InstructorFeedbackResultsPageUiTest extends BaseUiTestCase {
         resultsPage = loginToInstructorFeedbackResultsPageWithViewType("CFResultsUiT.instr", "Open Session", true,
                                                                        "giver-recipient-question");
 
-        resultsPage.clickAjaxPanel(0);
+        resultsPage.clickAjaxLoadResponsesPanel(0);
 
         resultsPage.verifyHtmlAjax("/instructorFeedbackResultsAjaxByGRQ.html");
 
@@ -346,15 +350,15 @@ public class InstructorFeedbackResultsPageUiTest extends BaseUiTestCase {
         
         ______TS("Failure case: ajax error for giver > recipient > question");
         // Change fs name so that the ajax request will fail
-        resultsPage.changeFsNameInAjaxForm(1, "invalidFsName");
-        resultsPage.clickAjaxPanel(1);
+        resultsPage.changeFsNameInAjaxLoadResponsesForm(1, "invalidFsName");
+        resultsPage.clickAjaxLoadResponsesPanel(1);
         resultsPage.waitForAjaxError(1);
         
         ______TS("Typical case: ajax for view by giver > question > recipient");
         
         resultsPage = loginToInstructorFeedbackResultsPageWithViewType("CFResultsUiT.instr", "Open Session", true, "giver-question-recipient");
         
-        resultsPage.clickAjaxPanel(0);
+        resultsPage.clickAjaxLoadResponsesPanel(0);
         resultsPage.verifyHtmlAjax("/instructorFeedbackResultsAjaxByGQR.html");
                 
         ______TS("Typical case: test view photo for view by giver > question > recipient");
@@ -368,7 +372,7 @@ public class InstructorFeedbackResultsPageUiTest extends BaseUiTestCase {
         resultsPage = loginToInstructorFeedbackResultsPageWithViewType("CFResultsUiT.instr", "Open Session", true,
                                                                        "recipient-question-giver");
 
-        resultsPage.clickAjaxPanel(0);
+        resultsPage.clickAjaxLoadResponsesPanel(0);
         resultsPage.verifyHtmlAjax("/instructorFeedbackResultsAjaxByRQG.html");
 
         ______TS("Typical case: test view photo for view by recipient > question > giver");
@@ -382,7 +386,7 @@ public class InstructorFeedbackResultsPageUiTest extends BaseUiTestCase {
         resultsPage = loginToInstructorFeedbackResultsPageWithViewType("CFResultsUiT.instr", "Open Session", true,
                                                                        "recipient-giver-question");
 
-        resultsPage.clickAjaxPanel(0);
+        resultsPage.clickAjaxLoadResponsesPanel(0);
         resultsPage.verifyHtmlAjax("/instructorFeedbackResultsAjaxByRGQ.html");
 
         ______TS("Typical case: test view photo for view by recipient > giver > question");

--- a/src/test/java/teammates/test/pageobjects/InstructorFeedbackResultsPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorFeedbackResultsPage.java
@@ -437,4 +437,24 @@ public class InstructorFeedbackResultsPage extends AppPage {
         return false;
     }
     
+    public void changeFsNameInAjaxForm(int indexOfForm, String newFsName) {
+   
+        String id = "seeMore" + "-" + indexOfForm;
+        By element = By.id(id);
+        waitForElementPresence(element);
+        
+        JavascriptExecutor js = (JavascriptExecutor) browser.driver;
+        js.executeScript("$('.ajax_submit:eq(" + indexOfForm 
+                         + ") [name=\"fsname\"]').val('" + newFsName + "')");     
+    }
+    
+    public void waitForAjaxError(int indexOfForm) {
+        By ajaxErrorSelector = By.cssSelector(".ajax_submit:nth-of-type(" + indexOfForm 
+                                        + ") .ajax-error");
+        waitForElementPresence(ajaxErrorSelector);
+        WebElement ajaxError = browser.driver.findElement(ajaxErrorSelector);
+        
+        assertEquals("[ Failed to load. Click here to retry. ]", ajaxError.getText());
+    }
+    
 }

--- a/src/test/java/teammates/test/pageobjects/InstructorFeedbackResultsPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorFeedbackResultsPage.java
@@ -280,9 +280,14 @@ public class InstructorFeedbackResultsPage extends AppPage {
         }
     }
 
-    public void clickAjaxPanel(int index) {
+    public void clickAjaxLoadResponsesPanel(int index) {
         List<WebElement> ajaxPanels = browser.driver.findElements(By.cssSelector(".ajax_submit"));
         ajaxPanels.get(index).click();
+    }
+    
+    public void clickAjaxNoResponsePanel() {
+        WebElement ajaxPanels = browser.driver.findElement(By.cssSelector(".ajax_response_rate_submit"));
+        ajaxPanels.click();
     }
 
     public void clickViewPhotoLink(int panelBodyIndex, String urlRegex) throws Exception {
@@ -437,16 +442,30 @@ public class InstructorFeedbackResultsPage extends AppPage {
         return false;
     }
     
-    public void changeFsNameInAjaxForm(int indexOfForm, String newFsName) {
+    public void changeFsNameInAjaxLoadResponsesForm(int indexOfForm, String newFsName) {
         
         JavascriptExecutor js = (JavascriptExecutor) browser.driver;
         js.executeScript("$('.ajax_submit:eq(" + indexOfForm 
                          + ") [name=\"fsname\"]').val('" + newFsName + "')");     
     }
     
+    public void changeFsNameInNoResponsePanelForm(String newFsName) {
+        
+        JavascriptExecutor js = (JavascriptExecutor) browser.driver;
+        js.executeScript("$('.ajax_response_rate_submit [name=\"fsname\"]').val('" + newFsName + "')");     
+    }
+    
     public void waitForAjaxError(int indexOfForm) {
         By ajaxErrorSelector = By.cssSelector(".ajax_submit:nth-of-type(" + indexOfForm 
                                         + ") .ajax-error");
+        waitForElementPresence(ajaxErrorSelector);
+        WebElement ajaxError = browser.driver.findElement(ajaxErrorSelector);
+        
+        assertEquals("[ Failed to load. Click here to retry. ]", ajaxError.getText());
+    }
+    
+    public void waitForAjaxErrorOnNoResponsePanel() {
+        By ajaxErrorSelector = By.cssSelector(".ajax_response_rate_submit .ajax-error");
         waitForElementPresence(ajaxErrorSelector);
         WebElement ajaxError = browser.driver.findElement(ajaxErrorSelector);
         

--- a/src/test/java/teammates/test/pageobjects/InstructorFeedbackResultsPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorFeedbackResultsPage.java
@@ -438,10 +438,6 @@ public class InstructorFeedbackResultsPage extends AppPage {
     }
     
     public void changeFsNameInAjaxForm(int indexOfForm, String newFsName) {
-   
-        String id = "seeMore" + "-" + indexOfForm;
-        By element = By.id(id);
-        waitForElementPresence(element);
         
         JavascriptExecutor js = (JavascriptExecutor) browser.driver;
         js.executeScript("$('.ajax_submit:eq(" + indexOfForm 


### PR DESCRIPTION
Fixes #4276

The "The results is too large to be viewed. Please choose to view the results by questions or download the results." might be affected because of #4184, where the error code returned by the page now (correctly) triggers the error callback instead of the success callback. We already have an issue for that message, will try to fix that soon.