### PR TITLE
 Constant sum questions: empty sub-response to a specific option/recipient should be considered as a 0. #4019

### DIFF
--- a/src/main/java/teammates/common/datatransfer/FeedbackConstantSumQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/FeedbackConstantSumQuestionDetails.java
@@ -377,8 +377,8 @@ public class FeedbackConstantSumQuestionDetails extends FeedbackQuestionDetails 
             
             if (distributeToRecipients) {
                 String participantIdentifier = entry.getKey();
-                String name = bundle.getNameForEmail(participantIdentifier);
-                String teamName = bundle.getTeamNameForEmail(participantIdentifier);
+                String name = bundle.getFullNameFromRoster(participantIdentifier);
+                String teamName = bundle.getTeamNameFromRoster(participantIdentifier);
                 
                 fragments += FeedbackQuestionFormTemplates.populateTemplate(FeedbackQuestionFormTemplates.CONSTSUM_RESULT_STATS_RECIPIENTFRAGMENT,
                         "${constSumOptionValue}",  Sanitizer.sanitizeForHtml(name),
@@ -433,8 +433,8 @@ public class FeedbackConstantSumQuestionDetails extends FeedbackQuestionDetails 
         for(Entry<String, List<Integer>> entry : optionPoints.entrySet() ){
             String option;
             if(distributeToRecipients){
-                String teamName = bundle.getTeamNameForEmail(entry.getKey());
-                String recipientName = bundle.getNameForEmail(entry.getKey());
+                String teamName = bundle.getTeamNameFromRoster(entry.getKey());
+                String recipientName = bundle.getFullNameFromRoster(entry.getKey());
                 option = Sanitizer.sanitizeForCsv(teamName) + "," + Sanitizer.sanitizeForCsv(recipientName);
             } else {
                 option = Sanitizer.sanitizeForCsv(options.get(Integer.parseInt(entry.getKey())));

--- a/src/main/java/teammates/common/datatransfer/FeedbackConstantSumQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/FeedbackConstantSumQuestionDetails.java
@@ -479,7 +479,8 @@ public class FeedbackConstantSumQuestionDetails extends FeedbackQuestionDetails 
     }
     
     /**
-     * Used to update the option points mapping with a default value when distributing to recipients
+     * Used to update the option points mapping with a default value of 0.
+     * To be used only when distributing to recipients.
      * @param optionPoints
      * @param question question for the option points mapping
      * @param responses responses for the option points mapping
@@ -491,16 +492,16 @@ public class FeedbackConstantSumQuestionDetails extends FeedbackQuestionDetails 
             List<FeedbackResponseAttributes> responses,
             FeedbackSessionResultsBundle bundle) {
         
-        Map<String, Set<String>> giverHasRecipients = new HashMap<>();
+        Map<String, Set<String>> giverRecipientsFromResponses = new HashMap<>();
         
         for (FeedbackResponseAttributes response : responses) {
-            if (!giverHasRecipients.containsKey(response.giverEmail)) {
-                giverHasRecipients.put(response.giverEmail, new HashSet<String>());
+            if (!giverRecipientsFromResponses.containsKey(response.giverEmail)) {
+                giverRecipientsFromResponses.put(response.giverEmail, new HashSet<String>());
             }
-            giverHasRecipients.get(response.giverEmail).add(response.recipientEmail);
+            giverRecipientsFromResponses.get(response.giverEmail).add(response.recipientEmail);
         }
         
-        for (Entry<String, Set<String>> giverRecipients : giverHasRecipients.entrySet()) {
+        for (Entry<String, Set<String>> giverRecipients : giverRecipientsFromResponses.entrySet()) {
             // only get recipients from givers that responded
             List<String> possibleGiverRecipients =
                     bundle.getPossibleRecipients(question, giverRecipients.getKey());

--- a/src/main/java/teammates/common/datatransfer/FeedbackConstantSumQuestionDetails.java
+++ b/src/main/java/teammates/common/datatransfer/FeedbackConstantSumQuestionDetails.java
@@ -363,7 +363,9 @@ public class FeedbackConstantSumQuestionDetails extends FeedbackQuestionDetails 
         List<String> options = constSumOptions;
         
         Map<String, List<Integer>> optionPoints = generateOptionPointsMapping(responses);
-        updateRecipientOptionPointsMappingWithDefaultValue(optionPoints, question, responses, bundle);
+        if (distributeToRecipients) {
+            updateOptionPointsMappingWithDefaultValue(optionPoints, question, responses, bundle);
+        }
 
         DecimalFormat df = new DecimalFormat("#.##");
         
@@ -422,7 +424,9 @@ public class FeedbackConstantSumQuestionDetails extends FeedbackQuestionDetails 
         String fragments = "";
         List<String> options = constSumOptions;
         Map<String, List<Integer>> optionPoints = generateOptionPointsMapping(responses);
-        updateRecipientOptionPointsMappingWithDefaultValue(optionPoints, question, responses, bundle);
+        if (distributeToRecipients) {
+            updateOptionPointsMappingWithDefaultValue(optionPoints, question, responses, bundle);
+        }
 
         DecimalFormat df = new DecimalFormat("#.##");
         
@@ -481,15 +485,11 @@ public class FeedbackConstantSumQuestionDetails extends FeedbackQuestionDetails 
      * @param responses responses for the option points mapping
      * @param bundle
      */
-    private void updateRecipientOptionPointsMappingWithDefaultValue(
+    private void updateOptionPointsMappingWithDefaultValue(
             Map<String, List<Integer>> optionPoints,
             FeedbackQuestionAttributes question,
             List<FeedbackResponseAttributes> responses,
             FeedbackSessionResultsBundle bundle) {
-        
-        if (!distributeToRecipients) {
-            return;
-        }
         
         Map<String, Set<String>> giverHasRecipients = new HashMap<>();
         


### PR DESCRIPTION
Fixes #4019

It's possible to combine it into the loop inside `generateOptionPointsMapping()`, but no idea if I should since it gets more messy.
There aren't any db queries, so it's not that heavy anyway.

Also, how should the below case be handled, if at all?

(↓ from Alice; "among options" question; valid submission)
![2015-09-22_14-12-33](https://cloud.githubusercontent.com/assets/8586080/10011922/58d18a1a-6134-11e5-8aed-32f7676c870c.png)

![2015-09-22_14-12-48](https://cloud.githubusercontent.com/assets/8586080/10011923/5a586ebc-6134-11e5-9a60-55154d5e12de.png)
