### PR TITLE
Regex for questionid replaces things that should be replaced by other regexes #4361

### DIFF
--- a/src/test/java/teammates/test/pageobjects/AppPage.java
+++ b/src/test/java/teammates/test/pageobjects/AppPage.java
@@ -784,7 +784,7 @@ public abstract class AppPage {
                         Const.ActionURIs.STUDENT_PROFILE_PICTURE + "\\?" + Const.ParamsNames.COURSE_ID 
                         + "={*}\\&amp;" + Const.ParamsNames.STUDENT_EMAIL + "={*}")
                 //regkey
-                .replaceAll(Const.ParamsNames.REGKEY + "=([a-zA-Z0-9]){1,}\\&", Const.ParamsNames.REGKEY + "={*}\\&")
+                .replaceAll(Const.ParamsNames.REGKEY + "=([a-zA-Z0-9]){1,}", Const.ParamsNames.REGKEY + "={*}")
                 .replaceAll(Const.ParamsNames.REGKEY + "%3D([a-zA-Z0-9]){1,}\\%", Const.ParamsNames.REGKEY + "%3D{*}\\%")
                 .replaceAll("\"([a-zA-Z0-9-_]){50,}\"","\"{*}\"")
                 //responseid

--- a/src/test/java/teammates/test/pageobjects/AppPage.java
+++ b/src/test/java/teammates/test/pageobjects/AppPage.java
@@ -787,8 +787,6 @@ public abstract class AppPage {
                 .replaceAll(Const.ParamsNames.REGKEY + "=([a-zA-Z0-9]){1,}", Const.ParamsNames.REGKEY + "={*}")
                 .replaceAll(Const.ParamsNames.REGKEY + "%3D([a-zA-Z0-9]){1,}\\%", Const.ParamsNames.REGKEY + "%3D{*}\\%")
                 .replaceAll("\"([a-zA-Z0-9-_]){50,}\"","\"{*}\"")
-                //questionid
-                .replaceAll("([a-zA-Z0-9-_]){62,}","{*}")
                 //questionid regex in responseid
                 .replaceAll("\"([a-zA-Z0-9-_]){62,}%", "\"{*}%")
                 //commentid

--- a/src/test/java/teammates/test/pageobjects/AppPage.java
+++ b/src/test/java/teammates/test/pageobjects/AppPage.java
@@ -775,14 +775,14 @@ public abstract class AppPage {
                 .replace("\"/_ah", "\"${web.url}/_ah")
                 .replaceAll("V[0-9]\\.[0-9]+", "V\\${version}")
                 // photo from instructor
-                .replaceAll(Const.ActionURIs.STUDENT_PROFILE_PICTURE + "\\?" + Const.ParamsNames.STUDENT_EMAIL + "=([a-zA-Z0-9]){1,}\\&"
+                .replaceAll(Const.ActionURIs.STUDENT_PROFILE_PICTURE + "\\?" + Const.ParamsNames.STUDENT_EMAIL + "=([a-zA-Z0-9]){1,}\\&amp;"
                         + Const.ParamsNames.COURSE_ID + "=([a-zA-Z0-9]){1,}", 
                         Const.ActionURIs.STUDENT_PROFILE_PICTURE + "\\?" + Const.ParamsNames.STUDENT_EMAIL 
-                        + "={*}\\&" + Const.ParamsNames.COURSE_ID + "={*}")
-                .replaceAll(Const.ActionURIs.STUDENT_PROFILE_PICTURE + "\\?" + Const.ParamsNames.COURSE_ID + "=([a-zA-Z0-9]){1,}\\&"
+                        + "={*}\\&amp;" + Const.ParamsNames.COURSE_ID + "={*}")
+                .replaceAll(Const.ActionURIs.STUDENT_PROFILE_PICTURE + "\\?" + Const.ParamsNames.COURSE_ID + "=([a-zA-Z0-9]){1,}\\&amp;"
                         + Const.ParamsNames.STUDENT_EMAIL + "=([a-zA-Z0-9]){1,}", 
                         Const.ActionURIs.STUDENT_PROFILE_PICTURE + "\\?" + Const.ParamsNames.COURSE_ID 
-                        + "={*}\\&" + Const.ParamsNames.STUDENT_EMAIL + "={*}")
+                        + "={*}\\&amp;" + Const.ParamsNames.STUDENT_EMAIL + "={*}")
                 //regkey
                 .replaceAll(Const.ParamsNames.REGKEY + "=([a-zA-Z0-9]){1,}\\&", Const.ParamsNames.REGKEY + "={*}\\&")
                 .replaceAll(Const.ParamsNames.REGKEY + "%3D([a-zA-Z0-9]){1,}\\%", Const.ParamsNames.REGKEY + "%3D{*}\\%")

--- a/src/test/java/teammates/test/pageobjects/AppPage.java
+++ b/src/test/java/teammates/test/pageobjects/AppPage.java
@@ -784,7 +784,7 @@ public abstract class AppPage {
                         Const.ActionURIs.STUDENT_PROFILE_PICTURE + "\\?" + Const.ParamsNames.COURSE_ID 
                         + "={*}\\&amp;" + Const.ParamsNames.STUDENT_EMAIL + "={*}")
                 //regkey
-                .replaceAll(Const.ParamsNames.REGKEY + "=([a-zA-Z0-9]){1,}", Const.ParamsNames.REGKEY + "={*}")
+                .replaceAll(Const.ParamsNames.REGKEY + "=([a-zA-Z0-9-_]){50,}", Const.ParamsNames.REGKEY + "={*}")
                 .replaceAll(Const.ParamsNames.REGKEY + "%3D([a-zA-Z0-9]){1,}\\%", Const.ParamsNames.REGKEY + "%3D{*}\\%")
                 .replaceAll("\"([a-zA-Z0-9-_]){50,}\"","\"{*}\"")
                 //questionid regex in responseid

--- a/src/test/java/teammates/test/pageobjects/AppPage.java
+++ b/src/test/java/teammates/test/pageobjects/AppPage.java
@@ -787,12 +787,10 @@ public abstract class AppPage {
                 .replaceAll(Const.ParamsNames.REGKEY + "=([a-zA-Z0-9]){1,}", Const.ParamsNames.REGKEY + "={*}")
                 .replaceAll(Const.ParamsNames.REGKEY + "%3D([a-zA-Z0-9]){1,}\\%", Const.ParamsNames.REGKEY + "%3D{*}\\%")
                 .replaceAll("\"([a-zA-Z0-9-_]){50,}\"","\"{*}\"")
-                //responseid
-                .replaceAll("([a-zA-Z0-9-_]){30,}%"
-                        + "[\\w+-][\\w+!#$%&'*/=?^_`{}~-]*+(\\.[\\w+!#$%&'*/=?^_`{}~-]+)*+@([A-Za-z0-9-]+\\.)*[A-Za-z]+%"
-                        + "[\\w+-][\\w+!#$%&'*/=?^_`{}~-]*+(\\.[\\w+!#$%&'*/=?^_`{}~-]+)*+@([A-Za-z0-9-]+\\.)*[A-Za-z]+", "{*}")
                 //questionid
                 .replaceAll("([a-zA-Z0-9-_]){62,}","{*}")
+                //questionid regex in responseid
+                .replaceAll("\"([a-zA-Z0-9-_]){62,}%", "\"{*}%")
                 //commentid
                 .replaceAll("\\\"([0-9]){16}\\\"", "\\\"{*}\\\"")
                 // comment div ids (added after standardization)

--- a/src/test/resources/pages/InstructorEditStudentFeedbackPageModified.html
+++ b/src/test/resources/pages/InstructorEditStudentFeedbackPageModified.html
@@ -120,7 +120,7 @@
                         <textarea class="form-control" cols="100%" name="responsetext-1-0" rows="4">
                            Good design
                         </textarea>
-                        <input name="responseid-1-0" type="hidden" value="{*}"/>
+                        <input name="responseid-1-0" type="hidden" value="{*}%student1InIESFPTCourse@gmail.tmt%student1InIESFPTCourse@gmail.tmt"/>
                                              </div>
                   </div>
                </div>
@@ -179,7 +179,7 @@
                         <div class="text-muted form-control-static">
                            [Possible values: 1, 1.5, 2, ..., 4, 4.5, 5]
                         </div>
-                        <input name="responseid-2-0" type="hidden" value="{*}"/>
+                        <input name="responseid-2-0" type="hidden" value="{*}%student1InIESFPTCourse@gmail.tmt%student1InIESFPTCourse@gmail.tmt"/>
                                              </div>
                   </div>
                </div>

--- a/src/test/resources/pages/InstructorEditStudentFeedbackPageOpen.html
+++ b/src/test/resources/pages/InstructorEditStudentFeedbackPageOpen.html
@@ -117,7 +117,7 @@
                         <textarea class="form-control" cols="100%" name="responsetext-1-0" rows="4">
                            Student 1 self feedback.
                         </textarea>
-                        <input name="responseid-1-0" type="hidden" value="{*}"/>
+                        <input name="responseid-1-0" type="hidden" value="{*}%student1InIESFPTCourse@gmail.tmt%student1InIESFPTCourse@gmail.tmt"/>
                                              </div>
                   </div>
                </div>

--- a/src/test/resources/pages/instructorCommentsPageAddFrc.html
+++ b/src/test/resources/pages/instructorCommentsPageAddFrc.html
@@ -1782,7 +1782,7 @@
                                                 <span class="glyphicon glyphicon-trash glyphicon-primary">
                                                 </span>
                                              </a>
-                                             <input name="responseid" type="hidden" value="{*}"/>
+                                             <input name="responseid" type="hidden" value="{*}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt"/>
                                                                                           <input name="responsecommentid" type="hidden" value="{*}"/>
                                                                                           <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                           <input name="fsname" type="hidden" value="comments.First feedback session"/>
@@ -1870,7 +1870,7 @@
                                              <input class="btn btn-default" onclick="return hideResponseCommentEditForm(1,1,1,1);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="responsecommentid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>
@@ -1888,7 +1888,7 @@
                                                 <span class="glyphicon glyphicon-trash glyphicon-primary">
                                                 </span>
                                              </a>
-                                             <input name="responseid" type="hidden" value="{*}"/>
+                                             <input name="responseid" type="hidden" value="{*}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt"/>
                                                                                           <input name="responsecommentid" type="hidden" value="{*}"/>
                                                                                           <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                           <input name="fsname" type="hidden" value="comments.First feedback session"/>
@@ -1976,7 +1976,7 @@
                                              <input class="btn btn-default" onclick="return hideResponseCommentEditForm(1,1,1,2);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="responsecommentid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>
@@ -2058,7 +2058,7 @@
                                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,1);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="questionid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>
@@ -2125,7 +2125,7 @@ Multiline test.
                                                 <span class="glyphicon glyphicon-trash glyphicon-primary">
                                                 </span>
                                              </a>
-                                             <input name="responseid" type="hidden" value="{*}"/>
+                                             <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                           <input name="responsecommentid" type="hidden" value="{*}"/>
                                                                                           <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                           <input name="fsname" type="hidden" value="comments.First feedback session"/>
@@ -2252,7 +2252,7 @@ Multiline test.
                                              <input class="btn btn-default" onclick="return hideResponseCommentEditForm(1,2,1,1);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="responsecommentid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>
@@ -2272,7 +2272,7 @@ Multiline test.
                                                 <span class="glyphicon glyphicon-trash glyphicon-primary">
                                                 </span>
                                              </a>
-                                             <input name="responseid" type="hidden" value="{*}"/>
+                                             <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                           <input name="responsecommentid" type="hidden" value="{*}"/>
                                                                                           <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                           <input name="fsname" type="hidden" value="comments.First feedback session"/>
@@ -2399,7 +2399,7 @@ Multiline test.
                                              <input class="btn btn-default" onclick="return hideResponseCommentEditForm(1,2,1,2);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="responsecommentid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>
@@ -2419,7 +2419,7 @@ Multiline test.
                                                 <span class="glyphicon glyphicon-trash glyphicon-primary">
                                                 </span>
                                              </a>
-                                             <input name="responseid" type="hidden" value="{*}"/>
+                                             <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                           <input name="responsecommentid" type="hidden" value="{*}"/>
                                                                                           <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                           <input name="fsname" type="hidden" value="comments.First feedback session"/>
@@ -2546,7 +2546,7 @@ Multiline test.
                                              <input class="btn btn-default" onclick="return hideResponseCommentEditForm(1,2,1,3);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="responsecommentid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>
@@ -2667,7 +2667,7 @@ Multiline test.
                                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,2,1);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="questionid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>

--- a/src/test/resources/pages/instructorCommentsPageDeleteFrc.html
+++ b/src/test/resources/pages/instructorCommentsPageDeleteFrc.html
@@ -1778,7 +1778,7 @@
                                                 <span class="glyphicon glyphicon-trash glyphicon-primary">
                                                 </span>
                                              </a>
-                                             <input name="responseid" type="hidden" value="{*}"/>
+                                             <input name="responseid" type="hidden" value="{*}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt"/>
                                                                                           <input name="responsecommentid" type="hidden" value="{*}"/>
                                                                                           <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                           <input name="fsname" type="hidden" value="comments.First feedback session"/>
@@ -1866,7 +1866,7 @@
                                              <input class="btn btn-default" onclick="return hideResponseCommentEditForm(1,1,1,1);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="responsecommentid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>
@@ -1948,7 +1948,7 @@
                                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,1);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="questionid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>
@@ -2015,7 +2015,7 @@ Multiline test.
                                                 <span class="glyphicon glyphicon-trash glyphicon-primary">
                                                 </span>
                                              </a>
-                                             <input name="responseid" type="hidden" value="{*}"/>
+                                             <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                           <input name="responsecommentid" type="hidden" value="{*}"/>
                                                                                           <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                           <input name="fsname" type="hidden" value="comments.First feedback session"/>
@@ -2142,7 +2142,7 @@ Multiline test.
                                              <input class="btn btn-default" onclick="return hideResponseCommentEditForm(1,2,1,1);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="responsecommentid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>
@@ -2162,7 +2162,7 @@ Multiline test.
                                                 <span class="glyphicon glyphicon-trash glyphicon-primary">
                                                 </span>
                                              </a>
-                                             <input name="responseid" type="hidden" value="{*}"/>
+                                             <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                           <input name="responsecommentid" type="hidden" value="{*}"/>
                                                                                           <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                           <input name="fsname" type="hidden" value="comments.First feedback session"/>
@@ -2289,7 +2289,7 @@ Multiline test.
                                              <input class="btn btn-default" onclick="return hideResponseCommentEditForm(1,2,1,2);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="responsecommentid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>
@@ -2309,7 +2309,7 @@ Multiline test.
                                                 <span class="glyphicon glyphicon-trash glyphicon-primary">
                                                 </span>
                                              </a>
-                                             <input name="responseid" type="hidden" value="{*}"/>
+                                             <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                           <input name="responsecommentid" type="hidden" value="{*}"/>
                                                                                           <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                           <input name="fsname" type="hidden" value="comments.First feedback session"/>
@@ -2436,7 +2436,7 @@ Multiline test.
                                              <input class="btn btn-default" onclick="return hideResponseCommentEditForm(1,2,1,3);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="responsecommentid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>
@@ -2557,7 +2557,7 @@ Multiline test.
                                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,2,1);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="questionid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>

--- a/src/test/resources/pages/instructorCommentsPageEditFrc.html
+++ b/src/test/resources/pages/instructorCommentsPageEditFrc.html
@@ -1778,7 +1778,7 @@
                                                 <span class="glyphicon glyphicon-trash glyphicon-primary">
                                                 </span>
                                              </a>
-                                             <input name="responseid" type="hidden" value="{*}"/>
+                                             <input name="responseid" type="hidden" value="{*}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt"/>
                                                                                           <input name="responsecommentid" type="hidden" value="{*}"/>
                                                                                           <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                           <input name="fsname" type="hidden" value="comments.First feedback session"/>
@@ -1869,7 +1869,7 @@
                                              <input class="btn btn-default" onclick="return hideResponseCommentEditForm(1,1,1,1);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="responsecommentid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>
@@ -1887,7 +1887,7 @@
                                                 <span class="glyphicon glyphicon-trash glyphicon-primary">
                                                 </span>
                                              </a>
-                                             <input name="responseid" type="hidden" value="{*}"/>
+                                             <input name="responseid" type="hidden" value="{*}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt"/>
                                                                                           <input name="responsecommentid" type="hidden" value="{*}"/>
                                                                                           <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                           <input name="fsname" type="hidden" value="comments.First feedback session"/>
@@ -1975,7 +1975,7 @@
                                              <input class="btn btn-default" onclick="return hideResponseCommentEditForm(1,1,1,2);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="responsecommentid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>
@@ -2057,7 +2057,7 @@
                                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,1);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="questionid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>
@@ -2124,7 +2124,7 @@ Multiline test.
                                                 <span class="glyphicon glyphicon-trash glyphicon-primary">
                                                 </span>
                                              </a>
-                                             <input name="responseid" type="hidden" value="{*}"/>
+                                             <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                           <input name="responsecommentid" type="hidden" value="{*}"/>
                                                                                           <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                           <input name="fsname" type="hidden" value="comments.First feedback session"/>
@@ -2251,7 +2251,7 @@ Multiline test.
                                              <input class="btn btn-default" onclick="return hideResponseCommentEditForm(1,2,1,1);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="responsecommentid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>
@@ -2271,7 +2271,7 @@ Multiline test.
                                                 <span class="glyphicon glyphicon-trash glyphicon-primary">
                                                 </span>
                                              </a>
-                                             <input name="responseid" type="hidden" value="{*}"/>
+                                             <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                           <input name="responsecommentid" type="hidden" value="{*}"/>
                                                                                           <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                           <input name="fsname" type="hidden" value="comments.First feedback session"/>
@@ -2398,7 +2398,7 @@ Multiline test.
                                              <input class="btn btn-default" onclick="return hideResponseCommentEditForm(1,2,1,2);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="responsecommentid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>
@@ -2418,7 +2418,7 @@ Multiline test.
                                                 <span class="glyphicon glyphicon-trash glyphicon-primary">
                                                 </span>
                                              </a>
-                                             <input name="responseid" type="hidden" value="{*}"/>
+                                             <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                           <input name="responsecommentid" type="hidden" value="{*}"/>
                                                                                           <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                           <input name="fsname" type="hidden" value="comments.First feedback session"/>
@@ -2545,7 +2545,7 @@ Multiline test.
                                              <input class="btn btn-default" onclick="return hideResponseCommentEditForm(1,2,1,3);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="responsecommentid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>
@@ -2666,7 +2666,7 @@ Multiline test.
                                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,2,1);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="questionid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>

--- a/src/test/resources/pages/instructorCommentsPageForCourseWithURIEncodedSessionName.html
+++ b/src/test/resources/pages/instructorCommentsPageForCourseWithURIEncodedSessionName.html
@@ -423,7 +423,7 @@
                                                 <span class="glyphicon glyphicon-trash glyphicon-primary">
                                                 </span>
                                              </a>
-                                             <input name="responseid" type="hidden" value="{*}"/>
+                                             <input name="responseid" type="hidden" value="{*}%comments.studentInCourseUri@gmail.tmt%comments.studentInCourseUri@gmail.tmt"/>
                                                                                           <input name="responsecommentid" type="hidden" value="{*}"/>
                                                                                           <input name="courseid" type="hidden" value="comments.idOfUriCharsCourse"/>
                                                                                           <input name="fsname" type="hidden" value="comments.Session with name ,?:@=+$#"/>
@@ -511,7 +511,7 @@
                                              <input class="btn btn-default" onclick="return hideResponseCommentEditForm(1,1,1,1);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="responsecommentid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.studentInCourseUri@gmail.tmt%comments.studentInCourseUri@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfUriCharsCourse"/>
                                                                                     <input name="fsname" type="hidden" value="comments.Session with name ,?:@=+$#"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructorOfCourseWithUriChars"/>
@@ -593,7 +593,7 @@
                                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,1);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="questionid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.studentInCourseUri@gmail.tmt%comments.studentInCourseUri@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfUriCharsCourse"/>
                                                                                     <input name="fsname" type="hidden" value="comments.Session with name ,?:@=+$#"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructorOfCourseWithUriChars"/>

--- a/src/test/resources/pages/instructorCommentsPageForTypicalCourseWithComments.html
+++ b/src/test/resources/pages/instructorCommentsPageForTypicalCourseWithComments.html
@@ -1891,7 +1891,7 @@
                                                 <span class="glyphicon glyphicon-trash glyphicon-primary">
                                                 </span>
                                              </a>
-                                             <input name="responseid" type="hidden" value="{*}"/>
+                                             <input name="responseid" type="hidden" value="{*}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt"/>
                                                                                           <input name="responsecommentid" type="hidden" value="{*}"/>
                                                                                           <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                           <input name="fsname" type="hidden" value="comments.First feedback session"/>
@@ -1979,7 +1979,7 @@
                                              <input class="btn btn-default" onclick="return hideResponseCommentEditForm(1,1,1,1);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="responsecommentid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>
@@ -2061,7 +2061,7 @@
                                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,1);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="questionid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>
@@ -2128,7 +2128,7 @@ Multiline test.
                                                 <span class="glyphicon glyphicon-trash glyphicon-primary">
                                                 </span>
                                              </a>
-                                             <input name="responseid" type="hidden" value="{*}"/>
+                                             <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                           <input name="responsecommentid" type="hidden" value="{*}"/>
                                                                                           <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                           <input name="fsname" type="hidden" value="comments.First feedback session"/>
@@ -2255,7 +2255,7 @@ Multiline test.
                                              <input class="btn btn-default" onclick="return hideResponseCommentEditForm(1,2,1,1);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="responsecommentid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>
@@ -2275,7 +2275,7 @@ Multiline test.
                                                 <span class="glyphicon glyphicon-trash glyphicon-primary">
                                                 </span>
                                              </a>
-                                             <input name="responseid" type="hidden" value="{*}"/>
+                                             <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                           <input name="responsecommentid" type="hidden" value="{*}"/>
                                                                                           <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                           <input name="fsname" type="hidden" value="comments.First feedback session"/>
@@ -2402,7 +2402,7 @@ Multiline test.
                                              <input class="btn btn-default" onclick="return hideResponseCommentEditForm(1,2,1,2);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="responsecommentid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>
@@ -2422,7 +2422,7 @@ Multiline test.
                                                 <span class="glyphicon glyphicon-trash glyphicon-primary">
                                                 </span>
                                              </a>
-                                             <input name="responseid" type="hidden" value="{*}"/>
+                                             <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                           <input name="responsecommentid" type="hidden" value="{*}"/>
                                                                                           <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                           <input name="fsname" type="hidden" value="comments.First feedback session"/>
@@ -2549,7 +2549,7 @@ Multiline test.
                                              <input class="btn btn-default" onclick="return hideResponseCommentEditForm(1,2,1,3);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="responsecommentid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>
@@ -2670,7 +2670,7 @@ Multiline test.
                                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,2,1);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="questionid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>

--- a/src/test/resources/pages/instructorCommentsPageShowCommentsForAll.html
+++ b/src/test/resources/pages/instructorCommentsPageShowCommentsForAll.html
@@ -1891,7 +1891,7 @@
                                                 <span class="glyphicon glyphicon-trash glyphicon-primary">
                                                 </span>
                                              </a>
-                                             <input name="responseid" type="hidden" value="{*}"/>
+                                             <input name="responseid" type="hidden" value="{*}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt"/>
                                                                                           <input name="responsecommentid" type="hidden" value="{*}"/>
                                                                                           <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                           <input name="fsname" type="hidden" value="comments.First feedback session"/>
@@ -1979,7 +1979,7 @@
                                              <input class="btn btn-default" onclick="return hideResponseCommentEditForm(1,1,1,1);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="responsecommentid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>
@@ -2061,7 +2061,7 @@
                                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,1);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="questionid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>
@@ -2128,7 +2128,7 @@ Multiline test.
                                                 <span class="glyphicon glyphicon-trash glyphicon-primary">
                                                 </span>
                                              </a>
-                                             <input name="responseid" type="hidden" value="{*}"/>
+                                             <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                           <input name="responsecommentid" type="hidden" value="{*}"/>
                                                                                           <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                           <input name="fsname" type="hidden" value="comments.First feedback session"/>
@@ -2255,7 +2255,7 @@ Multiline test.
                                              <input class="btn btn-default" onclick="return hideResponseCommentEditForm(1,2,1,1);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="responsecommentid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>
@@ -2275,7 +2275,7 @@ Multiline test.
                                                 <span class="glyphicon glyphicon-trash glyphicon-primary">
                                                 </span>
                                              </a>
-                                             <input name="responseid" type="hidden" value="{*}"/>
+                                             <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                           <input name="responsecommentid" type="hidden" value="{*}"/>
                                                                                           <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                           <input name="fsname" type="hidden" value="comments.First feedback session"/>
@@ -2402,7 +2402,7 @@ Multiline test.
                                              <input class="btn btn-default" onclick="return hideResponseCommentEditForm(1,2,1,2);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="responsecommentid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>
@@ -2422,7 +2422,7 @@ Multiline test.
                                                 <span class="glyphicon glyphicon-trash glyphicon-primary">
                                                 </span>
                                              </a>
-                                             <input name="responseid" type="hidden" value="{*}"/>
+                                             <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                           <input name="responsecommentid" type="hidden" value="{*}"/>
                                                                                           <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                           <input name="fsname" type="hidden" value="comments.First feedback session"/>
@@ -2549,7 +2549,7 @@ Multiline test.
                                              <input class="btn btn-default" onclick="return hideResponseCommentEditForm(1,2,1,3);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="responsecommentid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>
@@ -2670,7 +2670,7 @@ Multiline test.
                                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,2,1);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="questionid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>

--- a/src/test/resources/pages/instructorCommentsPageShowCommentsForPrivate.html
+++ b/src/test/resources/pages/instructorCommentsPageShowCommentsForPrivate.html
@@ -1891,7 +1891,7 @@
                                                 <span class="glyphicon glyphicon-trash glyphicon-primary">
                                                 </span>
                                              </a>
-                                             <input name="responseid" type="hidden" value="{*}"/>
+                                             <input name="responseid" type="hidden" value="{*}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt"/>
                                                                                           <input name="responsecommentid" type="hidden" value="{*}"/>
                                                                                           <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                           <input name="fsname" type="hidden" value="comments.First feedback session"/>
@@ -1979,7 +1979,7 @@
                                              <input class="btn btn-default" onclick="return hideResponseCommentEditForm(1,1,1,1);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="responsecommentid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>
@@ -2061,7 +2061,7 @@
                                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,1);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="questionid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>
@@ -2128,7 +2128,7 @@ Multiline test.
                                                 <span class="glyphicon glyphicon-trash glyphicon-primary">
                                                 </span>
                                              </a>
-                                             <input name="responseid" type="hidden" value="{*}"/>
+                                             <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                           <input name="responsecommentid" type="hidden" value="{*}"/>
                                                                                           <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                           <input name="fsname" type="hidden" value="comments.First feedback session"/>
@@ -2255,7 +2255,7 @@ Multiline test.
                                              <input class="btn btn-default" onclick="return hideResponseCommentEditForm(1,2,1,1);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="responsecommentid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>
@@ -2275,7 +2275,7 @@ Multiline test.
                                                 <span class="glyphicon glyphicon-trash glyphicon-primary">
                                                 </span>
                                              </a>
-                                             <input name="responseid" type="hidden" value="{*}"/>
+                                             <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                           <input name="responsecommentid" type="hidden" value="{*}"/>
                                                                                           <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                           <input name="fsname" type="hidden" value="comments.First feedback session"/>
@@ -2402,7 +2402,7 @@ Multiline test.
                                              <input class="btn btn-default" onclick="return hideResponseCommentEditForm(1,2,1,2);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="responsecommentid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>
@@ -2422,7 +2422,7 @@ Multiline test.
                                                 <span class="glyphicon glyphicon-trash glyphicon-primary">
                                                 </span>
                                              </a>
-                                             <input name="responseid" type="hidden" value="{*}"/>
+                                             <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                           <input name="responsecommentid" type="hidden" value="{*}"/>
                                                                                           <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                           <input name="fsname" type="hidden" value="comments.First feedback session"/>
@@ -2549,7 +2549,7 @@ Multiline test.
                                              <input class="btn btn-default" onclick="return hideResponseCommentEditForm(1,2,1,3);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="responsecommentid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>
@@ -2670,7 +2670,7 @@ Multiline test.
                                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,2,1);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="questionid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>

--- a/src/test/resources/pages/instructorCommentsPageShowCommentsForPublic.html
+++ b/src/test/resources/pages/instructorCommentsPageShowCommentsForPublic.html
@@ -1891,7 +1891,7 @@
                                                 <span class="glyphicon glyphicon-trash glyphicon-primary">
                                                 </span>
                                              </a>
-                                             <input name="responseid" type="hidden" value="{*}"/>
+                                             <input name="responseid" type="hidden" value="{*}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt"/>
                                                                                           <input name="responsecommentid" type="hidden" value="{*}"/>
                                                                                           <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                           <input name="fsname" type="hidden" value="comments.First feedback session"/>
@@ -1979,7 +1979,7 @@
                                              <input class="btn btn-default" onclick="return hideResponseCommentEditForm(1,1,1,1);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="responsecommentid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>
@@ -2061,7 +2061,7 @@
                                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,1);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="questionid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>
@@ -2128,7 +2128,7 @@ Multiline test.
                                                 <span class="glyphicon glyphicon-trash glyphicon-primary">
                                                 </span>
                                              </a>
-                                             <input name="responseid" type="hidden" value="{*}"/>
+                                             <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                           <input name="responsecommentid" type="hidden" value="{*}"/>
                                                                                           <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                           <input name="fsname" type="hidden" value="comments.First feedback session"/>
@@ -2255,7 +2255,7 @@ Multiline test.
                                              <input class="btn btn-default" onclick="return hideResponseCommentEditForm(1,2,1,1);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="responsecommentid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>
@@ -2275,7 +2275,7 @@ Multiline test.
                                                 <span class="glyphicon glyphicon-trash glyphicon-primary">
                                                 </span>
                                              </a>
-                                             <input name="responseid" type="hidden" value="{*}"/>
+                                             <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                           <input name="responsecommentid" type="hidden" value="{*}"/>
                                                                                           <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                           <input name="fsname" type="hidden" value="comments.First feedback session"/>
@@ -2402,7 +2402,7 @@ Multiline test.
                                              <input class="btn btn-default" onclick="return hideResponseCommentEditForm(1,2,1,2);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="responsecommentid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>
@@ -2422,7 +2422,7 @@ Multiline test.
                                                 <span class="glyphicon glyphicon-trash glyphicon-primary">
                                                 </span>
                                              </a>
-                                             <input name="responseid" type="hidden" value="{*}"/>
+                                             <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                           <input name="responsecommentid" type="hidden" value="{*}"/>
                                                                                           <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                           <input name="fsname" type="hidden" value="comments.First feedback session"/>
@@ -2549,7 +2549,7 @@ Multiline test.
                                              <input class="btn btn-default" onclick="return hideResponseCommentEditForm(1,2,1,3);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="responsecommentid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>
@@ -2670,7 +2670,7 @@ Multiline test.
                                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,2,1);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="questionid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>

--- a/src/test/resources/pages/instructorCommentsPageShowCommentsForSessionCommentPanel.html
+++ b/src/test/resources/pages/instructorCommentsPageShowCommentsForSessionCommentPanel.html
@@ -1891,7 +1891,7 @@
                                                 <span class="glyphicon glyphicon-trash glyphicon-primary">
                                                 </span>
                                              </a>
-                                             <input name="responseid" type="hidden" value="{*}"/>
+                                             <input name="responseid" type="hidden" value="{*}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt"/>
                                                                                           <input name="responsecommentid" type="hidden" value="{*}"/>
                                                                                           <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                           <input name="fsname" type="hidden" value="comments.First feedback session"/>
@@ -1979,7 +1979,7 @@
                                              <input class="btn btn-default" onclick="return hideResponseCommentEditForm(1,1,1,1);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="responsecommentid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>
@@ -2061,7 +2061,7 @@
                                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,1);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="questionid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>
@@ -2128,7 +2128,7 @@ Multiline test.
                                                 <span class="glyphicon glyphicon-trash glyphicon-primary">
                                                 </span>
                                              </a>
-                                             <input name="responseid" type="hidden" value="{*}"/>
+                                             <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                           <input name="responsecommentid" type="hidden" value="{*}"/>
                                                                                           <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                           <input name="fsname" type="hidden" value="comments.First feedback session"/>
@@ -2255,7 +2255,7 @@ Multiline test.
                                              <input class="btn btn-default" onclick="return hideResponseCommentEditForm(1,2,1,1);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="responsecommentid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>
@@ -2275,7 +2275,7 @@ Multiline test.
                                                 <span class="glyphicon glyphicon-trash glyphicon-primary">
                                                 </span>
                                              </a>
-                                             <input name="responseid" type="hidden" value="{*}"/>
+                                             <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                           <input name="responsecommentid" type="hidden" value="{*}"/>
                                                                                           <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                           <input name="fsname" type="hidden" value="comments.First feedback session"/>
@@ -2402,7 +2402,7 @@ Multiline test.
                                              <input class="btn btn-default" onclick="return hideResponseCommentEditForm(1,2,1,2);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="responsecommentid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>
@@ -2422,7 +2422,7 @@ Multiline test.
                                                 <span class="glyphicon glyphicon-trash glyphicon-primary">
                                                 </span>
                                              </a>
-                                             <input name="responseid" type="hidden" value="{*}"/>
+                                             <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                           <input name="responsecommentid" type="hidden" value="{*}"/>
                                                                                           <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                           <input name="fsname" type="hidden" value="comments.First feedback session"/>
@@ -2549,7 +2549,7 @@ Multiline test.
                                              <input class="btn btn-default" onclick="return hideResponseCommentEditForm(1,2,1,3);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="responsecommentid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>
@@ -2670,7 +2670,7 @@ Multiline test.
                                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,2,1);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="questionid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>

--- a/src/test/resources/pages/instructorCommentsPageShowCommentsForStudentCommentPanel.html
+++ b/src/test/resources/pages/instructorCommentsPageShowCommentsForStudentCommentPanel.html
@@ -1891,7 +1891,7 @@
                                                 <span class="glyphicon glyphicon-trash glyphicon-primary">
                                                 </span>
                                              </a>
-                                             <input name="responseid" type="hidden" value="{*}"/>
+                                             <input name="responseid" type="hidden" value="{*}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt"/>
                                                                                           <input name="responsecommentid" type="hidden" value="{*}"/>
                                                                                           <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                           <input name="fsname" type="hidden" value="comments.First feedback session"/>
@@ -1979,7 +1979,7 @@
                                              <input class="btn btn-default" onclick="return hideResponseCommentEditForm(1,1,1,1);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="responsecommentid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>
@@ -2061,7 +2061,7 @@
                                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,1);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="questionid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>
@@ -2128,7 +2128,7 @@ Multiline test.
                                                 <span class="glyphicon glyphicon-trash glyphicon-primary">
                                                 </span>
                                              </a>
-                                             <input name="responseid" type="hidden" value="{*}"/>
+                                             <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                           <input name="responsecommentid" type="hidden" value="{*}"/>
                                                                                           <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                           <input name="fsname" type="hidden" value="comments.First feedback session"/>
@@ -2255,7 +2255,7 @@ Multiline test.
                                              <input class="btn btn-default" onclick="return hideResponseCommentEditForm(1,2,1,1);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="responsecommentid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>
@@ -2275,7 +2275,7 @@ Multiline test.
                                                 <span class="glyphicon glyphicon-trash glyphicon-primary">
                                                 </span>
                                              </a>
-                                             <input name="responseid" type="hidden" value="{*}"/>
+                                             <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                           <input name="responsecommentid" type="hidden" value="{*}"/>
                                                                                           <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                           <input name="fsname" type="hidden" value="comments.First feedback session"/>
@@ -2402,7 +2402,7 @@ Multiline test.
                                              <input class="btn btn-default" onclick="return hideResponseCommentEditForm(1,2,1,2);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="responsecommentid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>
@@ -2422,7 +2422,7 @@ Multiline test.
                                                 <span class="glyphicon glyphicon-trash glyphicon-primary">
                                                 </span>
                                              </a>
-                                             <input name="responseid" type="hidden" value="{*}"/>
+                                             <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                           <input name="responsecommentid" type="hidden" value="{*}"/>
                                                                                           <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                           <input name="fsname" type="hidden" value="comments.First feedback session"/>
@@ -2549,7 +2549,7 @@ Multiline test.
                                              <input class="btn btn-default" onclick="return hideResponseCommentEditForm(1,2,1,3);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="responsecommentid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>
@@ -2670,7 +2670,7 @@ Multiline test.
                                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,2,1);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="questionid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>

--- a/src/test/resources/pages/instructorCommentsPageShowCommentsFromAll.html
+++ b/src/test/resources/pages/instructorCommentsPageShowCommentsFromAll.html
@@ -1891,7 +1891,7 @@
                                                 <span class="glyphicon glyphicon-trash glyphicon-primary">
                                                 </span>
                                              </a>
-                                             <input name="responseid" type="hidden" value="{*}"/>
+                                             <input name="responseid" type="hidden" value="{*}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt"/>
                                                                                           <input name="responsecommentid" type="hidden" value="{*}"/>
                                                                                           <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                           <input name="fsname" type="hidden" value="comments.First feedback session"/>
@@ -1979,7 +1979,7 @@
                                              <input class="btn btn-default" onclick="return hideResponseCommentEditForm(1,1,1,1);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="responsecommentid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>
@@ -2061,7 +2061,7 @@
                                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,1);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="questionid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>
@@ -2128,7 +2128,7 @@ Multiline test.
                                                 <span class="glyphicon glyphicon-trash glyphicon-primary">
                                                 </span>
                                              </a>
-                                             <input name="responseid" type="hidden" value="{*}"/>
+                                             <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                           <input name="responsecommentid" type="hidden" value="{*}"/>
                                                                                           <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                           <input name="fsname" type="hidden" value="comments.First feedback session"/>
@@ -2255,7 +2255,7 @@ Multiline test.
                                              <input class="btn btn-default" onclick="return hideResponseCommentEditForm(1,2,1,1);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="responsecommentid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>
@@ -2275,7 +2275,7 @@ Multiline test.
                                                 <span class="glyphicon glyphicon-trash glyphicon-primary">
                                                 </span>
                                              </a>
-                                             <input name="responseid" type="hidden" value="{*}"/>
+                                             <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                           <input name="responsecommentid" type="hidden" value="{*}"/>
                                                                                           <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                           <input name="fsname" type="hidden" value="comments.First feedback session"/>
@@ -2402,7 +2402,7 @@ Multiline test.
                                              <input class="btn btn-default" onclick="return hideResponseCommentEditForm(1,2,1,2);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="responsecommentid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>
@@ -2422,7 +2422,7 @@ Multiline test.
                                                 <span class="glyphicon glyphicon-trash glyphicon-primary">
                                                 </span>
                                              </a>
-                                             <input name="responseid" type="hidden" value="{*}"/>
+                                             <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                           <input name="responsecommentid" type="hidden" value="{*}"/>
                                                                                           <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                           <input name="fsname" type="hidden" value="comments.First feedback session"/>
@@ -2549,7 +2549,7 @@ Multiline test.
                                              <input class="btn btn-default" onclick="return hideResponseCommentEditForm(1,2,1,3);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="responsecommentid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>
@@ -2670,7 +2670,7 @@ Multiline test.
                                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,2,1);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="questionid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>

--- a/src/test/resources/pages/instructorCommentsPageShowCommentsFromAllStatus.html
+++ b/src/test/resources/pages/instructorCommentsPageShowCommentsFromAllStatus.html
@@ -1891,7 +1891,7 @@
                                                 <span class="glyphicon glyphicon-trash glyphicon-primary">
                                                 </span>
                                              </a>
-                                             <input name="responseid" type="hidden" value="{*}"/>
+                                             <input name="responseid" type="hidden" value="{*}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt"/>
                                                                                           <input name="responsecommentid" type="hidden" value="{*}"/>
                                                                                           <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                           <input name="fsname" type="hidden" value="comments.First feedback session"/>
@@ -1979,7 +1979,7 @@
                                              <input class="btn btn-default" onclick="return hideResponseCommentEditForm(1,1,1,1);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="responsecommentid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>
@@ -2061,7 +2061,7 @@
                                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,1);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="questionid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>
@@ -2128,7 +2128,7 @@ Multiline test.
                                                 <span class="glyphicon glyphicon-trash glyphicon-primary">
                                                 </span>
                                              </a>
-                                             <input name="responseid" type="hidden" value="{*}"/>
+                                             <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                           <input name="responsecommentid" type="hidden" value="{*}"/>
                                                                                           <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                           <input name="fsname" type="hidden" value="comments.First feedback session"/>
@@ -2255,7 +2255,7 @@ Multiline test.
                                              <input class="btn btn-default" onclick="return hideResponseCommentEditForm(1,2,1,1);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="responsecommentid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>
@@ -2275,7 +2275,7 @@ Multiline test.
                                                 <span class="glyphicon glyphicon-trash glyphicon-primary">
                                                 </span>
                                              </a>
-                                             <input name="responseid" type="hidden" value="{*}"/>
+                                             <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                           <input name="responsecommentid" type="hidden" value="{*}"/>
                                                                                           <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                           <input name="fsname" type="hidden" value="comments.First feedback session"/>
@@ -2402,7 +2402,7 @@ Multiline test.
                                              <input class="btn btn-default" onclick="return hideResponseCommentEditForm(1,2,1,2);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="responsecommentid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>
@@ -2422,7 +2422,7 @@ Multiline test.
                                                 <span class="glyphicon glyphicon-trash glyphicon-primary">
                                                 </span>
                                              </a>
-                                             <input name="responseid" type="hidden" value="{*}"/>
+                                             <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                           <input name="responsecommentid" type="hidden" value="{*}"/>
                                                                                           <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                           <input name="fsname" type="hidden" value="comments.First feedback session"/>
@@ -2549,7 +2549,7 @@ Multiline test.
                                              <input class="btn btn-default" onclick="return hideResponseCommentEditForm(1,2,1,3);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="responsecommentid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>
@@ -2670,7 +2670,7 @@ Multiline test.
                                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,2,1);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="questionid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>

--- a/src/test/resources/pages/instructorCommentsPageShowCommentsFromOthers.html
+++ b/src/test/resources/pages/instructorCommentsPageShowCommentsFromOthers.html
@@ -1891,7 +1891,7 @@
                                                 <span class="glyphicon glyphicon-trash glyphicon-primary">
                                                 </span>
                                              </a>
-                                             <input name="responseid" type="hidden" value="{*}"/>
+                                             <input name="responseid" type="hidden" value="{*}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt"/>
                                                                                           <input name="responsecommentid" type="hidden" value="{*}"/>
                                                                                           <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                           <input name="fsname" type="hidden" value="comments.First feedback session"/>
@@ -1979,7 +1979,7 @@
                                              <input class="btn btn-default" onclick="return hideResponseCommentEditForm(1,1,1,1);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="responsecommentid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>
@@ -2061,7 +2061,7 @@
                                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,1);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="questionid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>
@@ -2128,7 +2128,7 @@ Multiline test.
                                                 <span class="glyphicon glyphicon-trash glyphicon-primary">
                                                 </span>
                                              </a>
-                                             <input name="responseid" type="hidden" value="{*}"/>
+                                             <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                           <input name="responsecommentid" type="hidden" value="{*}"/>
                                                                                           <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                           <input name="fsname" type="hidden" value="comments.First feedback session"/>
@@ -2255,7 +2255,7 @@ Multiline test.
                                              <input class="btn btn-default" onclick="return hideResponseCommentEditForm(1,2,1,1);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="responsecommentid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>
@@ -2275,7 +2275,7 @@ Multiline test.
                                                 <span class="glyphicon glyphicon-trash glyphicon-primary">
                                                 </span>
                                              </a>
-                                             <input name="responseid" type="hidden" value="{*}"/>
+                                             <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                           <input name="responsecommentid" type="hidden" value="{*}"/>
                                                                                           <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                           <input name="fsname" type="hidden" value="comments.First feedback session"/>
@@ -2402,7 +2402,7 @@ Multiline test.
                                              <input class="btn btn-default" onclick="return hideResponseCommentEditForm(1,2,1,2);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="responsecommentid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>
@@ -2422,7 +2422,7 @@ Multiline test.
                                                 <span class="glyphicon glyphicon-trash glyphicon-primary">
                                                 </span>
                                              </a>
-                                             <input name="responseid" type="hidden" value="{*}"/>
+                                             <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                           <input name="responsecommentid" type="hidden" value="{*}"/>
                                                                                           <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                           <input name="fsname" type="hidden" value="comments.First feedback session"/>
@@ -2549,7 +2549,7 @@ Multiline test.
                                              <input class="btn btn-default" onclick="return hideResponseCommentEditForm(1,2,1,3);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="responsecommentid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>
@@ -2670,7 +2670,7 @@ Multiline test.
                                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,2,1);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="questionid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>

--- a/src/test/resources/pages/instructorCommentsPageShowCommentsFromYou.html
+++ b/src/test/resources/pages/instructorCommentsPageShowCommentsFromYou.html
@@ -1891,7 +1891,7 @@
                                                 <span class="glyphicon glyphicon-trash glyphicon-primary">
                                                 </span>
                                              </a>
-                                             <input name="responseid" type="hidden" value="{*}"/>
+                                             <input name="responseid" type="hidden" value="{*}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt"/>
                                                                                           <input name="responsecommentid" type="hidden" value="{*}"/>
                                                                                           <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                           <input name="fsname" type="hidden" value="comments.First feedback session"/>
@@ -1979,7 +1979,7 @@
                                              <input class="btn btn-default" onclick="return hideResponseCommentEditForm(1,1,1,1);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="responsecommentid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>
@@ -2061,7 +2061,7 @@
                                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,1);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="questionid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student1InCourse1@gmail.tmt%comments.student1InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>
@@ -2128,7 +2128,7 @@ Multiline test.
                                                 <span class="glyphicon glyphicon-trash glyphicon-primary">
                                                 </span>
                                              </a>
-                                             <input name="responseid" type="hidden" value="{*}"/>
+                                             <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                           <input name="responsecommentid" type="hidden" value="{*}"/>
                                                                                           <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                           <input name="fsname" type="hidden" value="comments.First feedback session"/>
@@ -2255,7 +2255,7 @@ Multiline test.
                                              <input class="btn btn-default" onclick="return hideResponseCommentEditForm(1,2,1,1);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="responsecommentid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>
@@ -2275,7 +2275,7 @@ Multiline test.
                                                 <span class="glyphicon glyphicon-trash glyphicon-primary">
                                                 </span>
                                              </a>
-                                             <input name="responseid" type="hidden" value="{*}"/>
+                                             <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                           <input name="responsecommentid" type="hidden" value="{*}"/>
                                                                                           <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                           <input name="fsname" type="hidden" value="comments.First feedback session"/>
@@ -2402,7 +2402,7 @@ Multiline test.
                                              <input class="btn btn-default" onclick="return hideResponseCommentEditForm(1,2,1,2);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="responsecommentid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>
@@ -2422,7 +2422,7 @@ Multiline test.
                                                 <span class="glyphicon glyphicon-trash glyphicon-primary">
                                                 </span>
                                              </a>
-                                             <input name="responseid" type="hidden" value="{*}"/>
+                                             <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                           <input name="responsecommentid" type="hidden" value="{*}"/>
                                                                                           <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                           <input name="fsname" type="hidden" value="comments.First feedback session"/>
@@ -2549,7 +2549,7 @@ Multiline test.
                                              <input class="btn btn-default" onclick="return hideResponseCommentEditForm(1,2,1,3);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="responsecommentid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>
@@ -2670,7 +2670,7 @@ Multiline test.
                                              <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,2,1);" type="button" value="Cancel"/>
                                                                                        </div>
                                           <input name="questionid" type="hidden" value="{*}"/>
-                                                                                    <input name="responseid" type="hidden" value="{*}"/>
+                                                                                    <input name="responseid" type="hidden" value="{*}%comments.student3InCourse1@gmail.tmt%comments.student2InCourse1@gmail.tmt"/>
                                                                                     <input name="courseid" type="hidden" value="comments.idOfTypicalCourse1"/>
                                                                                     <input name="fsname" type="hidden" value="comments.First feedback session"/>
                                                                                     <input name="user" type="hidden" value="comments.idOfInstructor1OfCourse1"/>

--- a/src/test/resources/pages/instructorCourseEnrollError.html
+++ b/src/test/resources/pages/instructorCourseEnrollError.html
@@ -37,7 +37,7 @@
 Team 3 | Frank Hughe
 Team 1 | Black Jack | bjack.gmail.tmt | This student email is invalid
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa | Robert Downey | rob@email.tmt | This student team name is too long
-Team 2 | {*} | longname@email.tmt | This student name is too long
+Team 2 | aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa | longname@email.tmt | This student name is too long
                         </textarea>
                         <br/>
                                                 <div class="alert alert-danger" id="statusMessage">
@@ -84,7 +84,7 @@ Team 2 | {*} | longname@email.tmt | This student name is too long
                               <span class="bold">
                                  Problem in line :
                                  <span class="invalidLine">
-                                    Team 2 | {*} | longname@email.tmt | This student name is too long
+                                    Team 2 | aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa | longname@email.tmt | This student name is too long
                                  </span>
                               </span>
                               <br/>

--- a/src/test/resources/pages/instructorFeedbackResultsAddComment.html
+++ b/src/test/resources/pages/instructorFeedbackResultsAddComment.html
@@ -818,7 +818,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,1);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="First Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -970,7 +970,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,2);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="First Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1129,7 +1129,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,3);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="First Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1269,7 +1269,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,4);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="First Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1409,7 +1409,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,5);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="First Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1582,7 +1582,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,2,1);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%drop.out@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="First Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1780,7 +1780,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,1,1);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="First Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1962,7 +1962,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,2,1);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="First Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -2135,7 +2135,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,3,1);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%drop.out@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="First Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -2354,7 +2354,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,1,1);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.charlie.d@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="First Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -2552,7 +2552,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(4,1,1);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.danny.e@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="First Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -2725,7 +2725,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(4,2,1);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%drop.out@gmail.tmt%CFResultsUiT.danny.e@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="First Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -2923,7 +2923,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(5,1,1);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%drop.out@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="First Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -3106,7 +3106,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(5,2,1);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%drop.out@gmail.tmt%drop.out@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="First Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -3246,7 +3246,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(5,2,2);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%drop.out@gmail.tmt%drop.out@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="First Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -3683,7 +3683,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(7,1,1);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%CFResultsUiT.charlie.d@gmail.tmt%CFResultsUiT.emily.f@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="First Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>

--- a/src/test/resources/pages/instructorFeedbackResultsAjaxByGRQ.html
+++ b/src/test/resources/pages/instructorFeedbackResultsAjaxByGRQ.html
@@ -449,7 +449,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,0,1);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -601,7 +601,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,0,2);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -760,7 +760,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,0,3);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -900,7 +900,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,0,4);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1040,7 +1040,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,0,5);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1205,7 +1205,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,0,1);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1370,7 +1370,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,0,1);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%drop.out@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1575,7 +1575,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,1);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1740,7 +1740,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,1,1);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.charlie.d@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1905,7 +1905,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,1,1);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.danny.e@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -2101,7 +2101,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,3,1);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%CFResultsUiT.charlie.d@gmail.tmt%CFResultsUiT.emily.f@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -2297,7 +2297,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,4,1);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%drop.out@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -2462,7 +2462,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,4,1);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%drop.out@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -2627,7 +2627,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,4,1);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%drop.out@gmail.tmt%CFResultsUiT.danny.e@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -2802,7 +2802,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(4,4,1);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%drop.out@gmail.tmt%drop.out@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -2942,7 +2942,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(4,4,2);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%drop.out@gmail.tmt%drop.out@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>

--- a/src/test/resources/pages/instructorFeedbackResultsAjaxByRGQ.html
+++ b/src/test/resources/pages/instructorFeedbackResultsAjaxByRGQ.html
@@ -451,7 +451,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,1);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -603,7 +603,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,2);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -762,7 +762,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,3);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -902,7 +902,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,4);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1042,7 +1042,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,5);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1215,7 +1215,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,2,1);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%drop.out@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1413,7 +1413,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,1);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1595,7 +1595,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,2,1);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1768,7 +1768,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,3,1);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%drop.out@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1966,7 +1966,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,1,1);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.charlie.d@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -2164,7 +2164,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,1,1);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.danny.e@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -2337,7 +2337,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,2,1);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%drop.out@gmail.tmt%CFResultsUiT.danny.e@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -2535,7 +2535,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(4,1,1);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%drop.out@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -2718,7 +2718,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(4,2,1);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%drop.out@gmail.tmt%drop.out@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -2858,7 +2858,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(4,2,2);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%drop.out@gmail.tmt%drop.out@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>

--- a/src/test/resources/pages/instructorFeedbackResultsDeleteComment.html
+++ b/src/test/resources/pages/instructorFeedbackResultsDeleteComment.html
@@ -635,7 +635,7 @@
                                                             <span class="glyphicon glyphicon-trash glyphicon-primary">
                                                             </span>
                                                          </a>
-                                                         <input name="responseid" type="hidden" value="{*}"/>
+                                                         <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                                                   <input name="responsecommentid" type="hidden" value="{*}"/>
                                                                                                                   <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                                   <input name="fsname" type="hidden" value="First Session"/>
@@ -749,7 +749,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentEditForm(1,1,1,1);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="responsecommentid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="First Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -857,7 +857,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,1);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="First Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1009,7 +1009,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,2);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="First Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1168,7 +1168,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,3);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="First Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1308,7 +1308,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,4);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="First Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1448,7 +1448,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,5);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="First Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1621,7 +1621,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,2,1);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%drop.out@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="First Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1819,7 +1819,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,1,1);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="First Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -2001,7 +2001,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,2,1);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="First Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -2174,7 +2174,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,3,1);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%drop.out@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="First Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -2393,7 +2393,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,1,1);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.charlie.d@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="First Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -2591,7 +2591,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(4,1,1);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.danny.e@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="First Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -2764,7 +2764,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(4,2,1);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%drop.out@gmail.tmt%CFResultsUiT.danny.e@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="First Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -2962,7 +2962,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(5,1,1);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%drop.out@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="First Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -3145,7 +3145,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(5,2,1);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%drop.out@gmail.tmt%drop.out@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="First Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -3285,7 +3285,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(5,2,2);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%drop.out@gmail.tmt%drop.out@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="First Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -3722,7 +3722,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(7,1,1);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%CFResultsUiT.charlie.d@gmail.tmt%CFResultsUiT.emily.f@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="First Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>

--- a/src/test/resources/pages/instructorFeedbackResultsPageRubricGRQView.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageRubricGRQView.html
@@ -424,7 +424,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,0,1);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%alice.b.tmms@gmail.tmt%benny.c.tmms@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="FRubricQnUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="Second Session"/>
                                                                                           <input name="user" type="hidden" value="FRubricQnUiT.instructor"/>

--- a/src/test/resources/pages/instructorFeedbackResultsPageRubricRGQView.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageRubricRGQView.html
@@ -426,7 +426,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(0,1,1);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%alice.b.tmms@gmail.tmt%benny.c.tmms@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="FRubricQnUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="Second Session"/>
                                                                                           <input name="user" type="hidden" value="FRubricQnUiT.instructor"/>

--- a/src/test/resources/pages/instructorFeedbackResultsSortGiverRecipientQuestion.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortGiverRecipientQuestion.html
@@ -687,7 +687,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,1);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="First Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -839,7 +839,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,2);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="First Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -998,7 +998,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,3);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="First Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1138,7 +1138,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,4);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="First Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1278,7 +1278,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,5);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="First Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1443,7 +1443,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,1,1);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="First Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1608,7 +1608,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,1,1);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%drop.out@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="First Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1813,7 +1813,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,2,1);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="First Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1978,7 +1978,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,2,1);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.charlie.d@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="First Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -2143,7 +2143,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,2,1);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.danny.e@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="First Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -2523,7 +2523,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,4,1);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%CFResultsUiT.charlie.d@gmail.tmt%CFResultsUiT.emily.f@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="First Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -2719,7 +2719,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,5,1);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%drop.out@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="First Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -2884,7 +2884,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,5,1);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%drop.out@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="First Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -3049,7 +3049,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,5,1);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%drop.out@gmail.tmt%CFResultsUiT.danny.e@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="First Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -3224,7 +3224,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(4,5,1);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%drop.out@gmail.tmt%drop.out@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="First Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -3364,7 +3364,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(4,5,2);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%drop.out@gmail.tmt%drop.out@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="First Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>

--- a/src/test/resources/pages/instructorFeedbackResultsSortGiverRecipientQuestionTeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortGiverRecipientQuestionTeam.html
@@ -648,7 +648,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,1);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -800,7 +800,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,2);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -959,7 +959,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,3);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1099,7 +1099,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,4);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1239,7 +1239,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,5);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1404,7 +1404,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,1,1);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1569,7 +1569,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,1,1);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%drop.out@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1774,7 +1774,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,2,1);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1939,7 +1939,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,2,1);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.charlie.d@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -2104,7 +2104,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,2,1);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.danny.e@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -2300,7 +2300,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,4,1);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%CFResultsUiT.charlie.d@gmail.tmt%CFResultsUiT.emily.f@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -2496,7 +2496,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,5,1);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%drop.out@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -2661,7 +2661,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,5,1);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%drop.out@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -2826,7 +2826,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,5,1);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%drop.out@gmail.tmt%CFResultsUiT.danny.e@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -3001,7 +3001,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(4,5,1);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%drop.out@gmail.tmt%drop.out@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -3141,7 +3141,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(4,5,2);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%drop.out@gmail.tmt%drop.out@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>

--- a/src/test/resources/pages/instructorFeedbackResultsSortRecipientGiverQuestion.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortRecipientGiverQuestion.html
@@ -632,7 +632,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,1);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="First Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -784,7 +784,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,2);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="First Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -943,7 +943,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,3);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="First Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1083,7 +1083,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,4);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="First Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1223,7 +1223,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,5);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="First Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1396,7 +1396,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,2,1);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%drop.out@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="First Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1594,7 +1594,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,1,1);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="First Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1776,7 +1776,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,2,1);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="First Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1949,7 +1949,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,3,1);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%drop.out@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="First Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -2168,7 +2168,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,1,1);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.charlie.d@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="First Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -2366,7 +2366,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(4,1,1);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.danny.e@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="First Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -2539,7 +2539,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(4,2,1);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%drop.out@gmail.tmt%CFResultsUiT.danny.e@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="First Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -2737,7 +2737,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(5,1,1);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%drop.out@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="First Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -2920,7 +2920,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(5,2,1);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%drop.out@gmail.tmt%drop.out@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="First Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -3060,7 +3060,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(5,2,2);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%drop.out@gmail.tmt%drop.out@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="First Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -3497,7 +3497,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(7,1,1);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%CFResultsUiT.charlie.d@gmail.tmt%CFResultsUiT.emily.f@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="First Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>

--- a/src/test/resources/pages/instructorFeedbackResultsSortRecipientGiverQuestionTeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortRecipientGiverQuestionTeam.html
@@ -593,7 +593,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,1);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -745,7 +745,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,2);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -904,7 +904,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,3);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1044,7 +1044,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,4);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1184,7 +1184,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,5);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1357,7 +1357,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,2,1);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%drop.out@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1555,7 +1555,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,1,1);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1737,7 +1737,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,2,1);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1910,7 +1910,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,3,1);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%drop.out@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -2108,7 +2108,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,1,1);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.charlie.d@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -2306,7 +2306,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(4,1,1);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%CFResultsUiT.benny.c@gmail.tmt%CFResultsUiT.danny.e@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -2479,7 +2479,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(4,2,1);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%drop.out@gmail.tmt%CFResultsUiT.danny.e@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -2677,7 +2677,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(5,1,1);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%drop.out@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -2860,7 +2860,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(5,2,1);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%drop.out@gmail.tmt%drop.out@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -3000,7 +3000,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(5,2,2);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%drop.out@gmail.tmt%drop.out@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -3416,7 +3416,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(7,1,1);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%CFResultsUiT.charlie.d@gmail.tmt%CFResultsUiT.emily.f@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="First Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionGiverRecipientQuestion.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionGiverRecipientQuestion.html
@@ -641,7 +641,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,1);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="Second Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -788,7 +788,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,2);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="Second Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -902,7 +902,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,3);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="Second Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1030,7 +1030,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,4);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="Second Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1157,7 +1157,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,5);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="Second Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1317,7 +1317,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,6);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="Second Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1451,7 +1451,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,1,1);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="Second Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1604,7 +1604,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,1,2);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="Second Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1738,7 +1738,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,1,1);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="Second Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1891,7 +1891,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,1,2);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="Second Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -2041,7 +2041,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(4,1,1);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="Second Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -2194,7 +2194,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(4,1,2);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="Second Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -2344,7 +2344,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(5,1,1);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.charlie.d@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="Second Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -2494,7 +2494,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(6,1,1);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.danny.e@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="Second Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionGiverRecipientQuestionTeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionGiverRecipientQuestionTeam.html
@@ -447,7 +447,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,1);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="Second Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -594,7 +594,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,2);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="Second Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -708,7 +708,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,3);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="Second Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -836,7 +836,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,4);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="Second Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -963,7 +963,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,5);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="Second Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1123,7 +1123,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,6);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="Second Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1257,7 +1257,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,1,1);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="Second Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1410,7 +1410,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,1,2);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="Second Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1544,7 +1544,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,1,1);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="Second Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1697,7 +1697,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,1,2);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="Second Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1847,7 +1847,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(4,1,1);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="Second Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -2000,7 +2000,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(4,1,2);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="Second Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -2150,7 +2150,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(5,1,1);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.charlie.d@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="Second Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -2300,7 +2300,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(6,1,1);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.danny.e@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="Second Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionRecipientGiverQuestion.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionRecipientGiverQuestion.html
@@ -789,7 +789,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,1);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="Second Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -942,7 +942,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,2);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="Second Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1129,7 +1129,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,1,1);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="Second Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1282,7 +1282,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,1,2);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="Second Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1503,7 +1503,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,1,1);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="Second Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1650,7 +1650,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,1,2);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="Second Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1764,7 +1764,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,1,3);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="Second Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1892,7 +1892,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,1,4);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="Second Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -2019,7 +2019,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,1,5);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="Second Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -2179,7 +2179,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,1,6);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="Second Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -2362,7 +2362,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(4,1,1);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="Second Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -2515,7 +2515,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(4,1,2);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="Second Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -2871,7 +2871,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(6,1,1);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.charlie.d@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="Second Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -3054,7 +3054,7 @@
                                                          <input class="btn btn-default" onclick="return hideResponseCommentAddForm(7,1,1);" type="button" value="Cancel"/>
                                                                                                                </div>
                                                       <input name="questionid" type="hidden" value="{*}"/>
-                                                                                                            <input name="responseid" type="hidden" value="{*}"/>
+                                                                                                            <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.danny.e@gmail.tmt"/>
                                                                                                             <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                                             <input name="fsname" type="hidden" value="Second Session"/>
                                                                                                             <input name="user" type="hidden" value="CFResultsUiT.instr"/>

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionRecipientGiverQuestionTeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionRecipientGiverQuestionTeam.html
@@ -784,7 +784,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,1,1);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="Second Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -931,7 +931,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,1,2);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="Second Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1045,7 +1045,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,1,3);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="Second Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1173,7 +1173,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,1,4);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="Second Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1300,7 +1300,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,1,5);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="Second Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1460,7 +1460,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(3,1,6);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="Second Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1626,7 +1626,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,1);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="Second Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1779,7 +1779,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(1,1,2);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.alice.b@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="Second Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -1945,7 +1945,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,1,1);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="Second Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -2098,7 +2098,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(2,1,2);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="Second Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -2281,7 +2281,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(4,1,1);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="Second Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -2434,7 +2434,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(4,1,2);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.benny.c@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="Second Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -2617,7 +2617,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(6,1,1);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.charlie.d@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="Second Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>
@@ -2800,7 +2800,7 @@
                                                 <input class="btn btn-default" onclick="return hideResponseCommentAddForm(7,1,1);" type="button" value="Cancel"/>
                                                                                              </div>
                                              <input name="questionid" type="hidden" value="{*}"/>
-                                                                                          <input name="responseid" type="hidden" value="{*}"/>
+                                                                                          <input name="responseid" type="hidden" value="{*}%CFResultsUiT.alice.b@gmail.tmt%CFResultsUiT.danny.e@gmail.tmt"/>
                                                                                           <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
                                                                                           <input name="fsname" type="hidden" value="Second Session"/>
                                                                                           <input name="user" type="hidden" value="CFResultsUiT.instr"/>

--- a/src/test/resources/pages/instructorFeedbackSubmitPageFullyFilled.html
+++ b/src/test/resources/pages/instructorFeedbackSubmitPageFullyFilled.html
@@ -115,7 +115,7 @@
                         <textarea class="form-control" cols="100%" name="responsetext-1-0" rows="4">
                            Test Self Feedback
                         </textarea>
-                        <input name="responseid-1-0" type="hidden" value="{*}"/>
+                        <input name="responseid-1-0" type="hidden" value="{*}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt"/>
                                              </div>
                   </div>
                </div>
@@ -183,7 +183,7 @@
                         <textarea class="form-control" cols="100%" name="responsetext-2-0" rows="4">
                            Edited response to Alice.
                         </textarea>
-                        <input name="responseid-2-0" type="hidden" value="{*}"/>
+                        <input name="responseid-2-0" type="hidden" value="{*}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.alice.b@gmail.tmt"/>
                                              </div>
                   </div>
                   <br/>
@@ -222,7 +222,7 @@
                         <textarea class="form-control" cols="100%" name="responsetext-2-1" rows="4">
                            Response to student who is going to drop out.
                         </textarea>
-                        <input name="responseid-2-1" type="hidden" value="{*}"/>
+                        <input name="responseid-2-1" type="hidden" value="{*}%IFSubmitUiT.instr@gmail.tmt%drop.out@gmail.tmt"/>
                                              </div>
                   </div>
                   <br/>
@@ -261,7 +261,7 @@
                         <textarea class="form-control" cols="100%" name="responsetext-2-2" rows="4">
                            Response to extra guy.
                         </textarea>
-                        <input name="responseid-2-2" type="hidden" value="{*}"/>
+                        <input name="responseid-2-2" type="hidden" value="{*}%IFSubmitUiT.instr@gmail.tmt%extra.guy@gmail.tmt"/>
                                              </div>
                   </div>
                </div>
@@ -370,7 +370,7 @@
                         <textarea class="form-control" cols="100%" name="responsetext-4-0" rows="4">
                            Feedback to instructor 2.
                         </textarea>
-                        <input name="responseid-4-0" type="hidden" value="{*}"/>
+                        <input name="responseid-4-0" type="hidden" value="{*}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr2@gmail.tmt"/>
                                              </div>
                   </div>
                   <br/>
@@ -403,7 +403,7 @@
                         <textarea class="form-control" cols="100%" name="responsetext-4-1" rows="4">
                            Feedback to Instructor 3
                         </textarea>
-                        <input name="responseid-4-1" type="hidden" value="{*}"/>
+                        <input name="responseid-4-1" type="hidden" value="{*}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr3@gmail.tmt"/>
                                              </div>
                   </div>
                   <br/>
@@ -436,7 +436,7 @@
                         <textarea class="form-control" cols="100%" name="responsetext-4-2" rows="4">
                            Feedback to instructor 4.
                         </textarea>
-                        <input name="responseid-4-2" type="hidden" value="{*}"/>
+                        <input name="responseid-4-2" type="hidden" value="{*}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr4@gmail.tmt"/>
                                              </div>
                   </div>
                   <br/>
@@ -469,7 +469,7 @@
                         <textarea class="form-control" cols="100%" name="responsetext-4-3" rows="4">
                            Feedback to instructor 5.
                         </textarea>
-                        <input name="responseid-4-3" type="hidden" value="{*}"/>
+                        <input name="responseid-4-3" type="hidden" value="{*}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr5@gmail.tmt"/>
                                              </div>
                   </div>
                </div>
@@ -539,7 +539,7 @@
                               </tr>
                            </tbody>
                         </table>
-                        <input name="responseid-5-0" type="hidden" value="{*}"/>
+                        <input name="responseid-5-0" type="hidden" value="{*}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt"/>
                                              </div>
                   </div>
                </div>
@@ -612,7 +612,7 @@
                               </tr>
                            </tbody>
                         </table>
-                        <input name="responseid-6-0" type="hidden" value="{*}"/>
+                        <input name="responseid-6-0" type="hidden" value="{*}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr2@gmail.tmt"/>
                                              </div>
                   </div>
                   <br/>
@@ -659,7 +659,7 @@
                               </tr>
                            </tbody>
                         </table>
-                        <input name="responseid-6-1" type="hidden" value="{*}"/>
+                        <input name="responseid-6-1" type="hidden" value="{*}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr3@gmail.tmt"/>
                                              </div>
                   </div>
                   <br/>
@@ -706,7 +706,7 @@
                               </tr>
                            </tbody>
                         </table>
-                        <input name="responseid-6-2" type="hidden" value="{*}"/>
+                        <input name="responseid-6-2" type="hidden" value="{*}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr4@gmail.tmt"/>
                                              </div>
                   </div>
                </div>
@@ -794,7 +794,7 @@
                               </tr>
                            </tbody>
                         </table>
-                        <input name="responseid-7-0" type="hidden" value="{*}"/>
+                        <input name="responseid-7-0" type="hidden" value="{*}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt"/>
                                              </div>
                   </div>
                </div>
@@ -885,7 +885,7 @@
                               </tr>
                            </tbody>
                         </table>
-                        <input name="responseid-8-0" type="hidden" value="{*}"/>
+                        <input name="responseid-8-0" type="hidden" value="{*}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr2@gmail.tmt"/>
                                              </div>
                   </div>
                   <br/>
@@ -950,7 +950,7 @@
                               </tr>
                            </tbody>
                         </table>
-                        <input name="responseid-8-1" type="hidden" value="{*}"/>
+                        <input name="responseid-8-1" type="hidden" value="{*}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr3@gmail.tmt"/>
                                              </div>
                   </div>
                   <br/>
@@ -1015,7 +1015,7 @@
                               </tr>
                            </tbody>
                         </table>
-                        <input name="responseid-8-2" type="hidden" value="{*}"/>
+                        <input name="responseid-8-2" type="hidden" value="{*}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr4@gmail.tmt"/>
                                              </div>
                   </div>
                </div>
@@ -1125,7 +1125,7 @@
                               </tr>
                            </tbody>
                         </table>
-                        <input name="responseid-9-0" type="hidden" value="{*}"/>
+                        <input name="responseid-9-0" type="hidden" value="{*}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt"/>
                                              </div>
                   </div>
                </div>
@@ -1245,7 +1245,7 @@
                               </tr>
                            </tbody>
                         </table>
-                        <input name="responseid-10-0" type="hidden" value="{*}"/>
+                        <input name="responseid-10-0" type="hidden" value="{*}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt"/>
                                              </div>
                   </div>
                </div>
@@ -1323,7 +1323,7 @@
                               </tr>
                            </tbody>
                         </table>
-                        <input name="responseid-11-0" type="hidden" value="{*}"/>
+                        <input name="responseid-11-0" type="hidden" value="{*}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt"/>
                                              </div>
                   </div>
                </div>
@@ -1411,7 +1411,7 @@
                               </tr>
                            </tbody>
                         </table>
-                        <input name="responseid-12-0" type="hidden" value="{*}"/>
+                        <input name="responseid-12-0" type="hidden" value="{*}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt"/>
                                              </div>
                   </div>
                </div>
@@ -1470,7 +1470,7 @@
                         <div class="text-muted form-control-static">
                            [Possible values: 1, 1.5, 2, ..., 4, 4.5, 5]
                         </div>
-                        <input name="responseid-13-0" type="hidden" value="{*}"/>
+                        <input name="responseid-13-0" type="hidden" value="{*}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt"/>
                                              </div>
                   </div>
                </div>
@@ -1532,7 +1532,7 @@
                         <div class="text-muted form-control-static">
                            [Possible values: 1, 1.5, 2, ..., 4, 4.5, 5]
                         </div>
-                        <input name="responseid-14-0" type="hidden" value="{*}"/>
+                        <input name="responseid-14-0" type="hidden" value="{*}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr2@gmail.tmt"/>
                                              </div>
                   </div>
                   <br/>
@@ -1568,7 +1568,7 @@
                         <div class="text-muted form-control-static">
                            [Possible values: 1, 1.5, 2, ..., 4, 4.5, 5]
                         </div>
-                        <input name="responseid-14-1" type="hidden" value="{*}"/>
+                        <input name="responseid-14-1" type="hidden" value="{*}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr3@gmail.tmt"/>
                                              </div>
                   </div>
                   <br/>
@@ -1604,7 +1604,7 @@
                         <div class="text-muted form-control-static">
                            [Possible values: 1, 1.5, 2, ..., 4, 4.5, 5]
                         </div>
-                        <input name="responseid-14-2" type="hidden" value="{*}"/>
+                        <input name="responseid-14-2" type="hidden" value="{*}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr4@gmail.tmt"/>
                                              </div>
                   </div>
                </div>
@@ -1698,7 +1698,7 @@
                               </tr>
                            </tbody>
                         </table>
-                        <input name="responseid-15-0" type="hidden" value="{*}"/>
+                        <input name="responseid-15-0" type="hidden" value="{*}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt"/>
                                              </div>
                   </div>
                </div>
@@ -1802,7 +1802,7 @@
                               </tr>
                            </tbody>
                         </table>
-                        <input name="responseid-16-0" type="hidden" value="{*}"/>
+                        <input name="responseid-16-0" type="hidden" value="{*}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt"/>
                                              </div>
                   </div>
                </div>
@@ -1886,7 +1886,7 @@
                                                       <input id="constSumPoints-17" type="hidden" value="100"/>
                                                       <input id="constSumUnevenDistribution-17" type="hidden" value="false"/>
                                                    </div>
-                        <input name="responseid-17-0" type="hidden" value="{*}"/>
+                        <input name="responseid-17-0" type="hidden" value="{*}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt"/>
                                              </div>
                   </div>
                </div>
@@ -2576,7 +2576,7 @@
                               </tr>
                            </tbody>
                         </table>
-                        <input name="responseid-21-0" type="hidden" value="{*}"/>
+                        <input name="responseid-21-0" type="hidden" value="{*}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt"/>
                                              </div>
                   </div>
                </div>

--- a/src/test/resources/pages/instructorFeedbackSubmitPageModified.html
+++ b/src/test/resources/pages/instructorFeedbackSubmitPageModified.html
@@ -115,7 +115,7 @@
                         <textarea class="form-control" cols="100%" name="responsetext-1-0" rows="4">
                            Test Self Feedback
                         </textarea>
-                        <input name="responseid-1-0" type="hidden" value="{*}"/>
+                        <input name="responseid-1-0" type="hidden" value="{*}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt"/>
                                              </div>
                   </div>
                </div>
@@ -180,7 +180,7 @@
                         <textarea class="form-control" cols="100%" name="responsetext-2-0" rows="4">
                            Edited response to Alice.
                         </textarea>
-                        <input name="responseid-2-0" type="hidden" value="{*}"/>
+                        <input name="responseid-2-0" type="hidden" value="{*}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.alice.b@gmail.tmt"/>
                                              </div>
                   </div>
                   <br/>
@@ -216,7 +216,7 @@
                         <textarea class="form-control" cols="100%" name="responsetext-2-1" rows="4">
                            Response to extra guy.
                         </textarea>
-                        <input name="responseid-2-1" type="hidden" value="{*}"/>
+                        <input name="responseid-2-1" type="hidden" value="{*}%IFSubmitUiT.instr@gmail.tmt%extra.guy@gmail.tmt"/>
                                              </div>
                   </div>
                   <br/>
@@ -359,7 +359,7 @@
                         <textarea class="form-control" cols="100%" name="responsetext-4-0" rows="4">
                            Feedback to instructor 2.
                         </textarea>
-                        <input name="responseid-4-0" type="hidden" value="{*}"/>
+                        <input name="responseid-4-0" type="hidden" value="{*}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr2@gmail.tmt"/>
                                              </div>
                   </div>
                   <br/>
@@ -392,7 +392,7 @@
                         <textarea class="form-control" cols="100%" name="responsetext-4-1" rows="4">
                            Feedback to Instructor 3
                         </textarea>
-                        <input name="responseid-4-1" type="hidden" value="{*}"/>
+                        <input name="responseid-4-1" type="hidden" value="{*}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr3@gmail.tmt"/>
                                              </div>
                   </div>
                   <br/>
@@ -425,7 +425,7 @@
                         <textarea class="form-control" cols="100%" name="responsetext-4-2" rows="4">
                            Feedback to instructor 4.
                         </textarea>
-                        <input name="responseid-4-2" type="hidden" value="{*}"/>
+                        <input name="responseid-4-2" type="hidden" value="{*}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr4@gmail.tmt"/>
                                              </div>
                   </div>
                   <br/>
@@ -458,7 +458,7 @@
                         <textarea class="form-control" cols="100%" name="responsetext-4-3" rows="4">
                            Feedback to instructor 5.
                         </textarea>
-                        <input name="responseid-4-3" type="hidden" value="{*}"/>
+                        <input name="responseid-4-3" type="hidden" value="{*}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr5@gmail.tmt"/>
                                              </div>
                   </div>
                </div>
@@ -528,7 +528,7 @@
                               </tr>
                            </tbody>
                         </table>
-                        <input name="responseid-5-0" type="hidden" value="{*}"/>
+                        <input name="responseid-5-0" type="hidden" value="{*}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt"/>
                                              </div>
                   </div>
                </div>
@@ -601,7 +601,7 @@
                               </tr>
                            </tbody>
                         </table>
-                        <input name="responseid-6-0" type="hidden" value="{*}"/>
+                        <input name="responseid-6-0" type="hidden" value="{*}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr2@gmail.tmt"/>
                                              </div>
                   </div>
                   <br/>
@@ -648,7 +648,7 @@
                               </tr>
                            </tbody>
                         </table>
-                        <input name="responseid-6-1" type="hidden" value="{*}"/>
+                        <input name="responseid-6-1" type="hidden" value="{*}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr3@gmail.tmt"/>
                                              </div>
                   </div>
                   <br/>
@@ -695,7 +695,7 @@
                               </tr>
                            </tbody>
                         </table>
-                        <input name="responseid-6-2" type="hidden" value="{*}"/>
+                        <input name="responseid-6-2" type="hidden" value="{*}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr4@gmail.tmt"/>
                                              </div>
                   </div>
                </div>
@@ -783,7 +783,7 @@
                               </tr>
                            </tbody>
                         </table>
-                        <input name="responseid-7-0" type="hidden" value="{*}"/>
+                        <input name="responseid-7-0" type="hidden" value="{*}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt"/>
                                              </div>
                   </div>
                </div>
@@ -874,7 +874,7 @@
                               </tr>
                            </tbody>
                         </table>
-                        <input name="responseid-8-0" type="hidden" value="{*}"/>
+                        <input name="responseid-8-0" type="hidden" value="{*}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr2@gmail.tmt"/>
                                              </div>
                   </div>
                   <br/>
@@ -939,7 +939,7 @@
                               </tr>
                            </tbody>
                         </table>
-                        <input name="responseid-8-1" type="hidden" value="{*}"/>
+                        <input name="responseid-8-1" type="hidden" value="{*}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr3@gmail.tmt"/>
                                              </div>
                   </div>
                   <br/>
@@ -1004,7 +1004,7 @@
                               </tr>
                            </tbody>
                         </table>
-                        <input name="responseid-8-2" type="hidden" value="{*}"/>
+                        <input name="responseid-8-2" type="hidden" value="{*}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr4@gmail.tmt"/>
                                              </div>
                   </div>
                </div>
@@ -1106,7 +1106,7 @@
                               </tr>
                            </tbody>
                         </table>
-                        <input name="responseid-9-0" type="hidden" value="{*}"/>
+                        <input name="responseid-9-0" type="hidden" value="{*}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt"/>
                                              </div>
                   </div>
                </div>
@@ -1218,7 +1218,7 @@
                               </tr>
                            </tbody>
                         </table>
-                        <input name="responseid-10-0" type="hidden" value="{*}"/>
+                        <input name="responseid-10-0" type="hidden" value="{*}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt"/>
                                              </div>
                   </div>
                </div>
@@ -1304,7 +1304,7 @@
                               </tr>
                            </tbody>
                         </table>
-                        <input name="responseid-11-0" type="hidden" value="{*}"/>
+                        <input name="responseid-11-0" type="hidden" value="{*}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt"/>
                                              </div>
                   </div>
                </div>
@@ -1400,7 +1400,7 @@
                               </tr>
                            </tbody>
                         </table>
-                        <input name="responseid-12-0" type="hidden" value="{*}"/>
+                        <input name="responseid-12-0" type="hidden" value="{*}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt"/>
                                              </div>
                   </div>
                </div>
@@ -1459,7 +1459,7 @@
                         <div class="text-muted form-control-static">
                            [Possible values: 1, 1.5, 2, ..., 4, 4.5, 5]
                         </div>
-                        <input name="responseid-13-0" type="hidden" value="{*}"/>
+                        <input name="responseid-13-0" type="hidden" value="{*}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt"/>
                                              </div>
                   </div>
                </div>
@@ -1521,7 +1521,7 @@
                         <div class="text-muted form-control-static">
                            [Possible values: 1, 1.5, 2, ..., 4, 4.5, 5]
                         </div>
-                        <input name="responseid-14-0" type="hidden" value="{*}"/>
+                        <input name="responseid-14-0" type="hidden" value="{*}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr2@gmail.tmt"/>
                                              </div>
                   </div>
                   <br/>
@@ -1557,7 +1557,7 @@
                         <div class="text-muted form-control-static">
                            [Possible values: 1, 1.5, 2, ..., 4, 4.5, 5]
                         </div>
-                        <input name="responseid-14-1" type="hidden" value="{*}"/>
+                        <input name="responseid-14-1" type="hidden" value="{*}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr3@gmail.tmt"/>
                                              </div>
                   </div>
                   <br/>
@@ -1593,7 +1593,7 @@
                         <div class="text-muted form-control-static">
                            [Possible values: 1, 1.5, 2, ..., 4, 4.5, 5]
                         </div>
-                        <input name="responseid-14-2" type="hidden" value="{*}"/>
+                        <input name="responseid-14-2" type="hidden" value="{*}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr4@gmail.tmt"/>
                                              </div>
                   </div>
                </div>
@@ -1687,7 +1687,7 @@
                               </tr>
                            </tbody>
                         </table>
-                        <input name="responseid-15-0" type="hidden" value="{*}"/>
+                        <input name="responseid-15-0" type="hidden" value="{*}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt"/>
                                              </div>
                   </div>
                </div>
@@ -1791,7 +1791,7 @@
                               </tr>
                            </tbody>
                         </table>
-                        <input name="responseid-16-0" type="hidden" value="{*}"/>
+                        <input name="responseid-16-0" type="hidden" value="{*}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt"/>
                                              </div>
                   </div>
                </div>
@@ -1875,7 +1875,7 @@
                                                       <input id="constSumPoints-17" type="hidden" value="100"/>
                                                       <input id="constSumUnevenDistribution-17" type="hidden" value="false"/>
                                                    </div>
-                        <input name="responseid-17-0" type="hidden" value="{*}"/>
+                        <input name="responseid-17-0" type="hidden" value="{*}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt"/>
                                              </div>
                   </div>
                </div>
@@ -2777,7 +2777,7 @@
                               </tr>
                            </tbody>
                         </table>
-                        <input name="responseid-21-0" type="hidden" value="{*}"/>
+                        <input name="responseid-21-0" type="hidden" value="{*}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt"/>
                                              </div>
                   </div>
                </div>

--- a/src/test/resources/pages/instructorFeedbackSubmitPagePartiallyFilled.html
+++ b/src/test/resources/pages/instructorFeedbackSubmitPagePartiallyFilled.html
@@ -115,7 +115,7 @@
                         <textarea class="form-control" cols="100%" name="responsetext-1-0" rows="4">
                            Test Self Feedback
                         </textarea>
-                        <input name="responseid-1-0" type="hidden" value="{*}"/>
+                        <input name="responseid-1-0" type="hidden" value="{*}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt"/>
                                              </div>
                   </div>
                </div>
@@ -183,7 +183,7 @@
                         <textarea class="form-control" cols="100%" name="responsetext-2-0" rows="4">
                            Response to Alice.
                         </textarea>
-                        <input name="responseid-2-0" type="hidden" value="{*}"/>
+                        <input name="responseid-2-0" type="hidden" value="{*}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.alice.b@gmail.tmt"/>
                                              </div>
                   </div>
                   <br/>
@@ -222,7 +222,7 @@
                         <textarea class="form-control" cols="100%" name="responsetext-2-1" rows="4">
                            Response to student who is going to drop out.
                         </textarea>
-                        <input name="responseid-2-1" type="hidden" value="{*}"/>
+                        <input name="responseid-2-1" type="hidden" value="{*}%IFSubmitUiT.instr@gmail.tmt%drop.out@gmail.tmt"/>
                                              </div>
                   </div>
                   <br/>
@@ -261,7 +261,7 @@
                         <textarea class="form-control" cols="100%" name="responsetext-2-2" rows="4">
                            Response to extra guy.
                         </textarea>
-                        <input name="responseid-2-2" type="hidden" value="{*}"/>
+                        <input name="responseid-2-2" type="hidden" value="{*}%IFSubmitUiT.instr@gmail.tmt%extra.guy@gmail.tmt"/>
                                              </div>
                   </div>
                </div>
@@ -368,7 +368,7 @@
                         <textarea class="form-control" cols="100%" name="responsetext-4-0" rows="4">
                            Feedback to Instructor 3
                         </textarea>
-                        <input name="responseid-4-0" type="hidden" value="{*}"/>
+                        <input name="responseid-4-0" type="hidden" value="{*}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr3@gmail.tmt"/>
                                              </div>
                   </div>
                   <br/>
@@ -603,7 +603,7 @@
                               </tr>
                            </tbody>
                         </table>
-                        <input name="responseid-6-0" type="hidden" value="{*}"/>
+                        <input name="responseid-6-0" type="hidden" value="{*}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr2@gmail.tmt"/>
                                              </div>
                   </div>
                   <br/>
@@ -873,7 +873,7 @@
                               </tr>
                            </tbody>
                         </table>
-                        <input name="responseid-8-0" type="hidden" value="{*}"/>
+                        <input name="responseid-8-0" type="hidden" value="{*}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr2@gmail.tmt"/>
                                              </div>
                   </div>
                   <br/>
@@ -1452,7 +1452,7 @@
                         <div class="text-muted form-control-static">
                            [Possible values: 1, 1.5, 2, ..., 4, 4.5, 5]
                         </div>
-                        <input name="responseid-13-0" type="hidden" value="{*}"/>
+                        <input name="responseid-13-0" type="hidden" value="{*}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt"/>
                                              </div>
                   </div>
                </div>
@@ -1863,7 +1863,7 @@
                                                       <input id="constSumPoints-17" type="hidden" value="100"/>
                                                       <input id="constSumUnevenDistribution-17" type="hidden" value="false"/>
                                                    </div>
-                        <input name="responseid-17-0" type="hidden" value="{*}"/>
+                        <input name="responseid-17-0" type="hidden" value="{*}%IFSubmitUiT.instr@gmail.tmt%IFSubmitUiT.instr@gmail.tmt"/>
                                              </div>
                   </div>
                </div>

--- a/src/test/resources/pages/newlyJoinedInstructorStudentFeedbackSubmissionEdit.html
+++ b/src/test/resources/pages/newlyJoinedInstructorStudentFeedbackSubmissionEdit.html
@@ -202,7 +202,7 @@
                               </option>
                            </select>
                         </div>
-                        <input name="responseid-1-0" type="hidden" value="{*}"/>
+                        <input name="responseid-1-0" type="hidden" value="{*}%AHPUiT.instr1@gmail.tmt%AHPUiT.instr1@gmail.tmt"/>
                                              </div>
                   </div>
                   <br/>
@@ -304,7 +304,7 @@
                               </option>
                            </select>
                         </div>
-                        <input name="responseid-1-1" type="hidden" value="{*}"/>
+                        <input name="responseid-1-1" type="hidden" value="{*}%AHPUiT.instr1@gmail.tmt%charlie.d.tmms@gmail.tmt"/>
                                              </div>
                   </div>
                   <br/>
@@ -406,7 +406,7 @@
                               </option>
                            </select>
                         </div>
-                        <input name="responseid-1-2" type="hidden" value="{*}"/>
+                        <input name="responseid-1-2" type="hidden" value="{*}%AHPUiT.instr1@gmail.tmt%francis.g.tmms@gmail.tmt"/>
                                              </div>
                   </div>
                   <br/>
@@ -508,7 +508,7 @@
                               </option>
                            </select>
                         </div>
-                        <input name="responseid-1-3" type="hidden" value="{*}"/>
+                        <input name="responseid-1-3" type="hidden" value="{*}%AHPUiT.instr1@gmail.tmt%gene.h.tmms@gmail.tmt"/>
                                              </div>
                   </div>
                </div>
@@ -567,7 +567,7 @@
                         <textarea class="form-control" cols="100%" disabled="disabled" name="responsetext-2-0" rows="4">
                            I was the project lead. I designed the application architecture and managed the project to ensure we deliver the product on time.
                         </textarea>
-                        <input name="responseid-2-0" type="hidden" value="{*}"/>
+                        <input name="responseid-2-0" type="hidden" value="{*}%AHPUiT.instr1@gmail.tmt%AHPUiT.instr1@gmail.tmt"/>
                                              </div>
                   </div>
                </div>
@@ -623,7 +623,7 @@
                         <textarea class="form-control" cols="100%" disabled="disabled" name="responsetext-3-0" rows="4">
                            A bit weak in terms of technical skills. He spent lots of time in picking up the skills. Although a bit slow in development, his attitude is good.
                         </textarea>
-                        <input name="responseid-3-0" type="hidden" value="{*}"/>
+                        <input name="responseid-3-0" type="hidden" value="{*}%AHPUiT.instr1@gmail.tmt%charlie.d.tmms@gmail.tmt"/>
                                              </div>
                   </div>
                   <br/>
@@ -653,7 +653,7 @@
                         <textarea class="form-control" cols="100%" disabled="disabled" name="responsetext-3-1" rows="4">
                            Francis is the designer of the project. He did a good job!
                         </textarea>
-                        <input name="responseid-3-1" type="hidden" value="{*}"/>
+                        <input name="responseid-3-1" type="hidden" value="{*}%AHPUiT.instr1@gmail.tmt%francis.g.tmms@gmail.tmt"/>
                                              </div>
                   </div>
                   <br/>
@@ -683,7 +683,7 @@
                         <textarea class="form-control" cols="100%" disabled="disabled" name="responsetext-3-2" rows="4">
                            Gene is the programmer for our team. She put in a lot of effort in coding a significant portion of the project.
                         </textarea>
-                        <input name="responseid-3-2" type="hidden" value="{*}"/>
+                        <input name="responseid-3-2" type="hidden" value="{*}%AHPUiT.instr1@gmail.tmt%gene.h.tmms@gmail.tmt"/>
                                              </div>
                   </div>
                </div>
@@ -792,7 +792,7 @@
                         <textarea class="form-control" cols="100%" disabled="disabled" name="responsetext-5-0" rows="4">
                            Good try Charlie! Thanks for showing great effort in picking up the skills.
                         </textarea>
-                        <input name="responseid-5-0" type="hidden" value="{*}"/>
+                        <input name="responseid-5-0" type="hidden" value="{*}%AHPUiT.instr1@gmail.tmt%charlie.d.tmms@gmail.tmt"/>
                                              </div>
                   </div>
                   <br/>
@@ -822,7 +822,7 @@
                         <textarea class="form-control" cols="100%" disabled="disabled" name="responsetext-5-1" rows="4">
                            Nice work Francis!
                         </textarea>
-                        <input name="responseid-5-1" type="hidden" value="{*}"/>
+                        <input name="responseid-5-1" type="hidden" value="{*}%AHPUiT.instr1@gmail.tmt%francis.g.tmms@gmail.tmt"/>
                                              </div>
                   </div>
                   <br/>
@@ -852,7 +852,7 @@
                         <textarea class="form-control" cols="100%" disabled="disabled" name="responsetext-5-2" rows="4">
                            Keep up the good work Gene!
                         </textarea>
-                        <input name="responseid-5-2" type="hidden" value="{*}"/>
+                        <input name="responseid-5-2" type="hidden" value="{*}%AHPUiT.instr1@gmail.tmt%gene.h.tmms@gmail.tmt"/>
                                              </div>
                   </div>
                </div>

--- a/src/test/resources/pages/studentFeedbackQuestionSubmitPageFilled.html
+++ b/src/test/resources/pages/studentFeedbackQuestionSubmitPageFilled.html
@@ -124,7 +124,7 @@
                         <textarea class="form-control" cols="100%" name="responsetext-1-0" rows="4">
                            Edited self feedback.
                         </textarea>
-                        <input name="responseid-1-0" type="hidden" value="{*}"/>
+                        <input name="responseid-1-0" type="hidden" value="{*}%SFQSubmitUiT.alice.b@gmail.tmt%SFQSubmitUiT.alice.b@gmail.tmt"/>
                                              </div>
                   </div>
                </div>

--- a/src/test/resources/pages/studentFeedbackSubmitPageFullyFilled.html
+++ b/src/test/resources/pages/studentFeedbackSubmitPageFullyFilled.html
@@ -121,7 +121,7 @@
                         <textarea class="form-control" cols="100%" name="responsetext-1-0" rows="4">
                            Test Self Feedback
                         </textarea>
-                        <input name="responseid-1-0" type="hidden" value="{*}"/>
+                        <input name="responseid-1-0" type="hidden" value="{*}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt"/>
                                              </div>
                   </div>
                </div>
@@ -189,7 +189,7 @@
                         <textarea class="form-control" cols="100%" name="responsetext-2-0" rows="4">
                            Edited response to Benny.
                         </textarea>
-                        <input name="responseid-2-0" type="hidden" value="{*}"/>
+                        <input name="responseid-2-0" type="hidden" value="{*}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.benny.c@gmail.tmt"/>
                                              </div>
                   </div>
                   <br/>
@@ -225,7 +225,7 @@
                         <textarea class="form-control" cols="100%" name="responsetext-2-1" rows="4">
                            Response to student who is going to drop out.
                         </textarea>
-                        <input name="responseid-2-1" type="hidden" value="{*}"/>
+                        <input name="responseid-2-1" type="hidden" value="{*}%SFSubmitUiT.alice.b@gmail.tmt%drop.out@gmail.tmt"/>
                                              </div>
                   </div>
                   <br/>
@@ -261,7 +261,7 @@
                         <textarea class="form-control" cols="100%" name="responsetext-2-2" rows="4">
                            Response to extra guy.
                         </textarea>
-                        <input name="responseid-2-2" type="hidden" value="{*}"/>
+                        <input name="responseid-2-2" type="hidden" value="{*}%SFSubmitUiT.alice.b@gmail.tmt%extra.guy@gmail.tmt"/>
                                              </div>
                   </div>
                </div>
@@ -444,7 +444,7 @@
                         <textarea class="form-control" cols="100%" name="responsetext-5-0" rows="4">
                            Feedback to teammate.
                         </textarea>
-                        <input name="responseid-5-0" type="hidden" value="{*}"/>
+                        <input name="responseid-5-0" type="hidden" value="{*}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.benny.c@gmail.tmt"/>
                                              </div>
                   </div>
                </div>
@@ -520,7 +520,7 @@
                               </tr>
                            </tbody>
                         </table>
-                        <input name="responseid-6-0" type="hidden" value="{*}"/>
+                        <input name="responseid-6-0" type="hidden" value="{*}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt"/>
                                              </div>
                   </div>
                </div>
@@ -728,7 +728,7 @@
                               </tr>
                            </tbody>
                         </table>
-                        <input name="responseid-8-0" type="hidden" value="{*}"/>
+                        <input name="responseid-8-0" type="hidden" value="{*}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt"/>
                                              </div>
                   </div>
                </div>
@@ -994,7 +994,7 @@
                               </tr>
                            </tbody>
                         </table>
-                        <input name="responseid-10-0" type="hidden" value="{*}"/>
+                        <input name="responseid-10-0" type="hidden" value="{*}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt"/>
                                              </div>
                   </div>
                </div>
@@ -1120,7 +1120,7 @@
                               </tr>
                            </tbody>
                         </table>
-                        <input name="responseid-11-0" type="hidden" value="{*}"/>
+                        <input name="responseid-11-0" type="hidden" value="{*}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt"/>
                                              </div>
                   </div>
                </div>
@@ -1204,7 +1204,7 @@
                               </tr>
                            </tbody>
                         </table>
-                        <input name="responseid-12-0" type="hidden" value="{*}"/>
+                        <input name="responseid-12-0" type="hidden" value="{*}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt"/>
                                              </div>
                   </div>
                </div>
@@ -1298,7 +1298,7 @@
                               </tr>
                            </tbody>
                         </table>
-                        <input name="responseid-13-0" type="hidden" value="{*}"/>
+                        <input name="responseid-13-0" type="hidden" value="{*}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt"/>
                                              </div>
                   </div>
                </div>
@@ -1363,7 +1363,7 @@
                         <div class="text-muted form-control-static">
                            [Possible values: 1, 1.5, 2, ..., 4, 4.5, 5]
                         </div>
-                        <input name="responseid-14-0" type="hidden" value="{*}"/>
+                        <input name="responseid-14-0" type="hidden" value="{*}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt"/>
                                              </div>
                   </div>
                </div>
@@ -1539,7 +1539,7 @@
                               </tr>
                            </tbody>
                         </table>
-                        <input name="responseid-16-0" type="hidden" value="{*}"/>
+                        <input name="responseid-16-0" type="hidden" value="{*}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt"/>
                                              </div>
                   </div>
                </div>
@@ -1633,7 +1633,7 @@
                               </tr>
                            </tbody>
                         </table>
-                        <input name="responseid-17-0" type="hidden" value="{*}"/>
+                        <input name="responseid-17-0" type="hidden" value="{*}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt"/>
                                              </div>
                   </div>
                </div>
@@ -1723,7 +1723,7 @@
                                                       <input id="constSumPoints-18" type="hidden" value="100"/>
                                                       <input id="constSumUnevenDistribution-18" type="hidden" value="false"/>
                                                    </div>
-                        <input name="responseid-18-0" type="hidden" value="{*}"/>
+                        <input name="responseid-18-0" type="hidden" value="{*}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt"/>
                                              </div>
                   </div>
                </div>
@@ -1971,7 +1971,7 @@
                               </option>
                            </select>
                         </div>
-                        <input name="responseid-20-0" type="hidden" value="{*}"/>
+                        <input name="responseid-20-0" type="hidden" value="{*}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt"/>
                                              </div>
                   </div>
                   <br/>
@@ -2067,7 +2067,7 @@
                               </option>
                            </select>
                         </div>
-                        <input name="responseid-20-1" type="hidden" value="{*}"/>
+                        <input name="responseid-20-1" type="hidden" value="{*}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.benny.c@gmail.tmt"/>
                                              </div>
                   </div>
                </div>

--- a/src/test/resources/pages/studentFeedbackSubmitPageModified.html
+++ b/src/test/resources/pages/studentFeedbackSubmitPageModified.html
@@ -121,7 +121,7 @@
                         <textarea class="form-control" cols="100%" name="responsetext-1-0" rows="4">
                            Test Self Feedback
                         </textarea>
-                        <input name="responseid-1-0" type="hidden" value="{*}"/>
+                        <input name="responseid-1-0" type="hidden" value="{*}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt"/>
                                              </div>
                   </div>
                </div>
@@ -186,7 +186,7 @@
                         <textarea class="form-control" cols="100%" name="responsetext-2-0" rows="4">
                            Edited response to Benny.
                         </textarea>
-                        <input name="responseid-2-0" type="hidden" value="{*}"/>
+                        <input name="responseid-2-0" type="hidden" value="{*}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.benny.c@gmail.tmt"/>
                                              </div>
                   </div>
                   <br/>
@@ -219,7 +219,7 @@
                         <textarea class="form-control" cols="100%" name="responsetext-2-1" rows="4">
                            Response to extra guy.
                         </textarea>
-                        <input name="responseid-2-1" type="hidden" value="{*}"/>
+                        <input name="responseid-2-1" type="hidden" value="{*}%SFSubmitUiT.alice.b@gmail.tmt%extra.guy@gmail.tmt"/>
                                              </div>
                   </div>
                   <br/>
@@ -493,7 +493,7 @@
                               </tr>
                            </tbody>
                         </table>
-                        <input name="responseid-5-0" type="hidden" value="{*}"/>
+                        <input name="responseid-5-0" type="hidden" value="{*}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt"/>
                                              </div>
                   </div>
                </div>
@@ -753,7 +753,7 @@
                               </tr>
                            </tbody>
                         </table>
-                        <input name="responseid-7-0" type="hidden" value="{*}"/>
+                        <input name="responseid-7-0" type="hidden" value="{*}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt"/>
                                              </div>
                   </div>
                </div>
@@ -1081,7 +1081,7 @@
                               </tr>
                            </tbody>
                         </table>
-                        <input name="responseid-9-0" type="hidden" value="{*}"/>
+                        <input name="responseid-9-0" type="hidden" value="{*}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt"/>
                                              </div>
                   </div>
                </div>
@@ -1199,7 +1199,7 @@
                               </tr>
                            </tbody>
                         </table>
-                        <input name="responseid-10-0" type="hidden" value="{*}"/>
+                        <input name="responseid-10-0" type="hidden" value="{*}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt"/>
                                              </div>
                   </div>
                </div>
@@ -1291,7 +1291,7 @@
                               </tr>
                            </tbody>
                         </table>
-                        <input name="responseid-11-0" type="hidden" value="{*}"/>
+                        <input name="responseid-11-0" type="hidden" value="{*}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt"/>
                                              </div>
                   </div>
                </div>
@@ -1393,7 +1393,7 @@
                               </tr>
                            </tbody>
                         </table>
-                        <input name="responseid-12-0" type="hidden" value="{*}"/>
+                        <input name="responseid-12-0" type="hidden" value="{*}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt"/>
                                              </div>
                   </div>
                </div>
@@ -1458,7 +1458,7 @@
                         <div class="text-muted form-control-static">
                            [Possible values: 1, 1.5, 2, ..., 4, 4.5, 5]
                         </div>
-                        <input name="responseid-13-0" type="hidden" value="{*}"/>
+                        <input name="responseid-13-0" type="hidden" value="{*}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt"/>
                                              </div>
                   </div>
                </div>
@@ -1675,7 +1675,7 @@
                               </tr>
                            </tbody>
                         </table>
-                        <input name="responseid-15-0" type="hidden" value="{*}"/>
+                        <input name="responseid-15-0" type="hidden" value="{*}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt"/>
                                              </div>
                   </div>
                </div>
@@ -1769,7 +1769,7 @@
                               </tr>
                            </tbody>
                         </table>
-                        <input name="responseid-16-0" type="hidden" value="{*}"/>
+                        <input name="responseid-16-0" type="hidden" value="{*}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt"/>
                                              </div>
                   </div>
                </div>
@@ -1859,7 +1859,7 @@
                                                       <input id="constSumPoints-17" type="hidden" value="100"/>
                                                       <input id="constSumUnevenDistribution-17" type="hidden" value="false"/>
                                                    </div>
-                        <input name="responseid-17-0" type="hidden" value="{*}"/>
+                        <input name="responseid-17-0" type="hidden" value="{*}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt"/>
                                              </div>
                   </div>
                </div>
@@ -2160,7 +2160,7 @@
                               </option>
                            </select>
                         </div>
-                        <input name="responseid-19-0" type="hidden" value="{*}"/>
+                        <input name="responseid-19-0" type="hidden" value="{*}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt"/>
                                              </div>
                   </div>
                </div>

--- a/src/test/resources/pages/studentFeedbackSubmitPagePartiallyFilled.html
+++ b/src/test/resources/pages/studentFeedbackSubmitPagePartiallyFilled.html
@@ -121,7 +121,7 @@
                         <textarea class="form-control" cols="100%" name="responsetext-1-0" rows="4">
                            Test Self Feedback
                         </textarea>
-                        <input name="responseid-1-0" type="hidden" value="{*}"/>
+                        <input name="responseid-1-0" type="hidden" value="{*}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt"/>
                                              </div>
                   </div>
                </div>
@@ -189,7 +189,7 @@
                         <textarea class="form-control" cols="100%" name="responsetext-2-0" rows="4">
                            Response to Benny.
                         </textarea>
-                        <input name="responseid-2-0" type="hidden" value="{*}"/>
+                        <input name="responseid-2-0" type="hidden" value="{*}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.benny.c@gmail.tmt"/>
                                              </div>
                   </div>
                   <br/>
@@ -225,7 +225,7 @@
                         <textarea class="form-control" cols="100%" name="responsetext-2-1" rows="4">
                            Response to student who is going to drop out.
                         </textarea>
-                        <input name="responseid-2-1" type="hidden" value="{*}"/>
+                        <input name="responseid-2-1" type="hidden" value="{*}%SFSubmitUiT.alice.b@gmail.tmt%drop.out@gmail.tmt"/>
                                              </div>
                   </div>
                   <br/>
@@ -261,7 +261,7 @@
                         <textarea class="form-control" cols="100%" name="responsetext-2-2" rows="4">
                            Response to extra guy.
                         </textarea>
-                        <input name="responseid-2-2" type="hidden" value="{*}"/>
+                        <input name="responseid-2-2" type="hidden" value="{*}%SFSubmitUiT.alice.b@gmail.tmt%extra.guy@gmail.tmt"/>
                                              </div>
                   </div>
                </div>
@@ -1349,7 +1349,7 @@
                         <div class="text-muted form-control-static">
                            [Possible values: 1, 1.5, 2, ..., 4, 4.5, 5]
                         </div>
-                        <input name="responseid-14-0" type="hidden" value="{*}"/>
+                        <input name="responseid-14-0" type="hidden" value="{*}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt"/>
                                              </div>
                   </div>
                </div>
@@ -1705,7 +1705,7 @@
                                                       <input id="constSumPoints-18" type="hidden" value="100"/>
                                                       <input id="constSumUnevenDistribution-18" type="hidden" value="false"/>
                                                    </div>
-                        <input name="responseid-18-0" type="hidden" value="{*}"/>
+                        <input name="responseid-18-0" type="hidden" value="{*}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt"/>
                                              </div>
                   </div>
                </div>
@@ -1951,7 +1951,7 @@
                               </option>
                            </select>
                         </div>
-                        <input name="responseid-20-0" type="hidden" value="{*}"/>
+                        <input name="responseid-20-0" type="hidden" value="{*}%SFSubmitUiT.alice.b@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt"/>
                                              </div>
                   </div>
                   <br/>

--- a/src/test/resources/pages/studentFeedbackSubmitPageRubricSuccess.html
+++ b/src/test/resources/pages/studentFeedbackSubmitPageRubricSuccess.html
@@ -176,7 +176,7 @@
                            </div>
                         </div>
                         <input id="rubricResponse-1-0" name="responsetext-1-0" type="hidden" value=""/>
-                                                <input name="responseid-1-0" type="hidden" value="{*}"/>
+                                                <input name="responseid-1-0" type="hidden" value="{*}%alice.b.tmms@gmail.tmt%benny.c.tmms@gmail.tmt"/>
                                              </div>
                   </div>
                   <br/>

--- a/src/test/resources/pages/unregisteredStudentFeedbackSubmitPagePartiallyFilled.html
+++ b/src/test/resources/pages/unregisteredStudentFeedbackSubmitPagePartiallyFilled.html
@@ -136,7 +136,7 @@
                         <textarea class="form-control" cols="100%" name="responsetext-1-0" rows="4">
                            Test Self Feedback
                         </textarea>
-                        <input name="responseid-1-0" type="hidden" value="{*}"/>
+                        <input name="responseid-1-0" type="hidden" value="{*}%drop.out@gmail.tmt%drop.out@gmail.tmt"/>
                                              </div>
                   </div>
                </div>
@@ -204,7 +204,7 @@
                         <textarea class="form-control" cols="100%" name="responsetext-2-0" rows="4">
                            Response to student who is number 1.
                         </textarea>
-                        <input name="responseid-2-0" type="hidden" value="{*}"/>
+                        <input name="responseid-2-0" type="hidden" value="{*}%drop.out@gmail.tmt%SFSubmitUiT.alice.b@gmail.tmt"/>
                                              </div>
                   </div>
                   <br/>
@@ -240,7 +240,7 @@
                         <textarea class="form-control" cols="100%" name="responsetext-2-1" rows="4">
                            Response to Benny.
                         </textarea>
-                        <input name="responseid-2-1" type="hidden" value="{*}"/>
+                        <input name="responseid-2-1" type="hidden" value="{*}%drop.out@gmail.tmt%SFSubmitUiT.benny.c@gmail.tmt"/>
                                              </div>
                   </div>
                   <br/>
@@ -276,7 +276,7 @@
                         <textarea class="form-control" cols="100%" name="responsetext-2-2" rows="4">
                            Response to extra guy.
                         </textarea>
-                        <input name="responseid-2-2" type="hidden" value="{*}"/>
+                        <input name="responseid-2-2" type="hidden" value="{*}%drop.out@gmail.tmt%extra.guy@gmail.tmt"/>
                                              </div>
                   </div>
                </div>
@@ -1426,7 +1426,7 @@
                         <div class="text-muted form-control-static">
                            [Possible values: 1, 1.5, 2, ..., 4, 4.5, 5]
                         </div>
-                        <input name="responseid-14-0" type="hidden" value="{*}"/>
+                        <input name="responseid-14-0" type="hidden" value="{*}%drop.out@gmail.tmt%drop.out@gmail.tmt"/>
                                              </div>
                   </div>
                </div>
@@ -1782,7 +1782,7 @@
                                                       <input id="constSumPoints-18" type="hidden" value="100"/>
                                                       <input id="constSumUnevenDistribution-18" type="hidden" value="false"/>
                                                    </div>
-                        <input name="responseid-18-0" type="hidden" value="{*}"/>
+                        <input name="responseid-18-0" type="hidden" value="{*}%drop.out@gmail.tmt%drop.out@gmail.tmt"/>
                                              </div>
                   </div>
                </div>
@@ -2034,7 +2034,7 @@
                               </option>
                            </select>
                         </div>
-                        <input name="responseid-20-0" type="hidden" value="{*}"/>
+                        <input name="responseid-20-0" type="hidden" value="{*}%drop.out@gmail.tmt%SFSubmitUiT.charlie.d@gmail.tmt"/>
                                              </div>
                   </div>
                   <br/>


### PR DESCRIPTION
Fixes #4361 and closes #4362 as the demo is no longer needed.
Some information:
- the original questionid regex is taken over by #4368.
- the erroneously replaced super long name in `instructorCourseEnrollError.html` is now recovered.
- there's a large number of change because responseid regex now targets only the questionid (background: responseid is in the form of `questionid%giver@email%recipient@email`) and instead of replacing the whole thing to `{*}`, it replaces just the questionid (i.e becomes `{*}%giver@email%recipient@email`). I believe this is ideal as both emails are non-random.