### PR TITLE
InstructorFeedbackResultsPageUiTest failing on live server #3639

### DIFF
--- a/src/test/java/teammates/test/cases/ui/browsertests/InstructorFeedbackResultsPageUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/InstructorFeedbackResultsPageUiTest.java
@@ -620,7 +620,11 @@ public class InstructorFeedbackResultsPageUiTest extends BaseUiTestCase {
         String afterReportDownloadUrl = browser.driver.getCurrentUrl();
         assertFalse(reportUrl.equals(afterReportDownloadUrl));
         // Get an error page due to missing parameters in URL
-        assertEquals(true, afterReportDownloadUrl.contains(Const.ActionURIs.INSTRUCTOR_HOME_PAGE));
+        // If admin is an instructor, expected url is InstructorHomePage
+        //                 otherwise, expected url is unauthorised.jsp
+        assertTrue("Expected url is InstructorHomePage or Unauthorised page, but is " + afterReportDownloadUrl,
+                   afterReportDownloadUrl.contains(Const.ActionURIs.INSTRUCTOR_HOME_PAGE) 
+                   || afterReportDownloadUrl.contains(Const.ViewURIs.UNAUTHORIZED));
 
         // return to the previous page
         loginToInstructorFeedbackResultsPage("CFResultsUiT.instr", "Open Session");


### PR DESCRIPTION
Fixes #3639.

The test can fail if the admin isn't a instructor. 

If the download url is invalid, the user is redirected back to instructorHomePage because of <code>assertPostParamNotNull</code>, but without the usual user parameter.

Even if the test isn't failing because of this, I added more information to the assert statement, so at least we will know which page is the test redirected to

