### PR TITLE
Detect invalid question numbers in feedback sessions #4328

### DIFF
--- a/src/main/java/teammates/common/datatransfer/FeedbackSessionResultsBundle.java
+++ b/src/main/java/teammates/common/datatransfer/FeedbackSessionResultsBundle.java
@@ -122,6 +122,23 @@ public class FeedbackSessionResultsBundle implements SessionResultsBundle {
         // roster.*Table is populated using the CourseRoster data directly
         this.rosterTeamNameMembersTable = getTeamNameToEmailsTableFromRoster(roster);
         this.rosterSectionTeamNameTable = getSectionToTeamNamesFromRoster(roster);
+        if (!isAllQuestionNumbersConsistent()) {
+            log.severe(feedbackSession.getIdentificationString() + " has invalid question numbers");
+        }
+    }
+    
+
+    //TODO can be removed once we are sure that question numbers will be consistent
+    private boolean isAllQuestionNumbersConsistent() {
+        Set<Integer> questionNumbersInSession = new HashSet<>();
+        for (FeedbackQuestionAttributes question : this.questions.values()) {
+            if (questionNumbersInSession.contains(question.questionNumber)) {
+                return false;
+            }
+            questionNumbersInSession.add(question.questionNumber);
+        }
+        
+        return true;
     }
     
 

--- a/src/main/java/teammates/common/datatransfer/FeedbackSessionResultsBundle.java
+++ b/src/main/java/teammates/common/datatransfer/FeedbackSessionResultsBundle.java
@@ -122,20 +122,26 @@ public class FeedbackSessionResultsBundle implements SessionResultsBundle {
         // roster.*Table is populated using the CourseRoster data directly
         this.rosterTeamNameMembersTable = getTeamNameToEmailsTableFromRoster(roster);
         this.rosterSectionTeamNameTable = getSectionToTeamNamesFromRoster(roster);
-        if (!isAllQuestionNumbersConsistent()) {
+        if (!areQuestionNumbersConsistent()) {
             log.severe(feedbackSession.getIdentificationString() + " has invalid question numbers");
         }
     }
     
 
     //TODO can be removed once we are sure that question numbers will be consistent
-    private boolean isAllQuestionNumbersConsistent() {
+    private boolean areQuestionNumbersConsistent() {
         Set<Integer> questionNumbersInSession = new HashSet<>();
         for (FeedbackQuestionAttributes question : this.questions.values()) {
             if (questionNumbersInSession.contains(question.questionNumber)) {
                 return false;
             }
             questionNumbersInSession.add(question.questionNumber);
+        }
+        
+        for (int i = 1; i <= this.questions.values().size(); i++) {
+            if (!questionNumbersInSession.contains(i)) {
+                return false;
+            }
         }
         
         return true;

--- a/src/main/java/teammates/common/datatransfer/FeedbackSessionResultsBundle.java
+++ b/src/main/java/teammates/common/datatransfer/FeedbackSessionResultsBundle.java
@@ -122,7 +122,7 @@ public class FeedbackSessionResultsBundle implements SessionResultsBundle {
         // roster.*Table is populated using the CourseRoster data directly
         this.rosterTeamNameMembersTable = getTeamNameToEmailsTableFromRoster(roster);
         this.rosterSectionTeamNameTable = getSectionToTeamNamesFromRoster(roster);
-        if (!areQuestionNumbersConsistent()) {
+        if (this.questions.size() > 1 && !areQuestionNumbersConsistent()) {
             log.severe(feedbackSession.getIdentificationString() + " has invalid question numbers");
         }
     }
@@ -132,10 +132,9 @@ public class FeedbackSessionResultsBundle implements SessionResultsBundle {
     private boolean areQuestionNumbersConsistent() {
         Set<Integer> questionNumbersInSession = new HashSet<>();
         for (FeedbackQuestionAttributes question : this.questions.values()) {
-            if (questionNumbersInSession.contains(question.questionNumber)) {
+            if (!questionNumbersInSession.add(question.questionNumber)) {
                 return false;
             }
-            questionNumbersInSession.add(question.questionNumber);
         }
         
         for (int i = 1; i <= this.questions.values().size(); i++) {


### PR DESCRIPTION
Fixes #4328.

Verified that the log severe triggers in the test case (in InstructorFeedbackResultsUiTest) for invalid question numbers