### PR TITLE
Highly duplicated methods used in HTML comparison #4470

### DIFF
--- a/src/test/java/teammates/test/cases/testdriver/HtmlHelperTest.java
+++ b/src/test/java/teammates/test/cases/testdriver/HtmlHelperTest.java
@@ -21,28 +21,28 @@ public class HtmlHelperTest {
     public void testComparison() throws SAXException, IOException, TransformerException{
         String expected = "<html></html>";
         String actual = expected;
-        HtmlHelper.assertSameHtml(actual, expected);
+        HtmlHelper.assertSameHtml(expected, actual, false, true);
         
         actual = "<html> </html>";
-        HtmlHelper.assertSameHtml(actual, expected);
+        HtmlHelper.assertSameHtml(expected, actual, false, true);
         
         expected = "<HTML><HEAD><SCRIPT language=\"JavaScript\" src=\"a.js\" ></SCRIPT></HEAD><BODY id=\"5\"><P>abc</P><DIV id=\"frameBottom\"><DIV></DIV></DIV></BODY></HTML>";
         actual = expected.replace("<HEAD>", "    <HEAD>    \t"+EOL);
-        HtmlHelper.assertSameHtml(actual, expected);
+        HtmlHelper.assertSameHtml(expected, actual, false, true);
         
         //change attribute order
         actual = expected.replace("language=\"JavaScript\" src=\"a.js\"", "  src=\"a.js\"   language=\"JavaScript\"  ");
-        HtmlHelper.assertSameHtml(actual, expected);
+        HtmlHelper.assertSameHtml(expected, actual, false, true);
         
         actual = expected.replace("<P>", "<P>\n\n"+EOL+EOL);
-        HtmlHelper.assertSameHtml(actual, expected);
+        HtmlHelper.assertSameHtml(expected, actual, false, true);
         
         actual = expected.replace("<DIV></DIV></DIV>", EOL+EOL+"\n<DIV>\n\n</DIV></DIV>\n\n"+EOL);
-        HtmlHelper.assertSameHtml(actual, expected);
+        HtmlHelper.assertSameHtml(expected, actual, false, true);
         
         expected = FileHelper.readFile(TestProperties.TEST_PAGES_FOLDER +"/sampleExpected.html");
         actual = FileHelper.readFile(TestProperties.TEST_PAGES_FOLDER +"/sampleActual.html");
-        HtmlHelper.assertSameHtml(actual, expected);
+        HtmlHelper.assertSameHtml(expected, actual, false, true);
 
     }
     
@@ -52,32 +52,32 @@ public class HtmlHelperTest {
         //Tool tip in actual. Should not be ignored.
         String actual = "<html><head></head><body><div class=\"tooltip\">tool tip <br> 2nd line </div></body></html>";
         String expected = "<html><head></head><body></body></html>";
-        assertTrue(HtmlHelper.areSameHtml(actual, expected));
+        assertTrue(HtmlHelper.assertSameHtml(expected, actual, false, false));
         
         //'<div>' without attributes (not a tool tip). Should not be ignored.
         actual = "<html><head></head><body><div></div></body></html>";
         expected = "<html><head></head><body></body></html>";
-        assertFalse(HtmlHelper.areSameHtml(actual, expected));
+        assertFalse(HtmlHelper.assertSameHtml(expected, actual, false, false));
                 
         //Using a '<div>' that is not a tool tip. Should not be ignored.
         actual = "<html><head></head><body><div id=\"otherId\"></div></body></html>";
         expected = "<html><head></head><body></body></html>";
-        assertFalse(HtmlHelper.areSameHtml(actual, expected));
+        assertFalse(HtmlHelper.assertSameHtml(expected, actual, false, false));
         
         //Different tool tips. Will be ignored (the logic does not detect this).
         actual = "<html><head></head><body><div class=\"tooltip\">tool tip <br> 2nd line </div></body></html>";
         expected = "<html><head></head><body><div class=\"tooltip\"></div></body></html>";
-        assertTrue(HtmlHelper.areSameHtml(actual, expected));
+        assertTrue(HtmlHelper.assertSameHtml(expected, actual, false, false));
         
         //Test against areSameHtmlPart
         actual = "<html><head><script></script></head><body><div></div></body></html>";
         expected = "<html><head></head><body><script></script><div></div></body></html>";
-        assertFalse(HtmlHelper.areSameHtml(actual, expected));
+        assertFalse(HtmlHelper.assertSameHtml(expected, actual, false, false));
         
         //Test against areSameHtmlPart
         expected = FileHelper.readFile(TestProperties.TEST_PAGES_FOLDER +"/sampleExpected.html");
         actual = FileHelper.readFile(TestProperties.TEST_PAGES_FOLDER +"/sampleActualPart.html");
-        assertFalse(HtmlHelper.areSameHtml(actual, expected));
+        assertFalse(HtmlHelper.assertSameHtml(expected, actual, false, false));
     }
     
     @Test
@@ -86,52 +86,52 @@ public class HtmlHelperTest {
         //Tool tip in actual. Should not be ignored.
         String actual = "<html><head></head><body><div class=\"tooltip\">tool tip <br> 2nd line </div></body></html>";
         String expected = "<html><head></head><body></body></html>";
-        assertTrue(HtmlHelper.areSameHtmlPart(actual, expected));
+        assertTrue(HtmlHelper.assertSameHtml(expected, actual, true, false));
         
         //one part does not contain html tag. Should be the same
         actual = "<html><head></head><body><div></div></body></html>";
         expected = "<html><div></div></html>";
-        assertTrue(HtmlHelper.areSameHtmlPart(actual, expected));
+        assertTrue(HtmlHelper.assertSameHtml(expected, actual, true, false));
         
         //one part does not contain head tag. Should be the same
         actual = "<html><head></head><body><div></div></body></html>";
         expected = "<html><body><div></div></body></html>";
-        assertTrue(HtmlHelper.areSameHtmlPart(actual, expected));
+        assertTrue(HtmlHelper.assertSameHtml(expected, actual, true, false));
         
         //one part does not contain body tag. Should be the same
         actual = "<html><head></head><body><div></div></body></html>";
         expected = "<html><head></head><div></div></html>";
-        assertTrue(HtmlHelper.areSameHtmlPart(actual, expected));
+        assertTrue(HtmlHelper.assertSameHtml(expected, actual, true, false));
         
         //Different tool tips. Will be ignored (the logic does not detect this)
         actual = "<html><head></head><body><div class=\"tooltip\">tool tip <br> 2nd line </div></body></html>";
         expected = "<html><head></head><body><div class=\"tooltip\"></div></body></html>";
-        assertTrue(HtmlHelper.areSameHtmlPart(actual, expected));
+        assertTrue(HtmlHelper.assertSameHtml(expected, actual, true, false));
         
         //Different tool tips and three tags(html, head, body) ignored. Should be the same
         actual = "<html><head></head><body><div class=\"tooltip\">tool tip <br> 2nd line </div></body></html>";
         expected = "<div class=\"tooltip\"></div>";
-        assertTrue(HtmlHelper.areSameHtmlPart(actual, expected));
+        assertTrue(HtmlHelper.assertSameHtml(expected, actual, true, false));
         
         //Contents inside div are different . Should be different
         actual = "<html><head></head><body><div>content<br> 2nd line </div></body></html>";
         expected = "<html><head></head><body><div></div></body></html>";
-        assertFalse(HtmlHelper.areSameHtmlPart(actual, expected));
+        assertFalse(HtmlHelper.assertSameHtml(expected, actual, true, false));
         
         //Test against areSameHtml
         actual = "<html><head><script></script></head><body><div></div></body></html>";
         expected = "<html><head></head><body><script></script><div></div></body></html>";
-        assertTrue(HtmlHelper.areSameHtmlPart(actual, expected));
+        assertTrue(HtmlHelper.assertSameHtml(expected, actual, true, false));
         
         //Same html structure
         expected = FileHelper.readFile(TestProperties.TEST_PAGES_FOLDER +"/sampleExpected.html");
         actual = FileHelper.readFile(TestProperties.TEST_PAGES_FOLDER +"/sampleActual.html");
-        HtmlHelper.assertSameHtmlPart(actual, expected);
+        HtmlHelper.assertSameHtml(expected, actual, true, true);
         
         //Same after ignoring html & head & body tag
         expected = FileHelper.readFile(TestProperties.TEST_PAGES_FOLDER +"/sampleExpected.html");
         actual = FileHelper.readFile(TestProperties.TEST_PAGES_FOLDER +"/sampleActualPart.html");
-        HtmlHelper.assertSameHtmlPart(actual, expected);
+        HtmlHelper.assertSameHtml(expected, actual, true, true);
         
         //other cases are tested in testComparison
     }

--- a/src/test/java/teammates/test/cases/testdriver/HtmlHelperTest.java
+++ b/src/test/java/teammates/test/cases/testdriver/HtmlHelperTest.java
@@ -21,28 +21,28 @@ public class HtmlHelperTest {
     public void testComparison() throws SAXException, IOException, TransformerException{
         String expected = "<html></html>";
         String actual = expected;
-        HtmlHelper.assertSameHtml(expected, actual, false, true);
+        HtmlHelper.assertSameHtml(expected, actual, false);
         
         actual = "<html> </html>";
-        HtmlHelper.assertSameHtml(expected, actual, false, true);
+        HtmlHelper.assertSameHtml(expected, actual, false);
         
         expected = "<HTML><HEAD><SCRIPT language=\"JavaScript\" src=\"a.js\" ></SCRIPT></HEAD><BODY id=\"5\"><P>abc</P><DIV id=\"frameBottom\"><DIV></DIV></DIV></BODY></HTML>";
         actual = expected.replace("<HEAD>", "    <HEAD>    \t"+EOL);
-        HtmlHelper.assertSameHtml(expected, actual, false, true);
+        HtmlHelper.assertSameHtml(expected, actual, false);
         
         //change attribute order
         actual = expected.replace("language=\"JavaScript\" src=\"a.js\"", "  src=\"a.js\"   language=\"JavaScript\"  ");
-        HtmlHelper.assertSameHtml(expected, actual, false, true);
+        HtmlHelper.assertSameHtml(expected, actual, false);
         
         actual = expected.replace("<P>", "<P>\n\n"+EOL+EOL);
-        HtmlHelper.assertSameHtml(expected, actual, false, true);
+        HtmlHelper.assertSameHtml(expected, actual, false);
         
         actual = expected.replace("<DIV></DIV></DIV>", EOL+EOL+"\n<DIV>\n\n</DIV></DIV>\n\n"+EOL);
-        HtmlHelper.assertSameHtml(expected, actual, false, true);
+        HtmlHelper.assertSameHtml(expected, actual, false);
         
         expected = FileHelper.readFile(TestProperties.TEST_PAGES_FOLDER +"/sampleExpected.html");
         actual = FileHelper.readFile(TestProperties.TEST_PAGES_FOLDER +"/sampleActual.html");
-        HtmlHelper.assertSameHtml(expected, actual, false, true);
+        HtmlHelper.assertSameHtml(expected, actual, false);
 
     }
     
@@ -52,32 +52,32 @@ public class HtmlHelperTest {
         //Tool tip in actual. Should not be ignored.
         String actual = "<html><head></head><body><div class=\"tooltip\">tool tip <br> 2nd line </div></body></html>";
         String expected = "<html><head></head><body></body></html>";
-        assertTrue(HtmlHelper.assertSameHtml(expected, actual, false, false));
+        assertTrue(HtmlHelper.areSameHtml(expected, actual, false));
         
         //'<div>' without attributes (not a tool tip). Should not be ignored.
         actual = "<html><head></head><body><div></div></body></html>";
         expected = "<html><head></head><body></body></html>";
-        assertFalse(HtmlHelper.assertSameHtml(expected, actual, false, false));
+        assertFalse(HtmlHelper.areSameHtml(expected, actual, false));
                 
         //Using a '<div>' that is not a tool tip. Should not be ignored.
         actual = "<html><head></head><body><div id=\"otherId\"></div></body></html>";
         expected = "<html><head></head><body></body></html>";
-        assertFalse(HtmlHelper.assertSameHtml(expected, actual, false, false));
+        assertFalse(HtmlHelper.areSameHtml(expected, actual, false));
         
         //Different tool tips. Will be ignored (the logic does not detect this).
         actual = "<html><head></head><body><div class=\"tooltip\">tool tip <br> 2nd line </div></body></html>";
         expected = "<html><head></head><body><div class=\"tooltip\"></div></body></html>";
-        assertTrue(HtmlHelper.assertSameHtml(expected, actual, false, false));
+        assertTrue(HtmlHelper.areSameHtml(expected, actual, false));
         
         //Test against areSameHtmlPart
         actual = "<html><head><script></script></head><body><div></div></body></html>";
         expected = "<html><head></head><body><script></script><div></div></body></html>";
-        assertFalse(HtmlHelper.assertSameHtml(expected, actual, false, false));
+        assertFalse(HtmlHelper.areSameHtml(expected, actual, false));
         
         //Test against areSameHtmlPart
         expected = FileHelper.readFile(TestProperties.TEST_PAGES_FOLDER +"/sampleExpected.html");
         actual = FileHelper.readFile(TestProperties.TEST_PAGES_FOLDER +"/sampleActualPart.html");
-        assertFalse(HtmlHelper.assertSameHtml(expected, actual, false, false));
+        assertFalse(HtmlHelper.areSameHtml(expected, actual, false));
     }
     
     @Test
@@ -86,52 +86,52 @@ public class HtmlHelperTest {
         //Tool tip in actual. Should not be ignored.
         String actual = "<html><head></head><body><div class=\"tooltip\">tool tip <br> 2nd line </div></body></html>";
         String expected = "<html><head></head><body></body></html>";
-        assertTrue(HtmlHelper.assertSameHtml(expected, actual, true, false));
+        assertTrue(HtmlHelper.areSameHtml(expected, actual, true));
         
         //one part does not contain html tag. Should be the same
         actual = "<html><head></head><body><div></div></body></html>";
         expected = "<html><div></div></html>";
-        assertTrue(HtmlHelper.assertSameHtml(expected, actual, true, false));
+        assertTrue(HtmlHelper.areSameHtml(expected, actual, true));
         
         //one part does not contain head tag. Should be the same
         actual = "<html><head></head><body><div></div></body></html>";
         expected = "<html><body><div></div></body></html>";
-        assertTrue(HtmlHelper.assertSameHtml(expected, actual, true, false));
+        assertTrue(HtmlHelper.areSameHtml(expected, actual, true));
         
         //one part does not contain body tag. Should be the same
         actual = "<html><head></head><body><div></div></body></html>";
         expected = "<html><head></head><div></div></html>";
-        assertTrue(HtmlHelper.assertSameHtml(expected, actual, true, false));
+        assertTrue(HtmlHelper.areSameHtml(expected, actual, true));
         
         //Different tool tips. Will be ignored (the logic does not detect this)
         actual = "<html><head></head><body><div class=\"tooltip\">tool tip <br> 2nd line </div></body></html>";
         expected = "<html><head></head><body><div class=\"tooltip\"></div></body></html>";
-        assertTrue(HtmlHelper.assertSameHtml(expected, actual, true, false));
+        assertTrue(HtmlHelper.areSameHtml(expected, actual, true));
         
         //Different tool tips and three tags(html, head, body) ignored. Should be the same
         actual = "<html><head></head><body><div class=\"tooltip\">tool tip <br> 2nd line </div></body></html>";
         expected = "<div class=\"tooltip\"></div>";
-        assertTrue(HtmlHelper.assertSameHtml(expected, actual, true, false));
+        assertTrue(HtmlHelper.areSameHtml(expected, actual, true));
         
         //Contents inside div are different . Should be different
         actual = "<html><head></head><body><div>content<br> 2nd line </div></body></html>";
         expected = "<html><head></head><body><div></div></body></html>";
-        assertFalse(HtmlHelper.assertSameHtml(expected, actual, true, false));
+        assertFalse(HtmlHelper.areSameHtml(expected, actual, true));
         
         //Test against areSameHtml
         actual = "<html><head><script></script></head><body><div></div></body></html>";
         expected = "<html><head></head><body><script></script><div></div></body></html>";
-        assertTrue(HtmlHelper.assertSameHtml(expected, actual, true, false));
+        assertTrue(HtmlHelper.areSameHtml(expected, actual, true));
         
         //Same html structure
         expected = FileHelper.readFile(TestProperties.TEST_PAGES_FOLDER +"/sampleExpected.html");
         actual = FileHelper.readFile(TestProperties.TEST_PAGES_FOLDER +"/sampleActual.html");
-        HtmlHelper.assertSameHtml(expected, actual, true, true);
+        HtmlHelper.assertSameHtml(expected, actual, true);
         
         //Same after ignoring html & head & body tag
         expected = FileHelper.readFile(TestProperties.TEST_PAGES_FOLDER +"/sampleExpected.html");
         actual = FileHelper.readFile(TestProperties.TEST_PAGES_FOLDER +"/sampleActualPart.html");
-        HtmlHelper.assertSameHtml(expected, actual, true, true);
+        HtmlHelper.assertSameHtml(expected, actual, true);
         
         //other cases are tested in testComparison
     }

--- a/src/test/java/teammates/test/driver/HtmlHelper.java
+++ b/src/test/java/teammates/test/driver/HtmlHelper.java
@@ -23,17 +23,31 @@ public class HtmlHelper {
 
     /**
      * Verifies that two HTML files are logically equivalent, e.g. ignores
+     * differences in whitespace and attribute order. If the assertion fails,
+     * <code>AssertionError</code> will be thrown and the difference can then be traced.
+     * @param expectedString the expected string for comparison
+     * @param actualString the actual string for comparison
+     * @param isPart if true, ignores top-level HTML tags, i.e <code>&lt;html&gt;</code>,
+     *               <code>&lt;head&gt;</code>, and <code>&lt;body&gt;</code>
+     */
+    public static boolean assertSameHtml(String expected, String actual, boolean isPart) {
+        return assertSameHtml(expected, actual, isPart, true);
+    }
+    
+    /**
+     * Verifies that two HTML files are logically equivalent, e.g. ignores
      * differences in whitespace and attribute order.
      * @param expectedString the expected string for comparison
      * @param actualString the actual string for comparison
      * @param isPart if true, ignores top-level HTML tags, i.e <code>&lt;html&gt;</code>,
      *               <code>&lt;head&gt;</code>, and <code>&lt;body&gt;</code>
-     * @param isDifferenceToBeShown if true, whenever the assertion fails,
-     *                              <code>AssertionError</code> will be thrown and
-     *                              the difference can then be traced
      */
-    public static boolean assertSameHtml(String expected, String actual, boolean isPart,
-                                         boolean isDifferenceToBeShown) {
+    public static boolean areSameHtml(String expected, String actual, boolean isPart) {
+        return assertSameHtml(expected, actual, isPart, false);
+    }
+    
+    private static boolean assertSameHtml(String expected, String actual, boolean isPart,
+                                          boolean isDifferenceToBeShown) {
         String processedExpected = convertToStandardHtml(expected, isPart);
         String processedActual = convertToStandardHtml(actual, isPart);
 

--- a/src/test/java/teammates/test/driver/HtmlHelper.java
+++ b/src/test/java/teammates/test/driver/HtmlHelper.java
@@ -22,53 +22,31 @@ import teammates.test.pageobjects.AppPage;
 public class HtmlHelper {
 
     /**
-     * Verifies that two HTML files are logically 
-     * equivalent e.g., ignores differences in whitespace and attribute order.
+     * Verifies that two HTML files are logically equivalent, e.g. ignores
+     * differences in whitespace and attribute order.
+     * @param expectedString the expected string for comparison
+     * @param actualString the actual string for comparison
+     * @param isPart if true, ignores top-level HTML tags, i.e <code>&lt;html&gt;</code>,
+     *               <code>&lt;head&gt;</code>, and <code>&lt;body&gt;</code>
+     * @param isDifferenceToBeShown if true, whenever the assertion fails,
+     *                              <code>AssertionError</code> will be thrown and
+     *                              the difference can then be traced
      */
-    //TODO: for the following 4 methods, change the order of parameters passed in
-    //      should be expectedString, acutalString
-    public static void assertSameHtml(String actualString, String expectedString){       
-        String processedExpectedHtml = convertToStandardHtml(expectedString, false);
-        String processedActualHtml = convertToStandardHtml(actualString, false);
-        
-        if(!AssertHelper.isContainsRegex(processedExpectedHtml, processedActualHtml)){
-            processedActualHtml = AppPage.processPageSourceForFailureCase(processedActualHtml);
-            processedExpectedHtml = AppPage.processPageSourceForFailureCase(processedExpectedHtml);
-            assertEquals("<expected>\n"+processedExpectedHtml+"</expected>", "<actual>\n"+processedActualHtml+"</actual>");
-        }
-    }
-    
-    public static void assertSameHtmlPart(String actualString, String expectedString) {
-        String processedExpectedHtmlPart = convertToStandardHtml(expectedString, true);
-        String processedActualHtmlPart = convertToStandardHtml(actualString, true);
-        
-        if(!AssertHelper.isContainsRegex(processedExpectedHtmlPart, processedActualHtmlPart)){
-            processedActualHtmlPart = AppPage.processPageSourceForFailureCase(processedActualHtmlPart);
-            processedExpectedHtmlPart = AppPage.processPageSourceForFailureCase(processedExpectedHtmlPart);
-            assertEquals("<expected>\n"+processedExpectedHtmlPart+"</expected>", "<actual>\n"+processedActualHtmlPart+"</actual>");
-        }
-    }
+    public static boolean assertSameHtml(String expected, String actual, boolean isPart,
+                                         boolean isDifferenceToBeShown) {
+        String processedExpected = convertToStandardHtml(expected, isPart);
+        String processedActual = convertToStandardHtml(actual, isPart);
 
-    /**
-     * Verifies that two HTML files are logically 
-     * equivalent e.g., ignores differences in whitespace and attribute order.
-     */
-    public static boolean areSameHtml(String actualString, String expectedString){
-        String processedExpectedHtml = convertToStandardHtml(expectedString, false);
-        String processedActualHtml = convertToStandardHtml(actualString, false);
-        
-        return AssertHelper.isContainsRegex(processedExpectedHtml, processedActualHtml);
-    }
-    
-    /**
-     * Verifies that two HTML parts are logically 
-     * equivalent e.g., ignores differences in whitespace and attribute order.
-     */
-    public static boolean areSameHtmlPart(String actualString, String expectedString){
-        String processedExpectedHtml = convertToStandardHtml(expectedString, true);
-        String processedActualHtml = convertToStandardHtml(actualString, true);
-        
-        return AssertHelper.isContainsRegex(processedExpectedHtml, processedActualHtml);
+        if (!AssertHelper.isContainsRegex(processedExpected, processedActual)) {
+            if (isDifferenceToBeShown) {
+                processedActual = AppPage.processPageSourceForFailureCase(processedActual);
+                processedExpected = AppPage.processPageSourceForFailureCase(processedExpected);
+                assertEquals("<expected>\n" + processedExpected + "</expected>",
+                             "<actual>\n" + processedActual + "</actual>");
+            }
+            return false;
+        }
+        return true;
     }
 
     /**

--- a/src/test/java/teammates/test/pageobjects/AppPage.java
+++ b/src/test/java/teammates/test/pageobjects/AppPage.java
@@ -751,14 +751,14 @@ public abstract class AppPage {
                 int maxRetryCount = 5;
                 int waitDuration = 1000;
                 for (int i = 0; i < maxRetryCount; i++) {
-                    if (HtmlHelper.assertSameHtml(expected, actual, isPart, false)) {
+                    if (HtmlHelper.areSameHtml(expected, actual, isPart)) {
                         break;
                     }
                     ThreadHelper.waitFor(waitDuration);
                     actual = getPageSource(by);
                 }
             }
-            HtmlHelper.assertSameHtml(expected, actual, isPart, true);
+            HtmlHelper.assertSameHtml(expected, actual, isPart);
             
         } catch (Exception e) {
             if (!testAndRunGodMode(filePath, actual, isPart)) {

--- a/src/test/java/teammates/test/pageobjects/AppPage.java
+++ b/src/test/java/teammates/test/pageobjects/AppPage.java
@@ -742,7 +742,7 @@ public abstract class AppPage {
         actual = processPageSourceForGodMode(actual);
         try {
             String expected = FileHelper.readFile(filePath);
-            HtmlHelper.assertSameHtml(actual, expected);
+            HtmlHelper.assertSameHtml(expected, actual, false, true);
             
         } catch (Exception e) {
             if (!testAndRunGodMode(filePath, actual, false)) {
@@ -874,7 +874,7 @@ public abstract class AppPage {
         actual = processPageSourceForGodMode(actual);
         try {
             String expected = FileHelper.readFile(filePath);
-            HtmlHelper.assertSameHtmlPart(actual, expected);            
+            HtmlHelper.assertSameHtml(expected, actual, true, true);
         } catch (AssertionError ae) { 
             if(!testAndRunGodMode(filePath, actual, true)) {
                 throw ae;
@@ -953,7 +953,7 @@ public abstract class AppPage {
             for(int i =0; i < maxRetryCount; i++) {
                 actual = browser.driver.findElement(By.id("mainContent")).getAttribute("outerHTML");
                 actual = processPageSourceForGodMode(actual);
-                if(HtmlHelper.areSameHtml(actual, expectedString)) {
+                if (HtmlHelper.assertSameHtml(expectedString, actual, true, false)) {
                     break;
                 } else {
                     testAndRunGodMode(filePath, actual, true);

--- a/src/test/java/teammates/test/pageobjects/AppPage.java
+++ b/src/test/java/teammates/test/pageobjects/AppPage.java
@@ -62,6 +62,7 @@ public abstract class AppPage {
     protected static Logger log = Utils.getLogger();
     /**Home page of the application, as per test.properties file*/
     protected static final String HOMEPAGE = TestProperties.inst().TEAMMATES_URL;
+    private static final By MAIN_CONTENT = By.id("mainContent");
     
     static final long ONE_MINUTE_IN_MILLIS=60000;
     
@@ -743,10 +744,7 @@ public abstract class AppPage {
             filePath = TestProperties.TEST_PAGES_FOLDER + filePath;
         }
         boolean isPart = by != null;
-        waitForAjaxLoaderGifToDisappear();
-        String actual = isPart ? getPageSource()
-                               : browser.driver.findElement(by).getAttribute("outerHTML");
-        actual = processPageSourceForGodMode(actual);
+        String actual = getPageSource(by);
         try {
             String expected = FileHelper.readFile(filePath);
             if (isAfterAjaxLoad) {
@@ -757,9 +755,7 @@ public abstract class AppPage {
                         break;
                     }
                     ThreadHelper.waitFor(waitDuration);
-                    actual = isPart ? getPageSource()
-                                    : browser.driver.findElement(by).getAttribute("outerHTML");
-                    actual = processPageSourceForGodMode(actual);
+                    actual = getPageSource(by);
                 }
             }
             HtmlHelper.assertSameHtml(expected, actual, isPart, true);
@@ -775,6 +771,13 @@ public abstract class AppPage {
         } 
         
         return this;
+    }
+
+    private String getPageSource(By by) {
+        waitForAjaxLoaderGifToDisappear();
+        String actual = by == null ? getPageSource()
+                                   : browser.driver.findElement(by).getAttribute("outerHTML");
+        return processPageSourceForGodMode(actual);
     }
 
     private boolean testAndRunGodMode(String filePath, String content, boolean isPart) {
@@ -899,7 +902,7 @@ public abstract class AppPage {
      * @return The page (for chaining method calls).
      */
     public AppPage verifyHtmlMainContent(String filePath) {
-        return verifyHtmlPart(By.id("mainContent"), filePath);
+        return verifyHtmlPart(MAIN_CONTENT, filePath);
     }
     
     /**
@@ -914,7 +917,7 @@ public abstract class AppPage {
      * @return The page (for chaining method calls).
      */
     public AppPage verifyHtmlAjaxMainContent(String filePath) throws Exception {
-        return verifyHtml(By.id("mainContent"), filePath, true);
+        return verifyHtml(MAIN_CONTENT, filePath, true);
     }
 
     /**


### PR DESCRIPTION
Fixes #4470 
- In `assertSameHtml` two extra params are introduced: `isPart` and `isDifferenceToBeShown`. Setting `isPart` to be true gives `*SameHtmlPart` in place of `*SameHtml` and setting `isDifferenceToBeShown` to be true gives `assert*` in place of `are*`.
- In `verifyHtml`, also two extra params are introduced: `by` and `isAfterAjaxLoad`. Setting `by` to be non-null gives `verify*Part/MainContent` and setting `isAfterAjaxLoad` to be true gives `verifyHtmlAjax*`. Just realized we don't have `verifyHtmlAjaxPart` :p (not needed for now though).