### PR TITLE
Enable full HTML check after ajax load #4359

### DIFF
--- a/src/test/java/teammates/test/cases/ui/browsertests/InstructorFeedbackPageUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/InstructorFeedbackPageUiTest.java
@@ -146,14 +146,14 @@ public class InstructorFeedbackPageUiTest extends BaseUiTestCase {
         String helperId = testData.accounts.get("helperWithSessions").googleId;
         
         feedbackPage = getFeedbackPageForInstructor(helperId);
-        feedbackPage.verifyHtmlAjax("/instructorFeedbackAllSessionTypesWithHelperView.html");
+        feedbackPage.verifyHtmlAjaxMainContent("/instructorFeedbackAllSessionTypesWithHelperView.html");
         
         
         ______TS("typical case, sort by name");
         
         feedbackPage = getFeedbackPageForInstructor(idOfInstructorWithSessions);
         
-        feedbackPage.verifyHtmlAjax("/instructorFeedbackAllSessionTypes.html");
+        feedbackPage.verifyHtmlAjaxMainContent("/instructorFeedbackAllSessionTypes.html");
 
         feedbackPage.sortByName().verifyTablePattern(
                 0, 1,"Awaiting Session{*}First Session{*}Manual Session{*}Open Session{*}Private Session");
@@ -553,7 +553,7 @@ public class InstructorFeedbackPageUiTest extends BaseUiTestCase {
                       BackDoor.getFeedbackSession(courseId, sessionName));
     
         feedbackPage.clickAndConfirm(feedbackPage.getDeleteLink(courseId, sessionName));
-        feedbackPage.verifyHtmlAjax("/instructorFeedbackDeleteSuccessful.html");
+        feedbackPage.verifyHtmlAjaxMainContent("/instructorFeedbackDeleteSuccessful.html");
         
     }
 
@@ -588,7 +588,7 @@ public class InstructorFeedbackPageUiTest extends BaseUiTestCase {
         feedbackPage.clickAndConfirm(feedbackPage.getPublishLink(courseId, sessionName));
         feedbackPage.verifyStatus(Const.StatusMessages.FEEDBACK_SESSION_PUBLISHED);
         assertEquals(true, BackDoor.getFeedbackSession(courseId, sessionName).isPublished());
-        feedbackPage.verifyHtmlAjax("/instructorFeedbackPublishSuccessful.html");
+        feedbackPage.verifyHtmlAjaxMainContent("/instructorFeedbackPublishSuccessful.html");
         
         
         ______TS("PUBLISHED: publish link hidden");
@@ -626,7 +626,7 @@ public class InstructorFeedbackPageUiTest extends BaseUiTestCase {
         feedbackPage.clickAndConfirm(feedbackPage.getUnpublishLink(courseId, sessionName));
         feedbackPage.verifyStatus(Const.StatusMessages.FEEDBACK_SESSION_UNPUBLISHED);
         assertEquals(false, BackDoor.getFeedbackSession(courseId, sessionName).isPublished());
-        feedbackPage.verifyHtmlAjax("/instructorFeedbackUnpublishSuccessful.html");
+        feedbackPage.verifyHtmlAjaxMainContent("/instructorFeedbackUnpublishSuccessful.html");
         
         
         ______TS("PUBLISHED: unpublish link hidden");

--- a/src/test/java/teammates/test/cases/ui/browsertests/InstructorFeedbackResultsPageUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/InstructorFeedbackResultsPageUiTest.java
@@ -338,7 +338,7 @@ public class InstructorFeedbackResultsPageUiTest extends BaseUiTestCase {
                                                                        "Open Session", true, "question");
 
         resultsPage.clickAjaxLoadResponsesPanel(0);
-        resultsPage.verifyHtmlAjax("/instructorFeedbackResultsAjaxByQuestion.html");
+        resultsPage.verifyHtmlAjaxMainContent("/instructorFeedbackResultsAjaxByQuestion.html");
         
         ______TS("Failure case: Ajax error");
         
@@ -364,14 +364,14 @@ public class InstructorFeedbackResultsPageUiTest extends BaseUiTestCase {
 
         resultsPage.clickAjaxLoadResponsesPanel(0);
 
-        resultsPage.verifyHtmlAjax("/instructorFeedbackResultsAjaxByQuestionViewForHelperOne.html");
+        resultsPage.verifyHtmlAjaxMainContent("/instructorFeedbackResultsAjaxByQuestionViewForHelperOne.html");
         
         ______TS("Typical case: ajax for view by question for helper2");
         resultsPage = loginToInstructorFeedbackResultsPageWithViewType("CFResultsUiT.helper2",
                                         "Open Session", true, "question");
 
         resultsPage.clickAjaxLoadResponsesPanel(0);
-        resultsPage.verifyHtmlAjax("/instructorFeedbackResultsAjaxByQuestionViewForHelperTwo.html");
+        resultsPage.verifyHtmlAjaxMainContent("/instructorFeedbackResultsAjaxByQuestionViewForHelperTwo.html");
 
         ______TS("Typical case: ajax for view by giver > recipient > question");
 
@@ -380,7 +380,7 @@ public class InstructorFeedbackResultsPageUiTest extends BaseUiTestCase {
 
         resultsPage.clickAjaxLoadResponsesPanel(0);
 
-        resultsPage.verifyHtmlAjax("/instructorFeedbackResultsAjaxByGRQ.html");
+        resultsPage.verifyHtmlAjaxMainContent("/instructorFeedbackResultsAjaxByGRQ.html");
 
         ______TS("Typical case: test view photo for view by giver > recipient > question");
 
@@ -403,7 +403,7 @@ public class InstructorFeedbackResultsPageUiTest extends BaseUiTestCase {
         resultsPage = loginToInstructorFeedbackResultsPageWithViewType("CFResultsUiT.instr", "Open Session", true, "giver-question-recipient");
         
         resultsPage.clickAjaxLoadResponsesPanel(0);
-        resultsPage.verifyHtmlAjax("/instructorFeedbackResultsAjaxByGQR.html");
+        resultsPage.verifyHtmlAjaxMainContent("/instructorFeedbackResultsAjaxByGQR.html");
                 
         ______TS("Typical case: test view photo for view by giver > question > recipient");
         
@@ -417,7 +417,7 @@ public class InstructorFeedbackResultsPageUiTest extends BaseUiTestCase {
                                                                        "recipient-question-giver");
 
         resultsPage.clickAjaxLoadResponsesPanel(0);
-        resultsPage.verifyHtmlAjax("/instructorFeedbackResultsAjaxByRQG.html");
+        resultsPage.verifyHtmlAjaxMainContent("/instructorFeedbackResultsAjaxByRQG.html");
 
         ______TS("Typical case: test view photo for view by recipient > question > giver");
 
@@ -431,7 +431,7 @@ public class InstructorFeedbackResultsPageUiTest extends BaseUiTestCase {
                                                                        "recipient-giver-question");
 
         resultsPage.clickAjaxLoadResponsesPanel(0);
-        resultsPage.verifyHtmlAjax("/instructorFeedbackResultsAjaxByRGQ.html");
+        resultsPage.verifyHtmlAjaxMainContent("/instructorFeedbackResultsAjaxByRGQ.html");
 
         ______TS("Typical case: test view photo for view by recipient > giver > question");
 

--- a/src/test/java/teammates/test/cases/ui/browsertests/InstructorHomePageUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/InstructorHomePageUiTest.java
@@ -90,7 +90,7 @@ public class InstructorHomePageUiTest extends BaseUiTestCase {
         loginAsInstructor("CHomeUiT.instructor.tmms.unloaded");
         
         homePage.clickHomeTab();
-        homePage.verifyHtmlAjax("/InstructorHomeHTMLWithUnloadedCourse.html");
+        homePage.verifyHtmlAjaxMainContent("/InstructorHomeHTMLWithUnloadedCourse.html");
         
         loginAsCommonInstructor();
         removeTestDataOnServer(unloadedCourseTestData);
@@ -122,18 +122,18 @@ public class InstructorHomePageUiTest extends BaseUiTestCase {
         ______TS("test case: fail, fetch response rate of invalid url");
         homePage.setViewResponseLinkValue(viewResponseLink, "/invalid/url");
         viewResponseLink.click();
-        homePage.verifyHtmlAjax("/InstructorHomeHTMLResponseRateFail.html");
+        homePage.verifyHtmlAjaxMainContent("/InstructorHomeHTMLResponseRateFail.html");
         
         ______TS("test case: fail to fetch response rate again, check consistency of fail message");
         viewResponseLink = homePage.getViewResponseLink("CHomeUiT.CS2104", "Fourth Feedback Session");
         viewResponseLink.click();
-        homePage.verifyHtmlAjax("/InstructorHomeHTMLResponseRateFail.html");
+        homePage.verifyHtmlAjaxMainContent("/InstructorHomeHTMLResponseRateFail.html");
         
         ______TS("test case: pass with valid url after multiple fails");
         viewResponseLink = homePage.getViewResponseLink("CHomeUiT.CS2104", "Fourth Feedback Session");
         homePage.setViewResponseLinkValue(viewResponseLink, currentValidUrl);
         viewResponseLink.click();
-        homePage.verifyHtmlAjax("/instructorHomeHTMLResponseRatePass.html");
+        homePage.verifyHtmlAjaxMainContent("/instructorHomeHTMLResponseRatePass.html");
     }
     
     public void testContent() throws Exception{
@@ -152,17 +152,17 @@ public class InstructorHomePageUiTest extends BaseUiTestCase {
         testData = loadDataBundle("/InstructorHomePageUiTest2.json");
         removeAndRestoreTestDataOnServer(testData);
         homePage.clickHomeTab();
-        homePage.verifyHtmlAjax("/InstructorHomeNewInstructorWithSampleCourse.html");
+        homePage.verifyHtmlAjaxMainContent("/InstructorHomeNewInstructorWithSampleCourse.html");
         
         ______TS("content: multiple courses");
         
         loadFinalHomePageTestData();
         homePage.clickHomeTab();
         // Should not see private session
-        homePage.verifyHtmlAjax("/InstructorHomeHTMLWithHelperView.html");
+        homePage.verifyHtmlAjaxMainContent("/InstructorHomeHTMLWithHelperView.html");
         updateInstructorToCoownerPrivileges();
         homePage.clickHomeTab();
-        homePage.verifyHtmlAjax("/InstructorHomeHTML.html");
+        homePage.verifyHtmlAjaxMainContent("/InstructorHomeHTML.html");
     }
 
     private void updateInstructorToCoownerPrivileges() {
@@ -327,7 +327,7 @@ public class InstructorHomePageUiTest extends BaseUiTestCase {
         // the course's isArchived status should not be modified
         assertFalse(BackDoor.getCourse(courseIdForCS1101).isArchived);
         
-        homePage.verifyHtmlAjax("/instructorHomeCourseArchiveSuccessful.html");
+        homePage.verifyHtmlAjaxMainContent("/instructorHomeCourseArchiveSuccessful.html");
         
         ______TS("archive action failed");
         
@@ -414,7 +414,7 @@ public class InstructorHomePageUiTest extends BaseUiTestCase {
         
         homePage.clickAndConfirm(homePage.getDeleteCourseLink(courseId));
         assertTrue(BackDoor.isCourseNonExistent(courseId));
-        homePage.verifyHtmlAjax("/instructorHomeCourseDeleteSuccessful.html");
+        homePage.verifyHtmlAjaxMainContent("/instructorHomeCourseDeleteSuccessful.html");
         
         //delete the other course as well
         courseId = testData.courses.get("CHomeUiT.CS1101").id;
@@ -432,15 +432,15 @@ public class InstructorHomePageUiTest extends BaseUiTestCase {
     public void testSortAction() throws Exception{
         ______TS("sort by id");
         homePage.clickSortByIdButton();
-        homePage.verifyHtmlAjax("/InstructorHomeHTMLSortById.html");
+        homePage.verifyHtmlAjaxMainContent("/InstructorHomeHTMLSortById.html");
         
         ______TS("sort by name");
         homePage.clickSortByNameButton();
-        homePage.verifyHtmlAjax("/InstructorHomeHTMLSortByName.html");
+        homePage.verifyHtmlAjaxMainContent("/InstructorHomeHTMLSortByName.html");
         
         ______TS("sort by date");
         homePage.clickSortByDateButton();
-        homePage.verifyHtmlAjax("/InstructorHomeHTMLSortByDate.html");
+        homePage.verifyHtmlAjaxMainContent("/InstructorHomeHTMLSortByDate.html");
     }
     
     private void loginAsCommonInstructor(){

--- a/src/test/java/teammates/test/cases/ui/browsertests/InstructorStudentListPageUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/InstructorStudentListPageUiTest.java
@@ -109,7 +109,7 @@ public class InstructorStudentListPageUiTest extends BaseUiTestCase {
         viewPage = loginAdminToPage(browser, viewPageUrl, InstructorStudentListPage.class);
         viewPage.checkCourse(0);
         viewPage.checkCourse(1);
-        viewPage.verifyHtmlAjax("/instructorStudentListWithHelperView.html");
+        viewPage.verifyHtmlAjaxMainContent("/instructorStudentListWithHelperView.html");
 
         // update current instructor privileges
         BackDoor.deleteInstructor(instructorWith2Courses.courseId, instructorWith2Courses.email);
@@ -122,7 +122,7 @@ public class InstructorStudentListPageUiTest extends BaseUiTestCase {
         viewPage = loginAdminToPage(browser, viewPageUrl, InstructorStudentListPage.class);
         viewPage.checkCourse(0);
         viewPage.checkCourse(1);
-        viewPage.verifyHtmlAjax("/instructorStudentList.html");
+        viewPage.verifyHtmlAjaxMainContent("/instructorStudentList.html");
 
         ______TS("content: 1 course with no students");
 
@@ -132,7 +132,7 @@ public class InstructorStudentListPageUiTest extends BaseUiTestCase {
 
         viewPage = loginAdminToPage(browser, viewPageUrl, InstructorStudentListPage.class);
         viewPage.checkCourse(0);
-        viewPage.verifyHtmlAjax("/instructorStudentListPageNoStudent.html");
+        viewPage.verifyHtmlAjaxMainContent("/instructorStudentListPageNoStudent.html");
 
         ______TS("content: no course");
 
@@ -263,14 +263,14 @@ public class InstructorStudentListPageUiTest extends BaseUiTestCase {
         viewPage.checkCourse(0);
         viewPage.checkCourse(1);
         viewPage.checkCourse(2);
-        viewPage.verifyHtmlAjax("/instructorStudentListPageDisplayArchivedCourses.html");
+        viewPage.verifyHtmlAjaxMainContent("/instructorStudentListPageDisplayArchivedCourses.html");
 
         ______TS("action: hide archive");
 
         viewPage.clickDisplayArchiveOptions();
         viewPage.checkCourse(0);
         viewPage.checkCourse(1);
-        viewPage.verifyHtmlAjax("/instructorStudentListPageHideArchivedCourses.html");
+        viewPage.verifyHtmlAjaxMainContent("/instructorStudentListPageHideArchivedCourses.html");
 
         ______TS("action: re-display archive");
 
@@ -278,7 +278,7 @@ public class InstructorStudentListPageUiTest extends BaseUiTestCase {
         viewPage.checkCourse(0);
         viewPage.checkCourse(1);
         viewPage.checkCourse(2);
-        viewPage.verifyHtmlAjax("/instructorStudentListPageDisplayArchivedCourses.html");
+        viewPage.verifyHtmlAjaxMainContent("/instructorStudentListPageDisplayArchivedCourses.html");
     }
 
     @AfterClass

--- a/src/test/java/teammates/test/cases/ui/browsertests/InstructorStudentRecordsPageUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/InstructorStudentRecordsPageUiTest.java
@@ -60,7 +60,7 @@ public class InstructorStudentRecordsPageUiTest extends BaseUiTestCase {
         studentEmail = student.email;
 
         viewPage = getStudentRecordsPage();
-        viewPage.verifyHtmlAjax("/instructorStudentRecords.html");
+        viewPage.verifyHtmlAjaxMainContent("/instructorStudentRecords.html");
 
         ______TS("content: typical case, normal student records with comments, helper view");
 
@@ -71,7 +71,7 @@ public class InstructorStudentRecordsPageUiTest extends BaseUiTestCase {
         studentEmail = student.email;
 
         viewPage = getStudentRecordsPage();
-        viewPage.verifyHtmlAjax("/instructorStudentRecordsWithHelperView.html");
+        viewPage.verifyHtmlAjaxMainContent("/instructorStudentRecordsWithHelperView.html");
 
         ______TS("content: normal student records with private feedback session");
 
@@ -83,7 +83,7 @@ public class InstructorStudentRecordsPageUiTest extends BaseUiTestCase {
         studentEmail = student.email;
 
         viewPage = getStudentRecordsPage();
-        viewPage.verifyHtmlAjax("/instructorStudentRecordsPageWithPrivateFeedback.html");
+        viewPage.verifyHtmlAjaxMainContent("/instructorStudentRecordsPageWithPrivateFeedback.html");
 
         ______TS("content: no student records, no profiles");
 
@@ -95,7 +95,7 @@ public class InstructorStudentRecordsPageUiTest extends BaseUiTestCase {
         studentEmail = student.email;
 
         viewPage = getStudentRecordsPage();
-        viewPage.verifyHtmlAjax("/instructorStudentRecordsPageNoRecords.html");
+        viewPage.verifyHtmlAjaxMainContent("/instructorStudentRecordsPageNoRecords.html");
 
         ______TS("content: multiple feedback session type student record");
 
@@ -109,7 +109,7 @@ public class InstructorStudentRecordsPageUiTest extends BaseUiTestCase {
         studentEmail = student.email;
 
         viewPage = getStudentRecordsPage();
-        viewPage.verifyHtmlAjax("/instructorStudentRecordsPageMixedQuestionType.html");
+        viewPage.verifyHtmlAjaxMainContent("/instructorStudentRecordsPageMixedQuestionType.html");
 
     }
 

--- a/src/test/java/teammates/test/pageobjects/AppPage.java
+++ b/src/test/java/teammates/test/pageobjects/AppPage.java
@@ -907,7 +907,7 @@ public abstract class AppPage {
      * simply mainContent check
      * @return The page (for chaining method calls).
      */
-    public AppPage verifyHtmlAfterAjaxLoad(String filePath, boolean isFullPageChecked) throws Exception {
+    private AppPage verifyHtmlAfterAjaxLoad(String filePath, boolean isFullPageChecked) throws Exception {
         int maxRetryCount = 5;
         int waitDuration = 1000;
         

--- a/src/test/java/teammates/test/pageobjects/AppPage.java
+++ b/src/test/java/teammates/test/pageobjects/AppPage.java
@@ -888,6 +888,14 @@ public abstract class AppPage {
         return this;
     }
     
+    public AppPage verifyHtmlAjaxMainContent(String filePath) throws Exception {
+        return verifyHtmlAfterAjaxLoad(filePath, false);
+    }
+
+    public AppPage verifyHtmlAjax(String filePath) throws Exception {
+        return verifyHtmlAfterAjaxLoad(filePath, true);
+    }
+
     /**
      * Verifies that the currently loaded page has the same HTML content as 
      * the content given in the file at {@code filePath}. <br>
@@ -895,9 +903,11 @@ public abstract class AppPage {
      * after "waitDuration", for "maxRetryCount" number of times.
      * @param filePath If this starts with "/" (e.g., "/expected.html"), the 
      * folder is assumed to be {@link Const.TEST_PAGES_FOLDER}. 
+     * @param isFullPageChecked indicates whether a full page check is done as compared to
+     * simply mainContent check
      * @return The page (for chaining method calls).
      */
-    public AppPage verifyHtmlAjax(String filePath) throws Exception {
+    public AppPage verifyHtmlAfterAjaxLoad(String filePath, boolean isFullPageChecked) throws Exception {
         int maxRetryCount = 5;
         int waitDuration = 1000;
         
@@ -932,7 +942,11 @@ public abstract class AppPage {
             }
         }
         
-        return verifyHtmlMainContent(filePath);
+        if (isFullPageChecked) {
+            return verifyHtml(filePath);
+        } else {
+            return verifyHtmlMainContent(filePath);
+        }
     }
     
     /**

--- a/src/test/java/teammates/test/pageobjects/AppPage.java
+++ b/src/test/java/teammates/test/pageobjects/AppPage.java
@@ -888,25 +888,35 @@ public abstract class AppPage {
         return this;
     }
     
+    /**
+     * Verifies that main content specified id "mainContent" in currently 
+     * loaded page has the same HTML content as 
+     * the content given in the file at {@code filePath}. <br>
+     * The HTML is checked for logical equivalence, not text equivalence. <br>
+     * Since the verification is done after making AJAX request(s), the HTML is checked
+     * after "waitDuration", for "maxRetryCount" number of times.
+     * @param filePath If this starts with "/" (e.g., "/expected.html"), the 
+     * folder is assumed to be {@link Const.TEST_PAGES_FOLDER}. 
+     * @return The page (for chaining method calls).
+     */
     public AppPage verifyHtmlAjaxMainContent(String filePath) throws Exception {
         return verifyHtmlAfterAjaxLoad(filePath, false);
-    }
-
-    public AppPage verifyHtmlAjax(String filePath) throws Exception {
-        return verifyHtmlAfterAjaxLoad(filePath, true);
     }
 
     /**
      * Verifies that the currently loaded page has the same HTML content as 
      * the content given in the file at {@code filePath}. <br>
-     * Since the verification is done after making an Ajax Request, the HTML is checked
+     * The HTML is checked for logical equivalence, not text equivalence. <br>
+     * Since the verification is done after making AJAX request(s), the HTML is checked
      * after "waitDuration", for "maxRetryCount" number of times.
      * @param filePath If this starts with "/" (e.g., "/expected.html"), the 
      * folder is assumed to be {@link Const.TEST_PAGES_FOLDER}. 
-     * @param isFullPageChecked indicates whether a full page check is done as compared to
-     * simply mainContent check
      * @return The page (for chaining method calls).
      */
+    public AppPage verifyHtmlAjax(String filePath) throws Exception {
+        return verifyHtmlAfterAjaxLoad(filePath, true);
+    }
+
     private AppPage verifyHtmlAfterAjaxLoad(String filePath, boolean isFullPageChecked) throws Exception {
         int maxRetryCount = 5;
         int waitDuration = 1000;


### PR DESCRIPTION
Fixes #4359 
This PR (and issue) will first add the capability for full HTML check after ajax load. The missing page checks are to be added in another (few) issue(s).