### PR TITLE
InstructorCommentsPageUiTest failing on live server #4179

### DIFF
--- a/src/test/java/teammates/test/pageobjects/InstructorCommentsPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorCommentsPage.java
@@ -157,6 +157,7 @@ public class InstructorCommentsPage extends AppPage {
     }
 
     public void clickResponseCommentAdd(int sessionIdx, int questionIdx, int responseIdx) {
+        waitForPageToLoad();
         browser.driver.findElement(By.id("button_add_comment-" + sessionIdx + "-" + questionIdx + "-" + responseIdx)).click();
         waitForPageToLoad();
     }
@@ -182,6 +183,7 @@ public class InstructorCommentsPage extends AppPage {
     }
 
     public void clickResponseCommentEdit(int sessionIdx, int questionIdx, int responseIdx, int commentIdx) {
+        waitForPageToLoad();
         JavascriptExecutor jsExecutor = (JavascriptExecutor) browser.driver;
         jsExecutor.executeScript("document.getElementById('"
                 + "commentedit-" + sessionIdx + "-" + questionIdx + "-" + responseIdx + "-" + commentIdx + "').click();");


### PR DESCRIPTION
Fixes #4179 

Prof @damithc, I couldn't replicate the test failure at line 110 of `InstructorCommentsPageUiTest` on the live server. However, 2 other lines were constantly failing on my live server. Specifically line 175 and 219. It seems to be because the page doesn't wait for the ajax to load before locating the element. 