### PR TITLE
Add support for more time zones #4467

### DIFF
--- a/src/main/java/teammates/common/util/Const.java
+++ b/src/main/java/teammates/common/util/Const.java
@@ -1188,10 +1188,6 @@ public class Const {
     public static final Date TIME_REPRESENTS_LATER;
     public static final Date TIME_REPRESENTS_NOW;
     
-    public static final double[] TIME_ZONE_VALUES = { -12, -11, -10, -9.5, -9, -8,
-            -7, -6, -5, -4.5, -4, -3.5, -3, -2, -1, 0, 1, 2, 3, 3.5, 4, 4.5, 5, 5.5,
-            5.75, 6, 6.5, 7, 8, 8.75, 9, 9.5, 10, 10.5, 11, 12, 12.75, 13, 14 };
-    
     static {
         TIME_REPRESENTS_FOLLOW_OPENING = TimeHelper.convertToDate("1970-12-31 00:00 AM UTC");
         TIME_REPRESENTS_FOLLOW_VISIBLE = TimeHelper.convertToDate("1970-06-22 00:00 AM UTC");

--- a/src/main/java/teammates/common/util/Const.java
+++ b/src/main/java/teammates/common/util/Const.java
@@ -1188,9 +1188,9 @@ public class Const {
     public static final Date TIME_REPRESENTS_LATER;
     public static final Date TIME_REPRESENTS_NOW;
     
-    public static final double[] TIME_ZONE_VALUES = { -12, -11, -10, -9, -8,
-            -7, -6, -5, -4.5, -4, -3.5, -3, -2, -1, 0, 1, 2, 3, 3.5, 4, 4.5, 5,
-            5.75, 6, 7, 8, 9, 10, 11, 12, 13 };
+    public static final double[] TIME_ZONE_VALUES = { -12, -11, -10, -9.5, -9, -8,
+            -7, -6, -5, -4.5, -4, -3.5, -3, -2, -1, 0, 1, 2, 3, 3.5, 4, 4.5, 5, 5.5,
+            5.75, 6, 6.5, 7, 8, 8.75, 9, 9.5, 10, 10.5, 11, 12, 12.75, 13, 14 };
     
     static {
         TIME_REPRESENTS_FOLLOW_OPENING = TimeHelper.convertToDate("1970-12-31 00:00 AM UTC");

--- a/src/main/java/teammates/common/util/TimeHelper.java
+++ b/src/main/java/teammates/common/util/TimeHelper.java
@@ -3,10 +3,13 @@ package teammates.common.util;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.TimeZone;
 
 import teammates.common.util.Const.SystemParams;
@@ -16,7 +19,8 @@ import teammates.common.util.Const.SystemParams;
  */
 public class TimeHelper {
     
-    private static HashMap<String, String> timeZoneCitysMap = new HashMap<String, String>();
+    private static final Map<String, String> TIME_ZONE_CITIES_MAP = new HashMap<String, String>();
+    private static final List<Double> TIME_ZONE_VALUES = new ArrayList<Double>();
     
     /*
      *This time zone - city map was created by selecting major cities from each time zone.
@@ -69,14 +73,17 @@ public class TimeHelper {
     }
         
     private static void map(String timeZone, String cities) {
-        timeZoneCitysMap.put(timeZone, cities);
+        TIME_ZONE_CITIES_MAP.put(timeZone, cities);
+        TIME_ZONE_VALUES.add(Double.parseDouble(timeZone));
     }
     
     public static String getCitiesForTimeZone(String zone){
-        return timeZoneCitysMap.get(zone);        
+        return TIME_ZONE_CITIES_MAP.get(zone);
     }
 
-    
+    public static List<Double> getTimeZoneValues() {
+        return new ArrayList<Double>(TIME_ZONE_VALUES);
+    }
     
     /**
      * Returns the current date and time as a {@code Calendar} object for the given timezone.

--- a/src/main/java/teammates/common/util/TimeHelper.java
+++ b/src/main/java/teammates/common/util/TimeHelper.java
@@ -28,7 +28,8 @@ public class TimeHelper {
     static{
         map("-12.0", "Baker Island, Howland Island");
         map("-11.0", "American Samoa, Niue");
-        map("-10.0", "Hawaii, Cook Islands, Marquesas Islands");
+        map("-10.0", "Hawaii, Cook Islands");
+        map("-9.5", "Marquesas Islands");
         map("-9.0", "Gambier Islands, Alaska");
         map("-8.0", "Los Angeles, Vancouver, Tijuana");
         map("-7.0", "Phoenix, Calgary, Ciudad Juárez");
@@ -51,13 +52,19 @@ public class TimeHelper {
         map("5.5", "Colombo, Delhi");
         map("5.75", "Kathmandu");
         map("6.0", "Almaty, Dhaka, Yekaterinburg");
+        map("6.5", "Yangon");
         map("7.0", "Jakarta, Bangkok, Novosibirsk, Hanoi");
         map("8.0", "Perth, Beijing, Manila, Singapore, Kuala Lumpur, Denpasar, Krasnoyarsk");
+        map("8.75", "Eucla");
         map("9.0", "Seoul, Tokyo, Pyongyang, Ambon, Irkutsk");
+        map("9.5", "Adelaide");
         map("10.0", "Canberra, Yakutsk, Port Moresby");
+        map("10.5", "Lord Howe Islands");
         map("11.0", "Vladivostok, Noumea");
         map("12.0", "Auckland, Suva");
+        map("12.75", "Chatham Islands");
         map("13.0", "Phoenix Islands, Tokelau, Tonga");
+        map("14.0", "Line Islands");
         
     }
         

--- a/src/main/java/teammates/ui/controller/PageData.java
+++ b/src/main/java/teammates/ui/controller/PageData.java
@@ -180,36 +180,36 @@ public class PageData {
      * None is selected, since the selection should only be done in client side.
      */
     protected ArrayList<String> getTimeZoneOptionsAsHtml(double existingTimeZone) {
-        double[] options = Const.TIME_ZONE_VALUES;
+       List<Double> options = TimeHelper.getTimeZoneValues();
        ArrayList<String> result = new ArrayList<String>();
        if (existingTimeZone == Const.DOUBLE_UNINITIALIZED) {
            result.add("<option value=\"" + Const.INT_UNINITIALIZED + "\" selected=\"selected\"></option>");
        }
-       for (int i = 0; i < options.length; i++) {
-           String utcFormatOption = StringHelper.toUtcFormat(options[i]);      
-           result.add("<option value=\"" + formatAsString(options[i]) + "\"" 
-                      + (existingTimeZone == options[i] ? " selected=\"selected\"" : "") + ">" + "(" + utcFormatOption 
-                      + ") " + TimeHelper.getCitiesForTimeZone(Double.toString(options[i])) + "</option>");
+       for (Double timeZoneOption : options) {
+           String utcFormatOption = StringHelper.toUtcFormat(timeZoneOption);      
+           result.add("<option value=\"" + formatAsString(timeZoneOption) + "\"" 
+                      + (existingTimeZone == timeZoneOption ? " selected=\"selected\"" : "") + ">" + "(" + utcFormatOption 
+                      + ") " + TimeHelper.getCitiesForTimeZone(Double.toString(timeZoneOption)) + "</option>");
        }
        return result;
     }
     
     public static List<ElementTag> getTimeZoneOptionsAsElementTags(double existingTimeZone) {
-        double[] options = Const.TIME_ZONE_VALUES;
+        List<Double> options = TimeHelper.getTimeZoneValues();
         ArrayList<ElementTag> result = new ArrayList<ElementTag>();
         if (existingTimeZone == Const.DOUBLE_UNINITIALIZED) {
             ElementTag option = createOption("", String.valueOf(Const.INT_UNINITIALIZED), false);
             result.add(option);
         }
         
-        for (int i = 0; i < options.length; i++) {
-            String utcFormatOption = StringHelper.toUtcFormat(options[i]);
+        for (Double timeZoneOption : options) {
+            String utcFormatOption = StringHelper.toUtcFormat(timeZoneOption);
             String textToDisplay = "(" + utcFormatOption 
-                                            + ") " + TimeHelper.getCitiesForTimeZone(Double.toString(options[i]));
-            boolean isExistingTimeZone = (existingTimeZone == options[i]);
+                                            + ") " + TimeHelper.getCitiesForTimeZone(Double.toString(timeZoneOption));
+            boolean isExistingTimeZone = (existingTimeZone == timeZoneOption);
             
             ElementTag option = createOption(textToDisplay, 
-                                            formatAsString(options[i]), isExistingTimeZone);
+                                             formatAsString(timeZoneOption), isExistingTimeZone);
             result.add(option);
         }
         return result;

--- a/src/main/java/teammates/ui/controller/PageData.java
+++ b/src/main/java/teammates/ui/controller/PageData.java
@@ -180,8 +180,7 @@ public class PageData {
      * None is selected, since the selection should only be done in client side.
      */
     protected ArrayList<String> getTimeZoneOptionsAsHtml(double existingTimeZone) {
-        double[] options = new double[] {-12, -11, -10, -9, -8, -7, -6, -5, -4.5, -4, -3.5, -3, -2, -1, 0, 1, 2, 3, 
-                                        3.5, 4, 4.5, 5, 5.5, 5.75, 6, 7, 8, 9, 10, 11, 12, 13};
+        double[] options = Const.TIME_ZONE_VALUES;
        ArrayList<String> result = new ArrayList<String>();
        if (existingTimeZone == Const.DOUBLE_UNINITIALIZED) {
            result.add("<option value=\"" + Const.INT_UNINITIALIZED + "\" selected=\"selected\"></option>");
@@ -196,8 +195,7 @@ public class PageData {
     }
     
     public static List<ElementTag> getTimeZoneOptionsAsElementTags(double existingTimeZone) {
-        double[] options = new double[] {-12, -11, -10, -9, -8, -7, -6, -5, -4.5, -4, -3.5, -3, -2, -1, 0, 1, 2, 3, 
-                                         3.5, 4, 4.5, 5, 5.5, 5.75, 6, 7, 8, 9, 10, 11, 12, 13};
+        double[] options = Const.TIME_ZONE_VALUES;
         ArrayList<ElementTag> result = new ArrayList<ElementTag>();
         if (existingTimeZone == Const.DOUBLE_UNINITIALIZED) {
             ElementTag option = createOption("", String.valueOf(Const.INT_UNINITIALIZED), false);

--- a/src/main/webapp/instructorHelp.html
+++ b/src/main/webapp/instructorHelp.html
@@ -1412,7 +1412,8 @@
                                                                 <select class="form-control" name="timezone" id="timezone">
                                                                     <option value="-12">(UTC -12:00) Baker Island, Howland Island</option>
                                                                     <option value="-11">(UTC -11:00) American Samoa, Niue</option>
-                                                                    <option value="-10">(UTC -10:00) Hawaii, Cook Islands, Marquesas Islands</option>
+                                                                    <option value="-10">(UTC -10:00) Hawaii, Cook Islands</option>
+                                                                    <option value="-9.5">(UTC -09:30) Marquesas Islands</option>
                                                                     <option value="-9">(UTC -09:00) Gambier Islands, Alaska</option>
                                                                     <option value="-8">(UTC -08:00) Los Angeles, Vancouver, Tijuana</option>
                                                                     <option value="-7">(UTC -07:00) Phoenix, Calgary, Ciudad Juárez</option>
@@ -1435,13 +1436,19 @@
                                                                     <option value="5.5">(UTC +05:30) Colombo, Delhi</option>
                                                                     <option value="5.75">(UTC +05:45) Kathmandu</option>
                                                                     <option value="6">(UTC +06:00) Almaty, Dhaka, Yekaterinburg</option>
+                                                                    <option value="6.5">(UTC +06:30) Yangon</option>
                                                                     <option value="7">(UTC +07:00) Jakarta, Bangkok, Novosibirsk, Hanoi</option>
                                                                     <option value="8">(UTC +08:00) Perth, Beijing, Manila, Singapore, Kuala Lumpur, Denpasar, Krasnoyarsk</option>
+                                                                    <option value="8.75">(UTC +08:45) Eucla</option>
                                                                     <option value="9">(UTC +09:00) Seoul, Tokyo, Pyongyang, Ambon, Irkutsk</option>
+                                                                    <option value="9.5">(UTC +09:30) Adelaide</option>
                                                                     <option value="10">(UTC +10:00) Canberra, Yakutsk, Port Moresby</option>
+                                                                    <option value="10.5">(UTC +10:30) Lord Howe Islands</option>
                                                                     <option value="11">(UTC +11:00) Vladivostok, Noumea</option>
                                                                     <option value="12">(UTC +12:00) Auckland, Suva</option>
+                                                                    <option value="12.75">(UTC +12:45) Chatham Islands</option>
                                                                     <option value="13">(UTC +13:00) Phoenix Islands, Tokelau, Tonga</option>
+                                                                    <option value="14">(UTC +14:00) Line Islands</option>
 
                                                                 </select>
                                                             </div>

--- a/src/test/java/teammates/test/cases/ui/pagedata/InstructorFeedbacksPageDataTest.java
+++ b/src/test/java/teammates/test/cases/ui/pagedata/InstructorFeedbacksPageDataTest.java
@@ -103,7 +103,7 @@ public class InstructorFeedbacksPageDataTest extends BaseTestCase {
         assertEquals(NUMBER_OF_HOURS_IN_DAY, formModel.getAdditionalSettings().getResponseVisibleTimeOptions().size());
         assertEquals("", formModel.getAdditionalSettings().getSessionVisibleDateValue());
         assertEquals(NUMBER_OF_HOURS_IN_DAY, formModel.getAdditionalSettings().getSessionVisibleTimeOptions().size());
-        assertEquals(33, formModel.getTimezoneSelectField().size());
+        assertEquals(40, formModel.getTimezoneSelectField().size());
         
         assertTrue(formModel.getAdditionalSettings().isResponseVisiblePublishManuallyChecked());
         assertFalse(formModel.getAdditionalSettings().isResponseVisibleDateChecked());

--- a/src/test/resources/pages/instructorFeedbackAddSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackAddSuccess.html
@@ -61,7 +61,10 @@
                                     (UTC -11:00) American Samoa, Niue
                                  </option>
                                  <option value="-10">
-                                    (UTC -10:00) Hawaii, Cook Islands, Marquesas Islands
+                                    (UTC -10:00) Hawaii, Cook Islands
+                                 </option>
+                                 <option value="-9.5">
+                                    (UTC -09:30) Marquesas Islands
                                  </option>
                                  <option value="-9">
                                     (UTC -09:00) Gambier Islands, Alaska
@@ -129,17 +132,29 @@
                                  <option value="6">
                                     (UTC +06:00) Almaty, Dhaka, Yekaterinburg
                                  </option>
+                                 <option value="6.5">
+                                    (UTC +06:30) Yangon
+                                 </option>
                                  <option value="7">
                                     (UTC +07:00) Jakarta, Bangkok, Novosibirsk, Hanoi
                                  </option>
                                  <option selected="selected" value="8">
                                     (UTC +08:00) Perth, Beijing, Manila, Singapore, Kuala Lumpur, Denpasar, Krasnoyarsk
                                  </option>
+                                 <option value="8.75">
+                                    (UTC +08:45) Eucla
+                                 </option>
                                  <option value="9">
                                     (UTC +09:00) Seoul, Tokyo, Pyongyang, Ambon, Irkutsk
                                  </option>
+                                 <option value="9.5">
+                                    (UTC +09:30) Adelaide
+                                 </option>
                                  <option value="10">
                                     (UTC +10:00) Canberra, Yakutsk, Port Moresby
+                                 </option>
+                                 <option value="10.5">
+                                    (UTC +10:30) Lord Howe Islands
                                  </option>
                                  <option value="11">
                                     (UTC +11:00) Vladivostok, Noumea
@@ -147,8 +162,14 @@
                                  <option value="12">
                                     (UTC +12:00) Auckland, Suva
                                  </option>
+                                 <option value="12.75">
+                                    (UTC +12:45) Chatham Islands
+                                 </option>
                                  <option value="13">
                                     (UTC +13:00) Phoenix Islands, Tokelau, Tonga
+                                 </option>
+                                 <option value="14">
+                                    (UTC +14:00) Line Islands
                                  </option>
                               </select>
                            </div>

--- a/src/test/resources/pages/instructorFeedbackAllSessionTypes.html
+++ b/src/test/resources/pages/instructorFeedbackAllSessionTypes.html
@@ -79,7 +79,10 @@
                                     (UTC -11:00) American Samoa, Niue
                                  </option>
                                  <option value="-10">
-                                    (UTC -10:00) Hawaii, Cook Islands, Marquesas Islands
+                                    (UTC -10:00) Hawaii, Cook Islands
+                                 </option>
+                                 <option value="-9.5">
+                                    (UTC -09:30) Marquesas Islands
                                  </option>
                                  <option value="-9">
                                     (UTC -09:00) Gambier Islands, Alaska
@@ -147,17 +150,29 @@
                                  <option value="6">
                                     (UTC +06:00) Almaty, Dhaka, Yekaterinburg
                                  </option>
+                                 <option value="6.5">
+                                    (UTC +06:30) Yangon
+                                 </option>
                                  <option value="7">
                                     (UTC +07:00) Jakarta, Bangkok, Novosibirsk, Hanoi
                                  </option>
                                  <option value="8">
                                     (UTC +08:00) Perth, Beijing, Manila, Singapore, Kuala Lumpur, Denpasar, Krasnoyarsk
                                  </option>
+                                 <option value="8.75">
+                                    (UTC +08:45) Eucla
+                                 </option>
                                  <option value="9">
                                     (UTC +09:00) Seoul, Tokyo, Pyongyang, Ambon, Irkutsk
                                  </option>
+                                 <option value="9.5">
+                                    (UTC +09:30) Adelaide
+                                 </option>
                                  <option value="10">
                                     (UTC +10:00) Canberra, Yakutsk, Port Moresby
+                                 </option>
+                                 <option value="10.5">
+                                    (UTC +10:30) Lord Howe Islands
                                  </option>
                                  <option value="11">
                                     (UTC +11:00) Vladivostok, Noumea
@@ -165,8 +180,14 @@
                                  <option value="12">
                                     (UTC +12:00) Auckland, Suva
                                  </option>
+                                 <option value="12.75">
+                                    (UTC +12:45) Chatham Islands
+                                 </option>
                                  <option value="13">
                                     (UTC +13:00) Phoenix Islands, Tokelau, Tonga
+                                 </option>
+                                 <option value="14">
+                                    (UTC +14:00) Line Islands
                                  </option>
                               </select>
                            </div>

--- a/src/test/resources/pages/instructorFeedbackAllSessionTypesWithHelperView.html
+++ b/src/test/resources/pages/instructorFeedbackAllSessionTypesWithHelperView.html
@@ -76,7 +76,10 @@
                                     (UTC -11:00) American Samoa, Niue
                                  </option>
                                  <option value="-10">
-                                    (UTC -10:00) Hawaii, Cook Islands, Marquesas Islands
+                                    (UTC -10:00) Hawaii, Cook Islands
+                                 </option>
+                                 <option value="-9.5">
+                                    (UTC -09:30) Marquesas Islands
                                  </option>
                                  <option value="-9">
                                     (UTC -09:00) Gambier Islands, Alaska
@@ -144,17 +147,29 @@
                                  <option value="6">
                                     (UTC +06:00) Almaty, Dhaka, Yekaterinburg
                                  </option>
+                                 <option value="6.5">
+                                    (UTC +06:30) Yangon
+                                 </option>
                                  <option value="7">
                                     (UTC +07:00) Jakarta, Bangkok, Novosibirsk, Hanoi
                                  </option>
                                  <option value="8">
                                     (UTC +08:00) Perth, Beijing, Manila, Singapore, Kuala Lumpur, Denpasar, Krasnoyarsk
                                  </option>
+                                 <option value="8.75">
+                                    (UTC +08:45) Eucla
+                                 </option>
                                  <option value="9">
                                     (UTC +09:00) Seoul, Tokyo, Pyongyang, Ambon, Irkutsk
                                  </option>
+                                 <option value="9.5">
+                                    (UTC +09:30) Adelaide
+                                 </option>
                                  <option value="10">
                                     (UTC +10:00) Canberra, Yakutsk, Port Moresby
+                                 </option>
+                                 <option value="10.5">
+                                    (UTC +10:30) Lord Howe Islands
                                  </option>
                                  <option value="11">
                                     (UTC +11:00) Vladivostok, Noumea
@@ -162,8 +177,14 @@
                                  <option value="12">
                                     (UTC +12:00) Auckland, Suva
                                  </option>
+                                 <option value="12.75">
+                                    (UTC +12:45) Chatham Islands
+                                 </option>
                                  <option value="13">
                                     (UTC +13:00) Phoenix Islands, Tokelau, Tonga
+                                 </option>
+                                 <option value="14">
+                                    (UTC +14:00) Line Islands
                                  </option>
                               </select>
                            </div>

--- a/src/test/resources/pages/instructorFeedbackConstSumOptionQuestionAddSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackConstSumOptionQuestionAddSuccess.html
@@ -61,7 +61,10 @@
                                     (UTC -11:00) American Samoa, Niue
                                  </option>
                                  <option value="-10">
-                                    (UTC -10:00) Hawaii, Cook Islands, Marquesas Islands
+                                    (UTC -10:00) Hawaii, Cook Islands
+                                 </option>
+                                 <option value="-9.5">
+                                    (UTC -09:30) Marquesas Islands
                                  </option>
                                  <option value="-9">
                                     (UTC -09:00) Gambier Islands, Alaska
@@ -129,17 +132,29 @@
                                  <option value="6">
                                     (UTC +06:00) Almaty, Dhaka, Yekaterinburg
                                  </option>
+                                 <option value="6.5">
+                                    (UTC +06:30) Yangon
+                                 </option>
                                  <option value="7">
                                     (UTC +07:00) Jakarta, Bangkok, Novosibirsk, Hanoi
                                  </option>
                                  <option value="8">
                                     (UTC +08:00) Perth, Beijing, Manila, Singapore, Kuala Lumpur, Denpasar, Krasnoyarsk
                                  </option>
+                                 <option value="8.75">
+                                    (UTC +08:45) Eucla
+                                 </option>
                                  <option value="9">
                                     (UTC +09:00) Seoul, Tokyo, Pyongyang, Ambon, Irkutsk
                                  </option>
+                                 <option value="9.5">
+                                    (UTC +09:30) Adelaide
+                                 </option>
                                  <option value="10">
                                     (UTC +10:00) Canberra, Yakutsk, Port Moresby
+                                 </option>
+                                 <option value="10.5">
+                                    (UTC +10:30) Lord Howe Islands
                                  </option>
                                  <option value="11">
                                     (UTC +11:00) Vladivostok, Noumea
@@ -147,8 +162,14 @@
                                  <option value="12">
                                     (UTC +12:00) Auckland, Suva
                                  </option>
+                                 <option value="12.75">
+                                    (UTC +12:45) Chatham Islands
+                                 </option>
                                  <option value="13">
                                     (UTC +13:00) Phoenix Islands, Tokelau, Tonga
+                                 </option>
+                                 <option value="14">
+                                    (UTC +14:00) Line Islands
                                  </option>
                               </select>
                            </div>

--- a/src/test/resources/pages/instructorFeedbackConstSumOptionQuestionEditSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackConstSumOptionQuestionEditSuccess.html
@@ -61,7 +61,10 @@
                                     (UTC -11:00) American Samoa, Niue
                                  </option>
                                  <option value="-10">
-                                    (UTC -10:00) Hawaii, Cook Islands, Marquesas Islands
+                                    (UTC -10:00) Hawaii, Cook Islands
+                                 </option>
+                                 <option value="-9.5">
+                                    (UTC -09:30) Marquesas Islands
                                  </option>
                                  <option value="-9">
                                     (UTC -09:00) Gambier Islands, Alaska
@@ -129,17 +132,29 @@
                                  <option value="6">
                                     (UTC +06:00) Almaty, Dhaka, Yekaterinburg
                                  </option>
+                                 <option value="6.5">
+                                    (UTC +06:30) Yangon
+                                 </option>
                                  <option value="7">
                                     (UTC +07:00) Jakarta, Bangkok, Novosibirsk, Hanoi
                                  </option>
                                  <option value="8">
                                     (UTC +08:00) Perth, Beijing, Manila, Singapore, Kuala Lumpur, Denpasar, Krasnoyarsk
                                  </option>
+                                 <option value="8.75">
+                                    (UTC +08:45) Eucla
+                                 </option>
                                  <option value="9">
                                     (UTC +09:00) Seoul, Tokyo, Pyongyang, Ambon, Irkutsk
                                  </option>
+                                 <option value="9.5">
+                                    (UTC +09:30) Adelaide
+                                 </option>
                                  <option value="10">
                                     (UTC +10:00) Canberra, Yakutsk, Port Moresby
+                                 </option>
+                                 <option value="10.5">
+                                    (UTC +10:30) Lord Howe Islands
                                  </option>
                                  <option value="11">
                                     (UTC +11:00) Vladivostok, Noumea
@@ -147,8 +162,14 @@
                                  <option value="12">
                                     (UTC +12:00) Auckland, Suva
                                  </option>
+                                 <option value="12.75">
+                                    (UTC +12:45) Chatham Islands
+                                 </option>
                                  <option value="13">
                                     (UTC +13:00) Phoenix Islands, Tokelau, Tonga
+                                 </option>
+                                 <option value="14">
+                                    (UTC +14:00) Line Islands
                                  </option>
                               </select>
                            </div>

--- a/src/test/resources/pages/instructorFeedbackConstSumRecipientQuestionAddSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackConstSumRecipientQuestionAddSuccess.html
@@ -61,7 +61,10 @@
                                     (UTC -11:00) American Samoa, Niue
                                  </option>
                                  <option value="-10">
-                                    (UTC -10:00) Hawaii, Cook Islands, Marquesas Islands
+                                    (UTC -10:00) Hawaii, Cook Islands
+                                 </option>
+                                 <option value="-9.5">
+                                    (UTC -09:30) Marquesas Islands
                                  </option>
                                  <option value="-9">
                                     (UTC -09:00) Gambier Islands, Alaska
@@ -129,17 +132,29 @@
                                  <option value="6">
                                     (UTC +06:00) Almaty, Dhaka, Yekaterinburg
                                  </option>
+                                 <option value="6.5">
+                                    (UTC +06:30) Yangon
+                                 </option>
                                  <option value="7">
                                     (UTC +07:00) Jakarta, Bangkok, Novosibirsk, Hanoi
                                  </option>
                                  <option value="8">
                                     (UTC +08:00) Perth, Beijing, Manila, Singapore, Kuala Lumpur, Denpasar, Krasnoyarsk
                                  </option>
+                                 <option value="8.75">
+                                    (UTC +08:45) Eucla
+                                 </option>
                                  <option value="9">
                                     (UTC +09:00) Seoul, Tokyo, Pyongyang, Ambon, Irkutsk
                                  </option>
+                                 <option value="9.5">
+                                    (UTC +09:30) Adelaide
+                                 </option>
                                  <option value="10">
                                     (UTC +10:00) Canberra, Yakutsk, Port Moresby
+                                 </option>
+                                 <option value="10.5">
+                                    (UTC +10:30) Lord Howe Islands
                                  </option>
                                  <option value="11">
                                     (UTC +11:00) Vladivostok, Noumea
@@ -147,8 +162,14 @@
                                  <option value="12">
                                     (UTC +12:00) Auckland, Suva
                                  </option>
+                                 <option value="12.75">
+                                    (UTC +12:45) Chatham Islands
+                                 </option>
                                  <option value="13">
                                     (UTC +13:00) Phoenix Islands, Tokelau, Tonga
+                                 </option>
+                                 <option value="14">
+                                    (UTC +14:00) Line Islands
                                  </option>
                               </select>
                            </div>

--- a/src/test/resources/pages/instructorFeedbackConstSumRecipientQuestionEditSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackConstSumRecipientQuestionEditSuccess.html
@@ -61,7 +61,10 @@
                                     (UTC -11:00) American Samoa, Niue
                                  </option>
                                  <option value="-10">
-                                    (UTC -10:00) Hawaii, Cook Islands, Marquesas Islands
+                                    (UTC -10:00) Hawaii, Cook Islands
+                                 </option>
+                                 <option value="-9.5">
+                                    (UTC -09:30) Marquesas Islands
                                  </option>
                                  <option value="-9">
                                     (UTC -09:00) Gambier Islands, Alaska
@@ -129,17 +132,29 @@
                                  <option value="6">
                                     (UTC +06:00) Almaty, Dhaka, Yekaterinburg
                                  </option>
+                                 <option value="6.5">
+                                    (UTC +06:30) Yangon
+                                 </option>
                                  <option value="7">
                                     (UTC +07:00) Jakarta, Bangkok, Novosibirsk, Hanoi
                                  </option>
                                  <option value="8">
                                     (UTC +08:00) Perth, Beijing, Manila, Singapore, Kuala Lumpur, Denpasar, Krasnoyarsk
                                  </option>
+                                 <option value="8.75">
+                                    (UTC +08:45) Eucla
+                                 </option>
                                  <option value="9">
                                     (UTC +09:00) Seoul, Tokyo, Pyongyang, Ambon, Irkutsk
                                  </option>
+                                 <option value="9.5">
+                                    (UTC +09:30) Adelaide
+                                 </option>
                                  <option value="10">
                                     (UTC +10:00) Canberra, Yakutsk, Port Moresby
+                                 </option>
+                                 <option value="10.5">
+                                    (UTC +10:30) Lord Howe Islands
                                  </option>
                                  <option value="11">
                                     (UTC +11:00) Vladivostok, Noumea
@@ -147,8 +162,14 @@
                                  <option value="12">
                                     (UTC +12:00) Auckland, Suva
                                  </option>
+                                 <option value="12.75">
+                                    (UTC +12:45) Chatham Islands
+                                 </option>
                                  <option value="13">
                                     (UTC +13:00) Phoenix Islands, Tokelau, Tonga
+                                 </option>
+                                 <option value="14">
+                                    (UTC +14:00) Line Islands
                                  </option>
                               </select>
                            </div>

--- a/src/test/resources/pages/instructorFeedbackContribQuestionAddSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackContribQuestionAddSuccess.html
@@ -61,7 +61,10 @@
                                     (UTC -11:00) American Samoa, Niue
                                  </option>
                                  <option value="-10">
-                                    (UTC -10:00) Hawaii, Cook Islands, Marquesas Islands
+                                    (UTC -10:00) Hawaii, Cook Islands
+                                 </option>
+                                 <option value="-9.5">
+                                    (UTC -09:30) Marquesas Islands
                                  </option>
                                  <option value="-9">
                                     (UTC -09:00) Gambier Islands, Alaska
@@ -129,17 +132,29 @@
                                  <option value="6">
                                     (UTC +06:00) Almaty, Dhaka, Yekaterinburg
                                  </option>
+                                 <option value="6.5">
+                                    (UTC +06:30) Yangon
+                                 </option>
                                  <option value="7">
                                     (UTC +07:00) Jakarta, Bangkok, Novosibirsk, Hanoi
                                  </option>
                                  <option value="8">
                                     (UTC +08:00) Perth, Beijing, Manila, Singapore, Kuala Lumpur, Denpasar, Krasnoyarsk
                                  </option>
+                                 <option value="8.75">
+                                    (UTC +08:45) Eucla
+                                 </option>
                                  <option value="9">
                                     (UTC +09:00) Seoul, Tokyo, Pyongyang, Ambon, Irkutsk
                                  </option>
+                                 <option value="9.5">
+                                    (UTC +09:30) Adelaide
+                                 </option>
                                  <option value="10">
                                     (UTC +10:00) Canberra, Yakutsk, Port Moresby
+                                 </option>
+                                 <option value="10.5">
+                                    (UTC +10:30) Lord Howe Islands
                                  </option>
                                  <option value="11">
                                     (UTC +11:00) Vladivostok, Noumea
@@ -147,8 +162,14 @@
                                  <option value="12">
                                     (UTC +12:00) Auckland, Suva
                                  </option>
+                                 <option value="12.75">
+                                    (UTC +12:45) Chatham Islands
+                                 </option>
                                  <option value="13">
                                     (UTC +13:00) Phoenix Islands, Tokelau, Tonga
+                                 </option>
+                                 <option value="14">
+                                    (UTC +14:00) Line Islands
                                  </option>
                               </select>
                            </div>

--- a/src/test/resources/pages/instructorFeedbackContribQuestionEdit.html
+++ b/src/test/resources/pages/instructorFeedbackContribQuestionEdit.html
@@ -61,7 +61,10 @@
                                     (UTC -11:00) American Samoa, Niue
                                  </option>
                                  <option value="-10">
-                                    (UTC -10:00) Hawaii, Cook Islands, Marquesas Islands
+                                    (UTC -10:00) Hawaii, Cook Islands
+                                 </option>
+                                 <option value="-9.5">
+                                    (UTC -09:30) Marquesas Islands
                                  </option>
                                  <option value="-9">
                                     (UTC -09:00) Gambier Islands, Alaska
@@ -129,17 +132,29 @@
                                  <option value="6">
                                     (UTC +06:00) Almaty, Dhaka, Yekaterinburg
                                  </option>
+                                 <option value="6.5">
+                                    (UTC +06:30) Yangon
+                                 </option>
                                  <option value="7">
                                     (UTC +07:00) Jakarta, Bangkok, Novosibirsk, Hanoi
                                  </option>
                                  <option value="8">
                                     (UTC +08:00) Perth, Beijing, Manila, Singapore, Kuala Lumpur, Denpasar, Krasnoyarsk
                                  </option>
+                                 <option value="8.75">
+                                    (UTC +08:45) Eucla
+                                 </option>
                                  <option value="9">
                                     (UTC +09:00) Seoul, Tokyo, Pyongyang, Ambon, Irkutsk
                                  </option>
+                                 <option value="9.5">
+                                    (UTC +09:30) Adelaide
+                                 </option>
                                  <option value="10">
                                     (UTC +10:00) Canberra, Yakutsk, Port Moresby
+                                 </option>
+                                 <option value="10.5">
+                                    (UTC +10:30) Lord Howe Islands
                                  </option>
                                  <option value="11">
                                     (UTC +11:00) Vladivostok, Noumea
@@ -147,8 +162,14 @@
                                  <option value="12">
                                     (UTC +12:00) Auckland, Suva
                                  </option>
+                                 <option value="12.75">
+                                    (UTC +12:45) Chatham Islands
+                                 </option>
                                  <option value="13">
                                     (UTC +13:00) Phoenix Islands, Tokelau, Tonga
+                                 </option>
+                                 <option value="14">
+                                    (UTC +14:00) Line Islands
                                  </option>
                               </select>
                            </div>

--- a/src/test/resources/pages/instructorFeedbackContribQuestionEditSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackContribQuestionEditSuccess.html
@@ -61,7 +61,10 @@
                                     (UTC -11:00) American Samoa, Niue
                                  </option>
                                  <option value="-10">
-                                    (UTC -10:00) Hawaii, Cook Islands, Marquesas Islands
+                                    (UTC -10:00) Hawaii, Cook Islands
+                                 </option>
+                                 <option value="-9.5">
+                                    (UTC -09:30) Marquesas Islands
                                  </option>
                                  <option value="-9">
                                     (UTC -09:00) Gambier Islands, Alaska
@@ -129,17 +132,29 @@
                                  <option value="6">
                                     (UTC +06:00) Almaty, Dhaka, Yekaterinburg
                                  </option>
+                                 <option value="6.5">
+                                    (UTC +06:30) Yangon
+                                 </option>
                                  <option value="7">
                                     (UTC +07:00) Jakarta, Bangkok, Novosibirsk, Hanoi
                                  </option>
                                  <option value="8">
                                     (UTC +08:00) Perth, Beijing, Manila, Singapore, Kuala Lumpur, Denpasar, Krasnoyarsk
                                  </option>
+                                 <option value="8.75">
+                                    (UTC +08:45) Eucla
+                                 </option>
                                  <option value="9">
                                     (UTC +09:00) Seoul, Tokyo, Pyongyang, Ambon, Irkutsk
                                  </option>
+                                 <option value="9.5">
+                                    (UTC +09:30) Adelaide
+                                 </option>
                                  <option value="10">
                                     (UTC +10:00) Canberra, Yakutsk, Port Moresby
+                                 </option>
+                                 <option value="10.5">
+                                    (UTC +10:30) Lord Howe Islands
                                  </option>
                                  <option value="11">
                                     (UTC +11:00) Vladivostok, Noumea
@@ -147,8 +162,14 @@
                                  <option value="12">
                                     (UTC +12:00) Auckland, Suva
                                  </option>
+                                 <option value="12.75">
+                                    (UTC +12:45) Chatham Islands
+                                 </option>
                                  <option value="13">
                                     (UTC +13:00) Phoenix Islands, Tokelau, Tonga
+                                 </option>
+                                 <option value="14">
+                                    (UTC +14:00) Line Islands
                                  </option>
                               </select>
                            </div>

--- a/src/test/resources/pages/instructorFeedbackCopyQuestionSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackCopyQuestionSuccess.html
@@ -61,7 +61,10 @@
                                     (UTC -11:00) American Samoa, Niue
                                  </option>
                                  <option value="-10">
-                                    (UTC -10:00) Hawaii, Cook Islands, Marquesas Islands
+                                    (UTC -10:00) Hawaii, Cook Islands
+                                 </option>
+                                 <option value="-9.5">
+                                    (UTC -09:30) Marquesas Islands
                                  </option>
                                  <option value="-9">
                                     (UTC -09:00) Gambier Islands, Alaska
@@ -129,17 +132,29 @@
                                  <option value="6">
                                     (UTC +06:00) Almaty, Dhaka, Yekaterinburg
                                  </option>
+                                 <option value="6.5">
+                                    (UTC +06:30) Yangon
+                                 </option>
                                  <option value="7">
                                     (UTC +07:00) Jakarta, Bangkok, Novosibirsk, Hanoi
                                  </option>
                                  <option value="8">
                                     (UTC +08:00) Perth, Beijing, Manila, Singapore, Kuala Lumpur, Denpasar, Krasnoyarsk
                                  </option>
+                                 <option value="8.75">
+                                    (UTC +08:45) Eucla
+                                 </option>
                                  <option value="9">
                                     (UTC +09:00) Seoul, Tokyo, Pyongyang, Ambon, Irkutsk
                                  </option>
+                                 <option value="9.5">
+                                    (UTC +09:30) Adelaide
+                                 </option>
                                  <option value="10">
                                     (UTC +10:00) Canberra, Yakutsk, Port Moresby
+                                 </option>
+                                 <option value="10.5">
+                                    (UTC +10:30) Lord Howe Islands
                                  </option>
                                  <option value="11">
                                     (UTC +11:00) Vladivostok, Noumea
@@ -147,8 +162,14 @@
                                  <option value="12">
                                     (UTC +12:00) Auckland, Suva
                                  </option>
+                                 <option value="12.75">
+                                    (UTC +12:45) Chatham Islands
+                                 </option>
                                  <option value="13">
                                     (UTC +13:00) Phoenix Islands, Tokelau, Tonga
+                                 </option>
+                                 <option value="14">
+                                    (UTC +14:00) Line Islands
                                  </option>
                               </select>
                            </div>

--- a/src/test/resources/pages/instructorFeedbackCopySuccess.html
+++ b/src/test/resources/pages/instructorFeedbackCopySuccess.html
@@ -61,7 +61,10 @@
                                     (UTC -11:00) American Samoa, Niue
                                  </option>
                                  <option value="-10">
-                                    (UTC -10:00) Hawaii, Cook Islands, Marquesas Islands
+                                    (UTC -10:00) Hawaii, Cook Islands
+                                 </option>
+                                 <option value="-9.5">
+                                    (UTC -09:30) Marquesas Islands
                                  </option>
                                  <option value="-9">
                                     (UTC -09:00) Gambier Islands, Alaska
@@ -129,17 +132,29 @@
                                  <option value="6">
                                     (UTC +06:00) Almaty, Dhaka, Yekaterinburg
                                  </option>
+                                 <option value="6.5">
+                                    (UTC +06:30) Yangon
+                                 </option>
                                  <option value="7">
                                     (UTC +07:00) Jakarta, Bangkok, Novosibirsk, Hanoi
                                  </option>
                                  <option value="8">
                                     (UTC +08:00) Perth, Beijing, Manila, Singapore, Kuala Lumpur, Denpasar, Krasnoyarsk
                                  </option>
+                                 <option value="8.75">
+                                    (UTC +08:45) Eucla
+                                 </option>
                                  <option value="9">
                                     (UTC +09:00) Seoul, Tokyo, Pyongyang, Ambon, Irkutsk
                                  </option>
+                                 <option value="9.5">
+                                    (UTC +09:30) Adelaide
+                                 </option>
                                  <option value="10">
                                     (UTC +10:00) Canberra, Yakutsk, Port Moresby
+                                 </option>
+                                 <option value="10.5">
+                                    (UTC +10:30) Lord Howe Islands
                                  </option>
                                  <option value="11">
                                     (UTC +11:00) Vladivostok, Noumea
@@ -147,8 +162,14 @@
                                  <option value="12">
                                     (UTC +12:00) Auckland, Suva
                                  </option>
+                                 <option value="12.75">
+                                    (UTC +12:45) Chatham Islands
+                                 </option>
                                  <option value="13">
                                     (UTC +13:00) Phoenix Islands, Tokelau, Tonga
+                                 </option>
+                                 <option value="14">
+                                    (UTC +14:00) Line Islands
                                  </option>
                               </select>
                            </div>

--- a/src/test/resources/pages/instructorFeedbackDeleteSuccessful.html
+++ b/src/test/resources/pages/instructorFeedbackDeleteSuccessful.html
@@ -79,7 +79,10 @@
                                     (UTC -11:00) American Samoa, Niue
                                  </option>
                                  <option value="-10">
-                                    (UTC -10:00) Hawaii, Cook Islands, Marquesas Islands
+                                    (UTC -10:00) Hawaii, Cook Islands
+                                 </option>
+                                 <option value="-9.5">
+                                    (UTC -09:30) Marquesas Islands
                                  </option>
                                  <option value="-9">
                                     (UTC -09:00) Gambier Islands, Alaska
@@ -147,17 +150,29 @@
                                  <option value="6">
                                     (UTC +06:00) Almaty, Dhaka, Yekaterinburg
                                  </option>
+                                 <option value="6.5">
+                                    (UTC +06:30) Yangon
+                                 </option>
                                  <option value="7">
                                     (UTC +07:00) Jakarta, Bangkok, Novosibirsk, Hanoi
                                  </option>
                                  <option value="8">
                                     (UTC +08:00) Perth, Beijing, Manila, Singapore, Kuala Lumpur, Denpasar, Krasnoyarsk
                                  </option>
+                                 <option value="8.75">
+                                    (UTC +08:45) Eucla
+                                 </option>
                                  <option value="9">
                                     (UTC +09:00) Seoul, Tokyo, Pyongyang, Ambon, Irkutsk
                                  </option>
+                                 <option value="9.5">
+                                    (UTC +09:30) Adelaide
+                                 </option>
                                  <option value="10">
                                     (UTC +10:00) Canberra, Yakutsk, Port Moresby
+                                 </option>
+                                 <option value="10.5">
+                                    (UTC +10:30) Lord Howe Islands
                                  </option>
                                  <option value="11">
                                     (UTC +11:00) Vladivostok, Noumea
@@ -165,8 +180,14 @@
                                  <option value="12">
                                     (UTC +12:00) Auckland, Suva
                                  </option>
+                                 <option value="12.75">
+                                    (UTC +12:45) Chatham Islands
+                                 </option>
                                  <option value="13">
                                     (UTC +13:00) Phoenix Islands, Tokelau, Tonga
+                                 </option>
+                                 <option value="14">
+                                    (UTC +14:00) Line Islands
                                  </option>
                               </select>
                            </div>

--- a/src/test/resources/pages/instructorFeedbackEditCopyFail.html
+++ b/src/test/resources/pages/instructorFeedbackEditCopyFail.html
@@ -61,7 +61,10 @@
                                     (UTC -11:00) American Samoa, Niue
                                  </option>
                                  <option value="-10">
-                                    (UTC -10:00) Hawaii, Cook Islands, Marquesas Islands
+                                    (UTC -10:00) Hawaii, Cook Islands
+                                 </option>
+                                 <option value="-9.5">
+                                    (UTC -09:30) Marquesas Islands
                                  </option>
                                  <option value="-9">
                                     (UTC -09:00) Gambier Islands, Alaska
@@ -129,17 +132,29 @@
                                  <option value="6">
                                     (UTC +06:00) Almaty, Dhaka, Yekaterinburg
                                  </option>
+                                 <option value="6.5">
+                                    (UTC +06:30) Yangon
+                                 </option>
                                  <option value="7">
                                     (UTC +07:00) Jakarta, Bangkok, Novosibirsk, Hanoi
                                  </option>
                                  <option value="8">
                                     (UTC +08:00) Perth, Beijing, Manila, Singapore, Kuala Lumpur, Denpasar, Krasnoyarsk
                                  </option>
+                                 <option value="8.75">
+                                    (UTC +08:45) Eucla
+                                 </option>
                                  <option value="9">
                                     (UTC +09:00) Seoul, Tokyo, Pyongyang, Ambon, Irkutsk
                                  </option>
+                                 <option value="9.5">
+                                    (UTC +09:30) Adelaide
+                                 </option>
                                  <option value="10">
                                     (UTC +10:00) Canberra, Yakutsk, Port Moresby
+                                 </option>
+                                 <option value="10.5">
+                                    (UTC +10:30) Lord Howe Islands
                                  </option>
                                  <option value="11">
                                     (UTC +11:00) Vladivostok, Noumea
@@ -147,8 +162,14 @@
                                  <option value="12">
                                     (UTC +12:00) Auckland, Suva
                                  </option>
+                                 <option value="12.75">
+                                    (UTC +12:45) Chatham Islands
+                                 </option>
                                  <option value="13">
                                     (UTC +13:00) Phoenix Islands, Tokelau, Tonga
+                                 </option>
+                                 <option value="14">
+                                    (UTC +14:00) Line Islands
                                  </option>
                               </select>
                            </div>

--- a/src/test/resources/pages/instructorFeedbackEditCopyPage.html
+++ b/src/test/resources/pages/instructorFeedbackEditCopyPage.html
@@ -61,7 +61,10 @@
                                     (UTC -11:00) American Samoa, Niue
                                  </option>
                                  <option value="-10">
-                                    (UTC -10:00) Hawaii, Cook Islands, Marquesas Islands
+                                    (UTC -10:00) Hawaii, Cook Islands
+                                 </option>
+                                 <option value="-9.5">
+                                    (UTC -09:30) Marquesas Islands
                                  </option>
                                  <option value="-9">
                                     (UTC -09:00) Gambier Islands, Alaska
@@ -129,17 +132,29 @@
                                  <option value="6">
                                     (UTC +06:00) Almaty, Dhaka, Yekaterinburg
                                  </option>
+                                 <option value="6.5">
+                                    (UTC +06:30) Yangon
+                                 </option>
                                  <option value="7">
                                     (UTC +07:00) Jakarta, Bangkok, Novosibirsk, Hanoi
                                  </option>
                                  <option value="8">
                                     (UTC +08:00) Perth, Beijing, Manila, Singapore, Kuala Lumpur, Denpasar, Krasnoyarsk
                                  </option>
+                                 <option value="8.75">
+                                    (UTC +08:45) Eucla
+                                 </option>
                                  <option value="9">
                                     (UTC +09:00) Seoul, Tokyo, Pyongyang, Ambon, Irkutsk
                                  </option>
+                                 <option value="9.5">
+                                    (UTC +09:30) Adelaide
+                                 </option>
                                  <option value="10">
                                     (UTC +10:00) Canberra, Yakutsk, Port Moresby
+                                 </option>
+                                 <option value="10.5">
+                                    (UTC +10:30) Lord Howe Islands
                                  </option>
                                  <option value="11">
                                     (UTC +11:00) Vladivostok, Noumea
@@ -147,8 +162,14 @@
                                  <option value="12">
                                     (UTC +12:00) Auckland, Suva
                                  </option>
+                                 <option value="12.75">
+                                    (UTC +12:45) Chatham Islands
+                                 </option>
                                  <option value="13">
                                     (UTC +13:00) Phoenix Islands, Tokelau, Tonga
+                                 </option>
+                                 <option value="14">
+                                    (UTC +14:00) Line Islands
                                  </option>
                               </select>
                            </div>

--- a/src/test/resources/pages/instructorFeedbackEditCopySuccess.html
+++ b/src/test/resources/pages/instructorFeedbackEditCopySuccess.html
@@ -82,7 +82,10 @@
                                     (UTC -11:00) American Samoa, Niue
                                  </option>
                                  <option value="-10">
-                                    (UTC -10:00) Hawaii, Cook Islands, Marquesas Islands
+                                    (UTC -10:00) Hawaii, Cook Islands
+                                 </option>
+                                 <option value="-9.5">
+                                    (UTC -09:30) Marquesas Islands
                                  </option>
                                  <option value="-9">
                                     (UTC -09:00) Gambier Islands, Alaska
@@ -150,17 +153,29 @@
                                  <option value="6">
                                     (UTC +06:00) Almaty, Dhaka, Yekaterinburg
                                  </option>
+                                 <option value="6.5">
+                                    (UTC +06:30) Yangon
+                                 </option>
                                  <option value="7">
                                     (UTC +07:00) Jakarta, Bangkok, Novosibirsk, Hanoi
                                  </option>
                                  <option value="8">
                                     (UTC +08:00) Perth, Beijing, Manila, Singapore, Kuala Lumpur, Denpasar, Krasnoyarsk
                                  </option>
+                                 <option value="8.75">
+                                    (UTC +08:45) Eucla
+                                 </option>
                                  <option value="9">
                                     (UTC +09:00) Seoul, Tokyo, Pyongyang, Ambon, Irkutsk
                                  </option>
+                                 <option value="9.5">
+                                    (UTC +09:30) Adelaide
+                                 </option>
                                  <option value="10">
                                     (UTC +10:00) Canberra, Yakutsk, Port Moresby
+                                 </option>
+                                 <option value="10.5">
+                                    (UTC +10:30) Lord Howe Islands
                                  </option>
                                  <option value="11">
                                     (UTC +11:00) Vladivostok, Noumea
@@ -168,8 +183,14 @@
                                  <option value="12">
                                     (UTC +12:00) Auckland, Suva
                                  </option>
+                                 <option value="12.75">
+                                    (UTC +12:45) Chatham Islands
+                                 </option>
                                  <option value="13">
                                     (UTC +13:00) Phoenix Islands, Tokelau, Tonga
+                                 </option>
+                                 <option value="14">
+                                    (UTC +14:00) Line Islands
                                  </option>
                               </select>
                            </div>

--- a/src/test/resources/pages/instructorFeedbackEditEmpty.html
+++ b/src/test/resources/pages/instructorFeedbackEditEmpty.html
@@ -172,7 +172,10 @@
                                           (UTC -11:00) American Samoa, Niue
                                        </option>
                                        <option value="-10">
-                                          (UTC -10:00) Hawaii, Cook Islands, Marquesas Islands
+                                          (UTC -10:00) Hawaii, Cook Islands
+                                       </option>
+                                       <option value="-9.5">
+                                          (UTC -09:30) Marquesas Islands
                                        </option>
                                        <option value="-9">
                                           (UTC -09:00) Gambier Islands, Alaska
@@ -240,17 +243,29 @@
                                        <option value="6">
                                           (UTC +06:00) Almaty, Dhaka, Yekaterinburg
                                        </option>
+                                       <option value="6.5">
+                                          (UTC +06:30) Yangon
+                                       </option>
                                        <option value="7">
                                           (UTC +07:00) Jakarta, Bangkok, Novosibirsk, Hanoi
                                        </option>
                                        <option value="8">
                                           (UTC +08:00) Perth, Beijing, Manila, Singapore, Kuala Lumpur, Denpasar, Krasnoyarsk
                                        </option>
+                                       <option value="8.75">
+                                          (UTC +08:45) Eucla
+                                       </option>
                                        <option value="9">
                                           (UTC +09:00) Seoul, Tokyo, Pyongyang, Ambon, Irkutsk
                                        </option>
+                                       <option value="9.5">
+                                          (UTC +09:30) Adelaide
+                                       </option>
                                        <option value="10">
                                           (UTC +10:00) Canberra, Yakutsk, Port Moresby
+                                       </option>
+                                       <option value="10.5">
+                                          (UTC +10:30) Lord Howe Islands
                                        </option>
                                        <option value="11">
                                           (UTC +11:00) Vladivostok, Noumea
@@ -258,8 +273,14 @@
                                        <option value="12">
                                           (UTC +12:00) Auckland, Suva
                                        </option>
+                                       <option value="12.75">
+                                          (UTC +12:45) Chatham Islands
+                                       </option>
                                        <option value="13">
                                           (UTC +13:00) Phoenix Islands, Tokelau, Tonga
+                                       </option>
+                                       <option value="14">
+                                          (UTC +14:00) Line Islands
                                        </option>
                                     </select>
                                  </div>

--- a/src/test/resources/pages/instructorFeedbackEditManuallyPublished.html
+++ b/src/test/resources/pages/instructorFeedbackEditManuallyPublished.html
@@ -172,7 +172,10 @@
                                           (UTC -11:00) American Samoa, Niue
                                        </option>
                                        <option value="-10">
-                                          (UTC -10:00) Hawaii, Cook Islands, Marquesas Islands
+                                          (UTC -10:00) Hawaii, Cook Islands
+                                       </option>
+                                       <option value="-9.5">
+                                          (UTC -09:30) Marquesas Islands
                                        </option>
                                        <option value="-9">
                                           (UTC -09:00) Gambier Islands, Alaska
@@ -240,17 +243,29 @@
                                        <option value="6">
                                           (UTC +06:00) Almaty, Dhaka, Yekaterinburg
                                        </option>
+                                       <option value="6.5">
+                                          (UTC +06:30) Yangon
+                                       </option>
                                        <option value="7">
                                           (UTC +07:00) Jakarta, Bangkok, Novosibirsk, Hanoi
                                        </option>
                                        <option value="8">
                                           (UTC +08:00) Perth, Beijing, Manila, Singapore, Kuala Lumpur, Denpasar, Krasnoyarsk
                                        </option>
+                                       <option value="8.75">
+                                          (UTC +08:45) Eucla
+                                       </option>
                                        <option value="9">
                                           (UTC +09:00) Seoul, Tokyo, Pyongyang, Ambon, Irkutsk
                                        </option>
+                                       <option value="9.5">
+                                          (UTC +09:30) Adelaide
+                                       </option>
                                        <option value="10">
                                           (UTC +10:00) Canberra, Yakutsk, Port Moresby
+                                       </option>
+                                       <option value="10.5">
+                                          (UTC +10:30) Lord Howe Islands
                                        </option>
                                        <option value="11">
                                           (UTC +11:00) Vladivostok, Noumea
@@ -258,8 +273,14 @@
                                        <option value="12">
                                           (UTC +12:00) Auckland, Suva
                                        </option>
+                                       <option value="12.75">
+                                          (UTC +12:45) Chatham Islands
+                                       </option>
                                        <option value="13">
                                           (UTC +13:00) Phoenix Islands, Tokelau, Tonga
+                                       </option>
+                                       <option value="14">
+                                          (UTC +14:00) Line Islands
                                        </option>
                                     </select>
                                  </div>

--- a/src/test/resources/pages/instructorFeedbackEditSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackEditSuccess.html
@@ -61,7 +61,10 @@
                                     (UTC -11:00) American Samoa, Niue
                                  </option>
                                  <option value="-10">
-                                    (UTC -10:00) Hawaii, Cook Islands, Marquesas Islands
+                                    (UTC -10:00) Hawaii, Cook Islands
+                                 </option>
+                                 <option value="-9.5">
+                                    (UTC -09:30) Marquesas Islands
                                  </option>
                                  <option value="-9">
                                     (UTC -09:00) Gambier Islands, Alaska
@@ -129,17 +132,29 @@
                                  <option value="6">
                                     (UTC +06:00) Almaty, Dhaka, Yekaterinburg
                                  </option>
+                                 <option value="6.5">
+                                    (UTC +06:30) Yangon
+                                 </option>
                                  <option value="7">
                                     (UTC +07:00) Jakarta, Bangkok, Novosibirsk, Hanoi
                                  </option>
                                  <option value="8">
                                     (UTC +08:00) Perth, Beijing, Manila, Singapore, Kuala Lumpur, Denpasar, Krasnoyarsk
                                  </option>
+                                 <option value="8.75">
+                                    (UTC +08:45) Eucla
+                                 </option>
                                  <option value="9">
                                     (UTC +09:00) Seoul, Tokyo, Pyongyang, Ambon, Irkutsk
                                  </option>
+                                 <option value="9.5">
+                                    (UTC +09:30) Adelaide
+                                 </option>
                                  <option value="10">
                                     (UTC +10:00) Canberra, Yakutsk, Port Moresby
+                                 </option>
+                                 <option value="10.5">
+                                    (UTC +10:30) Lord Howe Islands
                                  </option>
                                  <option value="11">
                                     (UTC +11:00) Vladivostok, Noumea
@@ -147,8 +162,14 @@
                                  <option value="12">
                                     (UTC +12:00) Auckland, Suva
                                  </option>
+                                 <option value="12.75">
+                                    (UTC +12:45) Chatham Islands
+                                 </option>
                                  <option value="13">
                                     (UTC +13:00) Phoenix Islands, Tokelau, Tonga
+                                 </option>
+                                 <option value="14">
+                                    (UTC +14:00) Line Islands
                                  </option>
                               </select>
                            </div>

--- a/src/test/resources/pages/instructorFeedbackEmptyAll.html
+++ b/src/test/resources/pages/instructorFeedbackEmptyAll.html
@@ -190,7 +190,10 @@
                                           (UTC -11:00) American Samoa, Niue
                                        </option>
                                        <option value="-10">
-                                          (UTC -10:00) Hawaii, Cook Islands, Marquesas Islands
+                                          (UTC -10:00) Hawaii, Cook Islands
+                                       </option>
+                                       <option value="-9.5">
+                                          (UTC -09:30) Marquesas Islands
                                        </option>
                                        <option value="-9">
                                           (UTC -09:00) Gambier Islands, Alaska
@@ -258,17 +261,29 @@
                                        <option value="6">
                                           (UTC +06:00) Almaty, Dhaka, Yekaterinburg
                                        </option>
+                                       <option value="6.5">
+                                          (UTC +06:30) Yangon
+                                       </option>
                                        <option value="7">
                                           (UTC +07:00) Jakarta, Bangkok, Novosibirsk, Hanoi
                                        </option>
                                        <option value="8">
                                           (UTC +08:00) Perth, Beijing, Manila, Singapore, Kuala Lumpur, Denpasar, Krasnoyarsk
                                        </option>
+                                       <option value="8.75">
+                                          (UTC +08:45) Eucla
+                                       </option>
                                        <option value="9">
                                           (UTC +09:00) Seoul, Tokyo, Pyongyang, Ambon, Irkutsk
                                        </option>
+                                       <option value="9.5">
+                                          (UTC +09:30) Adelaide
+                                       </option>
                                        <option value="10">
                                           (UTC +10:00) Canberra, Yakutsk, Port Moresby
+                                       </option>
+                                       <option value="10.5">
+                                          (UTC +10:30) Lord Howe Islands
                                        </option>
                                        <option value="11">
                                           (UTC +11:00) Vladivostok, Noumea
@@ -276,8 +291,14 @@
                                        <option value="12">
                                           (UTC +12:00) Auckland, Suva
                                        </option>
+                                       <option value="12.75">
+                                          (UTC +12:45) Chatham Islands
+                                       </option>
                                        <option value="13">
                                           (UTC +13:00) Phoenix Islands, Tokelau, Tonga
+                                       </option>
+                                       <option value="14">
+                                          (UTC +14:00) Line Islands
                                        </option>
                                     </select>
                                  </div>

--- a/src/test/resources/pages/instructorFeedbackEmptySession.html
+++ b/src/test/resources/pages/instructorFeedbackEmptySession.html
@@ -76,7 +76,10 @@
                                     (UTC -11:00) American Samoa, Niue
                                  </option>
                                  <option value="-10">
-                                    (UTC -10:00) Hawaii, Cook Islands, Marquesas Islands
+                                    (UTC -10:00) Hawaii, Cook Islands
+                                 </option>
+                                 <option value="-9.5">
+                                    (UTC -09:30) Marquesas Islands
                                  </option>
                                  <option value="-9">
                                     (UTC -09:00) Gambier Islands, Alaska
@@ -144,17 +147,29 @@
                                  <option value="6">
                                     (UTC +06:00) Almaty, Dhaka, Yekaterinburg
                                  </option>
+                                 <option value="6.5">
+                                    (UTC +06:30) Yangon
+                                 </option>
                                  <option value="7">
                                     (UTC +07:00) Jakarta, Bangkok, Novosibirsk, Hanoi
                                  </option>
                                  <option value="8">
                                     (UTC +08:00) Perth, Beijing, Manila, Singapore, Kuala Lumpur, Denpasar, Krasnoyarsk
                                  </option>
+                                 <option value="8.75">
+                                    (UTC +08:45) Eucla
+                                 </option>
                                  <option value="9">
                                     (UTC +09:00) Seoul, Tokyo, Pyongyang, Ambon, Irkutsk
                                  </option>
+                                 <option value="9.5">
+                                    (UTC +09:30) Adelaide
+                                 </option>
                                  <option value="10">
                                     (UTC +10:00) Canberra, Yakutsk, Port Moresby
+                                 </option>
+                                 <option value="10.5">
+                                    (UTC +10:30) Lord Howe Islands
                                  </option>
                                  <option value="11">
                                     (UTC +11:00) Vladivostok, Noumea
@@ -162,8 +177,14 @@
                                  <option value="12">
                                     (UTC +12:00) Auckland, Suva
                                  </option>
+                                 <option value="12.75">
+                                    (UTC +12:45) Chatham Islands
+                                 </option>
                                  <option value="13">
                                     (UTC +13:00) Phoenix Islands, Tokelau, Tonga
+                                 </option>
+                                 <option value="14">
+                                    (UTC +14:00) Line Islands
                                  </option>
                               </select>
                            </div>

--- a/src/test/resources/pages/instructorFeedbackMcqQuestionAddSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackMcqQuestionAddSuccess.html
@@ -61,7 +61,10 @@
                                     (UTC -11:00) American Samoa, Niue
                                  </option>
                                  <option value="-10">
-                                    (UTC -10:00) Hawaii, Cook Islands, Marquesas Islands
+                                    (UTC -10:00) Hawaii, Cook Islands
+                                 </option>
+                                 <option value="-9.5">
+                                    (UTC -09:30) Marquesas Islands
                                  </option>
                                  <option value="-9">
                                     (UTC -09:00) Gambier Islands, Alaska
@@ -129,17 +132,29 @@
                                  <option value="6">
                                     (UTC +06:00) Almaty, Dhaka, Yekaterinburg
                                  </option>
+                                 <option value="6.5">
+                                    (UTC +06:30) Yangon
+                                 </option>
                                  <option value="7">
                                     (UTC +07:00) Jakarta, Bangkok, Novosibirsk, Hanoi
                                  </option>
                                  <option value="8">
                                     (UTC +08:00) Perth, Beijing, Manila, Singapore, Kuala Lumpur, Denpasar, Krasnoyarsk
                                  </option>
+                                 <option value="8.75">
+                                    (UTC +08:45) Eucla
+                                 </option>
                                  <option value="9">
                                     (UTC +09:00) Seoul, Tokyo, Pyongyang, Ambon, Irkutsk
                                  </option>
+                                 <option value="9.5">
+                                    (UTC +09:30) Adelaide
+                                 </option>
                                  <option value="10">
                                     (UTC +10:00) Canberra, Yakutsk, Port Moresby
+                                 </option>
+                                 <option value="10.5">
+                                    (UTC +10:30) Lord Howe Islands
                                  </option>
                                  <option value="11">
                                     (UTC +11:00) Vladivostok, Noumea
@@ -147,8 +162,14 @@
                                  <option value="12">
                                     (UTC +12:00) Auckland, Suva
                                  </option>
+                                 <option value="12.75">
+                                    (UTC +12:45) Chatham Islands
+                                 </option>
                                  <option value="13">
                                     (UTC +13:00) Phoenix Islands, Tokelau, Tonga
+                                 </option>
+                                 <option value="14">
+                                    (UTC +14:00) Line Islands
                                  </option>
                               </select>
                            </div>

--- a/src/test/resources/pages/instructorFeedbackMcqQuestionEditSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackMcqQuestionEditSuccess.html
@@ -61,7 +61,10 @@
                                     (UTC -11:00) American Samoa, Niue
                                  </option>
                                  <option value="-10">
-                                    (UTC -10:00) Hawaii, Cook Islands, Marquesas Islands
+                                    (UTC -10:00) Hawaii, Cook Islands
+                                 </option>
+                                 <option value="-9.5">
+                                    (UTC -09:30) Marquesas Islands
                                  </option>
                                  <option value="-9">
                                     (UTC -09:00) Gambier Islands, Alaska
@@ -129,17 +132,29 @@
                                  <option value="6">
                                     (UTC +06:00) Almaty, Dhaka, Yekaterinburg
                                  </option>
+                                 <option value="6.5">
+                                    (UTC +06:30) Yangon
+                                 </option>
                                  <option value="7">
                                     (UTC +07:00) Jakarta, Bangkok, Novosibirsk, Hanoi
                                  </option>
                                  <option value="8">
                                     (UTC +08:00) Perth, Beijing, Manila, Singapore, Kuala Lumpur, Denpasar, Krasnoyarsk
                                  </option>
+                                 <option value="8.75">
+                                    (UTC +08:45) Eucla
+                                 </option>
                                  <option value="9">
                                     (UTC +09:00) Seoul, Tokyo, Pyongyang, Ambon, Irkutsk
                                  </option>
+                                 <option value="9.5">
+                                    (UTC +09:30) Adelaide
+                                 </option>
                                  <option value="10">
                                     (UTC +10:00) Canberra, Yakutsk, Port Moresby
+                                 </option>
+                                 <option value="10.5">
+                                    (UTC +10:30) Lord Howe Islands
                                  </option>
                                  <option value="11">
                                     (UTC +11:00) Vladivostok, Noumea
@@ -147,8 +162,14 @@
                                  <option value="12">
                                     (UTC +12:00) Auckland, Suva
                                  </option>
+                                 <option value="12.75">
+                                    (UTC +12:45) Chatham Islands
+                                 </option>
                                  <option value="13">
                                     (UTC +13:00) Phoenix Islands, Tokelau, Tonga
+                                 </option>
+                                 <option value="14">
+                                    (UTC +14:00) Line Islands
                                  </option>
                               </select>
                            </div>

--- a/src/test/resources/pages/instructorFeedbackMsqQuestionAddSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackMsqQuestionAddSuccess.html
@@ -61,7 +61,10 @@
                                     (UTC -11:00) American Samoa, Niue
                                  </option>
                                  <option value="-10">
-                                    (UTC -10:00) Hawaii, Cook Islands, Marquesas Islands
+                                    (UTC -10:00) Hawaii, Cook Islands
+                                 </option>
+                                 <option value="-9.5">
+                                    (UTC -09:30) Marquesas Islands
                                  </option>
                                  <option value="-9">
                                     (UTC -09:00) Gambier Islands, Alaska
@@ -129,17 +132,29 @@
                                  <option value="6">
                                     (UTC +06:00) Almaty, Dhaka, Yekaterinburg
                                  </option>
+                                 <option value="6.5">
+                                    (UTC +06:30) Yangon
+                                 </option>
                                  <option value="7">
                                     (UTC +07:00) Jakarta, Bangkok, Novosibirsk, Hanoi
                                  </option>
                                  <option value="8">
                                     (UTC +08:00) Perth, Beijing, Manila, Singapore, Kuala Lumpur, Denpasar, Krasnoyarsk
                                  </option>
+                                 <option value="8.75">
+                                    (UTC +08:45) Eucla
+                                 </option>
                                  <option value="9">
                                     (UTC +09:00) Seoul, Tokyo, Pyongyang, Ambon, Irkutsk
                                  </option>
+                                 <option value="9.5">
+                                    (UTC +09:30) Adelaide
+                                 </option>
                                  <option value="10">
                                     (UTC +10:00) Canberra, Yakutsk, Port Moresby
+                                 </option>
+                                 <option value="10.5">
+                                    (UTC +10:30) Lord Howe Islands
                                  </option>
                                  <option value="11">
                                     (UTC +11:00) Vladivostok, Noumea
@@ -147,8 +162,14 @@
                                  <option value="12">
                                     (UTC +12:00) Auckland, Suva
                                  </option>
+                                 <option value="12.75">
+                                    (UTC +12:45) Chatham Islands
+                                 </option>
                                  <option value="13">
                                     (UTC +13:00) Phoenix Islands, Tokelau, Tonga
+                                 </option>
+                                 <option value="14">
+                                    (UTC +14:00) Line Islands
                                  </option>
                               </select>
                            </div>

--- a/src/test/resources/pages/instructorFeedbackMsqQuestionEditSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackMsqQuestionEditSuccess.html
@@ -61,7 +61,10 @@
                                     (UTC -11:00) American Samoa, Niue
                                  </option>
                                  <option value="-10">
-                                    (UTC -10:00) Hawaii, Cook Islands, Marquesas Islands
+                                    (UTC -10:00) Hawaii, Cook Islands
+                                 </option>
+                                 <option value="-9.5">
+                                    (UTC -09:30) Marquesas Islands
                                  </option>
                                  <option value="-9">
                                     (UTC -09:00) Gambier Islands, Alaska
@@ -129,17 +132,29 @@
                                  <option value="6">
                                     (UTC +06:00) Almaty, Dhaka, Yekaterinburg
                                  </option>
+                                 <option value="6.5">
+                                    (UTC +06:30) Yangon
+                                 </option>
                                  <option value="7">
                                     (UTC +07:00) Jakarta, Bangkok, Novosibirsk, Hanoi
                                  </option>
                                  <option value="8">
                                     (UTC +08:00) Perth, Beijing, Manila, Singapore, Kuala Lumpur, Denpasar, Krasnoyarsk
                                  </option>
+                                 <option value="8.75">
+                                    (UTC +08:45) Eucla
+                                 </option>
                                  <option value="9">
                                     (UTC +09:00) Seoul, Tokyo, Pyongyang, Ambon, Irkutsk
                                  </option>
+                                 <option value="9.5">
+                                    (UTC +09:30) Adelaide
+                                 </option>
                                  <option value="10">
                                     (UTC +10:00) Canberra, Yakutsk, Port Moresby
+                                 </option>
+                                 <option value="10.5">
+                                    (UTC +10:30) Lord Howe Islands
                                  </option>
                                  <option value="11">
                                     (UTC +11:00) Vladivostok, Noumea
@@ -147,8 +162,14 @@
                                  <option value="12">
                                     (UTC +12:00) Auckland, Suva
                                  </option>
+                                 <option value="12.75">
+                                    (UTC +12:45) Chatham Islands
+                                 </option>
                                  <option value="13">
                                     (UTC +13:00) Phoenix Islands, Tokelau, Tonga
+                                 </option>
+                                 <option value="14">
+                                    (UTC +14:00) Line Islands
                                  </option>
                               </select>
                            </div>

--- a/src/test/resources/pages/instructorFeedbackNumScaleQuestionAddSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackNumScaleQuestionAddSuccess.html
@@ -61,7 +61,10 @@
                                     (UTC -11:00) American Samoa, Niue
                                  </option>
                                  <option value="-10">
-                                    (UTC -10:00) Hawaii, Cook Islands, Marquesas Islands
+                                    (UTC -10:00) Hawaii, Cook Islands
+                                 </option>
+                                 <option value="-9.5">
+                                    (UTC -09:30) Marquesas Islands
                                  </option>
                                  <option value="-9">
                                     (UTC -09:00) Gambier Islands, Alaska
@@ -129,17 +132,29 @@
                                  <option value="6">
                                     (UTC +06:00) Almaty, Dhaka, Yekaterinburg
                                  </option>
+                                 <option value="6.5">
+                                    (UTC +06:30) Yangon
+                                 </option>
                                  <option value="7">
                                     (UTC +07:00) Jakarta, Bangkok, Novosibirsk, Hanoi
                                  </option>
                                  <option value="8">
                                     (UTC +08:00) Perth, Beijing, Manila, Singapore, Kuala Lumpur, Denpasar, Krasnoyarsk
                                  </option>
+                                 <option value="8.75">
+                                    (UTC +08:45) Eucla
+                                 </option>
                                  <option value="9">
                                     (UTC +09:00) Seoul, Tokyo, Pyongyang, Ambon, Irkutsk
                                  </option>
+                                 <option value="9.5">
+                                    (UTC +09:30) Adelaide
+                                 </option>
                                  <option value="10">
                                     (UTC +10:00) Canberra, Yakutsk, Port Moresby
+                                 </option>
+                                 <option value="10.5">
+                                    (UTC +10:30) Lord Howe Islands
                                  </option>
                                  <option value="11">
                                     (UTC +11:00) Vladivostok, Noumea
@@ -147,8 +162,14 @@
                                  <option value="12">
                                     (UTC +12:00) Auckland, Suva
                                  </option>
+                                 <option value="12.75">
+                                    (UTC +12:45) Chatham Islands
+                                 </option>
                                  <option value="13">
                                     (UTC +13:00) Phoenix Islands, Tokelau, Tonga
+                                 </option>
+                                 <option value="14">
+                                    (UTC +14:00) Line Islands
                                  </option>
                               </select>
                            </div>

--- a/src/test/resources/pages/instructorFeedbackNumScaleQuestionEditSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackNumScaleQuestionEditSuccess.html
@@ -61,7 +61,10 @@
                                     (UTC -11:00) American Samoa, Niue
                                  </option>
                                  <option value="-10">
-                                    (UTC -10:00) Hawaii, Cook Islands, Marquesas Islands
+                                    (UTC -10:00) Hawaii, Cook Islands
+                                 </option>
+                                 <option value="-9.5">
+                                    (UTC -09:30) Marquesas Islands
                                  </option>
                                  <option value="-9">
                                     (UTC -09:00) Gambier Islands, Alaska
@@ -129,17 +132,29 @@
                                  <option value="6">
                                     (UTC +06:00) Almaty, Dhaka, Yekaterinburg
                                  </option>
+                                 <option value="6.5">
+                                    (UTC +06:30) Yangon
+                                 </option>
                                  <option value="7">
                                     (UTC +07:00) Jakarta, Bangkok, Novosibirsk, Hanoi
                                  </option>
                                  <option value="8">
                                     (UTC +08:00) Perth, Beijing, Manila, Singapore, Kuala Lumpur, Denpasar, Krasnoyarsk
                                  </option>
+                                 <option value="8.75">
+                                    (UTC +08:45) Eucla
+                                 </option>
                                  <option value="9">
                                     (UTC +09:00) Seoul, Tokyo, Pyongyang, Ambon, Irkutsk
                                  </option>
+                                 <option value="9.5">
+                                    (UTC +09:30) Adelaide
+                                 </option>
                                  <option value="10">
                                     (UTC +10:00) Canberra, Yakutsk, Port Moresby
+                                 </option>
+                                 <option value="10.5">
+                                    (UTC +10:30) Lord Howe Islands
                                  </option>
                                  <option value="11">
                                     (UTC +11:00) Vladivostok, Noumea
@@ -147,8 +162,14 @@
                                  <option value="12">
                                     (UTC +12:00) Auckland, Suva
                                  </option>
+                                 <option value="12.75">
+                                    (UTC +12:45) Chatham Islands
+                                 </option>
                                  <option value="13">
                                     (UTC +13:00) Phoenix Islands, Tokelau, Tonga
+                                 </option>
+                                 <option value="14">
+                                    (UTC +14:00) Line Islands
                                  </option>
                               </select>
                            </div>

--- a/src/test/resources/pages/instructorFeedbackPublishSuccessful.html
+++ b/src/test/resources/pages/instructorFeedbackPublishSuccessful.html
@@ -79,7 +79,10 @@
                                     (UTC -11:00) American Samoa, Niue
                                  </option>
                                  <option value="-10">
-                                    (UTC -10:00) Hawaii, Cook Islands, Marquesas Islands
+                                    (UTC -10:00) Hawaii, Cook Islands
+                                 </option>
+                                 <option value="-9.5">
+                                    (UTC -09:30) Marquesas Islands
                                  </option>
                                  <option value="-9">
                                     (UTC -09:00) Gambier Islands, Alaska
@@ -147,17 +150,29 @@
                                  <option value="6">
                                     (UTC +06:00) Almaty, Dhaka, Yekaterinburg
                                  </option>
+                                 <option value="6.5">
+                                    (UTC +06:30) Yangon
+                                 </option>
                                  <option value="7">
                                     (UTC +07:00) Jakarta, Bangkok, Novosibirsk, Hanoi
                                  </option>
                                  <option value="8">
                                     (UTC +08:00) Perth, Beijing, Manila, Singapore, Kuala Lumpur, Denpasar, Krasnoyarsk
                                  </option>
+                                 <option value="8.75">
+                                    (UTC +08:45) Eucla
+                                 </option>
                                  <option value="9">
                                     (UTC +09:00) Seoul, Tokyo, Pyongyang, Ambon, Irkutsk
                                  </option>
+                                 <option value="9.5">
+                                    (UTC +09:30) Adelaide
+                                 </option>
                                  <option value="10">
                                     (UTC +10:00) Canberra, Yakutsk, Port Moresby
+                                 </option>
+                                 <option value="10.5">
+                                    (UTC +10:30) Lord Howe Islands
                                  </option>
                                  <option value="11">
                                     (UTC +11:00) Vladivostok, Noumea
@@ -165,8 +180,14 @@
                                  <option value="12">
                                     (UTC +12:00) Auckland, Suva
                                  </option>
+                                 <option value="12.75">
+                                    (UTC +12:45) Chatham Islands
+                                 </option>
                                  <option value="13">
                                     (UTC +13:00) Phoenix Islands, Tokelau, Tonga
+                                 </option>
+                                 <option value="14">
+                                    (UTC +14:00) Line Islands
                                  </option>
                               </select>
                            </div>

--- a/src/test/resources/pages/instructorFeedbackQuestionAddSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackQuestionAddSuccess.html
@@ -61,7 +61,10 @@
                                     (UTC -11:00) American Samoa, Niue
                                  </option>
                                  <option value="-10">
-                                    (UTC -10:00) Hawaii, Cook Islands, Marquesas Islands
+                                    (UTC -10:00) Hawaii, Cook Islands
+                                 </option>
+                                 <option value="-9.5">
+                                    (UTC -09:30) Marquesas Islands
                                  </option>
                                  <option value="-9">
                                     (UTC -09:00) Gambier Islands, Alaska
@@ -129,17 +132,29 @@
                                  <option value="6">
                                     (UTC +06:00) Almaty, Dhaka, Yekaterinburg
                                  </option>
+                                 <option value="6.5">
+                                    (UTC +06:30) Yangon
+                                 </option>
                                  <option value="7">
                                     (UTC +07:00) Jakarta, Bangkok, Novosibirsk, Hanoi
                                  </option>
                                  <option value="8">
                                     (UTC +08:00) Perth, Beijing, Manila, Singapore, Kuala Lumpur, Denpasar, Krasnoyarsk
                                  </option>
+                                 <option value="8.75">
+                                    (UTC +08:45) Eucla
+                                 </option>
                                  <option value="9">
                                     (UTC +09:00) Seoul, Tokyo, Pyongyang, Ambon, Irkutsk
                                  </option>
+                                 <option value="9.5">
+                                    (UTC +09:30) Adelaide
+                                 </option>
                                  <option value="10">
                                     (UTC +10:00) Canberra, Yakutsk, Port Moresby
+                                 </option>
+                                 <option value="10.5">
+                                    (UTC +10:30) Lord Howe Islands
                                  </option>
                                  <option value="11">
                                     (UTC +11:00) Vladivostok, Noumea
@@ -147,8 +162,14 @@
                                  <option value="12">
                                     (UTC +12:00) Auckland, Suva
                                  </option>
+                                 <option value="12.75">
+                                    (UTC +12:45) Chatham Islands
+                                 </option>
                                  <option value="13">
                                     (UTC +13:00) Phoenix Islands, Tokelau, Tonga
+                                 </option>
+                                 <option value="14">
+                                    (UTC +14:00) Line Islands
                                  </option>
                               </select>
                            </div>

--- a/src/test/resources/pages/instructorFeedbackQuestionEditToTeamToTeam.html
+++ b/src/test/resources/pages/instructorFeedbackQuestionEditToTeamToTeam.html
@@ -61,7 +61,10 @@
                                     (UTC -11:00) American Samoa, Niue
                                  </option>
                                  <option value="-10">
-                                    (UTC -10:00) Hawaii, Cook Islands, Marquesas Islands
+                                    (UTC -10:00) Hawaii, Cook Islands
+                                 </option>
+                                 <option value="-9.5">
+                                    (UTC -09:30) Marquesas Islands
                                  </option>
                                  <option value="-9">
                                     (UTC -09:00) Gambier Islands, Alaska
@@ -129,17 +132,29 @@
                                  <option value="6">
                                     (UTC +06:00) Almaty, Dhaka, Yekaterinburg
                                  </option>
+                                 <option value="6.5">
+                                    (UTC +06:30) Yangon
+                                 </option>
                                  <option value="7">
                                     (UTC +07:00) Jakarta, Bangkok, Novosibirsk, Hanoi
                                  </option>
                                  <option value="8">
                                     (UTC +08:00) Perth, Beijing, Manila, Singapore, Kuala Lumpur, Denpasar, Krasnoyarsk
                                  </option>
+                                 <option value="8.75">
+                                    (UTC +08:45) Eucla
+                                 </option>
                                  <option value="9">
                                     (UTC +09:00) Seoul, Tokyo, Pyongyang, Ambon, Irkutsk
                                  </option>
+                                 <option value="9.5">
+                                    (UTC +09:30) Adelaide
+                                 </option>
                                  <option value="10">
                                     (UTC +10:00) Canberra, Yakutsk, Port Moresby
+                                 </option>
+                                 <option value="10.5">
+                                    (UTC +10:30) Lord Howe Islands
                                  </option>
                                  <option value="11">
                                     (UTC +11:00) Vladivostok, Noumea
@@ -147,8 +162,14 @@
                                  <option value="12">
                                     (UTC +12:00) Auckland, Suva
                                  </option>
+                                 <option value="12.75">
+                                    (UTC +12:45) Chatham Islands
+                                 </option>
                                  <option value="13">
                                     (UTC +13:00) Phoenix Islands, Tokelau, Tonga
+                                 </option>
+                                 <option value="14">
+                                    (UTC +14:00) Line Islands
                                  </option>
                               </select>
                            </div>

--- a/src/test/resources/pages/instructorFeedbackQuestionVisibilityOptions.html
+++ b/src/test/resources/pages/instructorFeedbackQuestionVisibilityOptions.html
@@ -61,7 +61,10 @@
                                     (UTC -11:00) American Samoa, Niue
                                  </option>
                                  <option value="-10">
-                                    (UTC -10:00) Hawaii, Cook Islands, Marquesas Islands
+                                    (UTC -10:00) Hawaii, Cook Islands
+                                 </option>
+                                 <option value="-9.5">
+                                    (UTC -09:30) Marquesas Islands
                                  </option>
                                  <option value="-9">
                                     (UTC -09:00) Gambier Islands, Alaska
@@ -129,17 +132,29 @@
                                  <option value="6">
                                     (UTC +06:00) Almaty, Dhaka, Yekaterinburg
                                  </option>
+                                 <option value="6.5">
+                                    (UTC +06:30) Yangon
+                                 </option>
                                  <option value="7">
                                     (UTC +07:00) Jakarta, Bangkok, Novosibirsk, Hanoi
                                  </option>
                                  <option value="8">
                                     (UTC +08:00) Perth, Beijing, Manila, Singapore, Kuala Lumpur, Denpasar, Krasnoyarsk
                                  </option>
+                                 <option value="8.75">
+                                    (UTC +08:45) Eucla
+                                 </option>
                                  <option value="9">
                                     (UTC +09:00) Seoul, Tokyo, Pyongyang, Ambon, Irkutsk
                                  </option>
+                                 <option value="9.5">
+                                    (UTC +09:30) Adelaide
+                                 </option>
                                  <option value="10">
                                     (UTC +10:00) Canberra, Yakutsk, Port Moresby
+                                 </option>
+                                 <option value="10.5">
+                                    (UTC +10:30) Lord Howe Islands
                                  </option>
                                  <option value="11">
                                     (UTC +11:00) Vladivostok, Noumea
@@ -147,8 +162,14 @@
                                  <option value="12">
                                     (UTC +12:00) Auckland, Suva
                                  </option>
+                                 <option value="12.75">
+                                    (UTC +12:45) Chatham Islands
+                                 </option>
                                  <option value="13">
                                     (UTC +13:00) Phoenix Islands, Tokelau, Tonga
+                                 </option>
+                                 <option value="14">
+                                    (UTC +14:00) Line Islands
                                  </option>
                               </select>
                            </div>

--- a/src/test/resources/pages/instructorFeedbackQuestionVisibilityPreview.html
+++ b/src/test/resources/pages/instructorFeedbackQuestionVisibilityPreview.html
@@ -61,7 +61,10 @@
                                     (UTC -11:00) American Samoa, Niue
                                  </option>
                                  <option value="-10">
-                                    (UTC -10:00) Hawaii, Cook Islands, Marquesas Islands
+                                    (UTC -10:00) Hawaii, Cook Islands
+                                 </option>
+                                 <option value="-9.5">
+                                    (UTC -09:30) Marquesas Islands
                                  </option>
                                  <option value="-9">
                                     (UTC -09:00) Gambier Islands, Alaska
@@ -129,17 +132,29 @@
                                  <option value="6">
                                     (UTC +06:00) Almaty, Dhaka, Yekaterinburg
                                  </option>
+                                 <option value="6.5">
+                                    (UTC +06:30) Yangon
+                                 </option>
                                  <option value="7">
                                     (UTC +07:00) Jakarta, Bangkok, Novosibirsk, Hanoi
                                  </option>
                                  <option value="8">
                                     (UTC +08:00) Perth, Beijing, Manila, Singapore, Kuala Lumpur, Denpasar, Krasnoyarsk
                                  </option>
+                                 <option value="8.75">
+                                    (UTC +08:45) Eucla
+                                 </option>
                                  <option value="9">
                                     (UTC +09:00) Seoul, Tokyo, Pyongyang, Ambon, Irkutsk
                                  </option>
+                                 <option value="9.5">
+                                    (UTC +09:30) Adelaide
+                                 </option>
                                  <option value="10">
                                     (UTC +10:00) Canberra, Yakutsk, Port Moresby
+                                 </option>
+                                 <option value="10.5">
+                                    (UTC +10:30) Lord Howe Islands
                                  </option>
                                  <option value="11">
                                     (UTC +11:00) Vladivostok, Noumea
@@ -147,8 +162,14 @@
                                  <option value="12">
                                     (UTC +12:00) Auckland, Suva
                                  </option>
+                                 <option value="12.75">
+                                    (UTC +12:45) Chatham Islands
+                                 </option>
                                  <option value="13">
                                     (UTC +13:00) Phoenix Islands, Tokelau, Tonga
+                                 </option>
+                                 <option value="14">
+                                    (UTC +14:00) Line Islands
                                  </option>
                               </select>
                            </div>

--- a/src/test/resources/pages/instructorFeedbackRubricQuestionAddSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackRubricQuestionAddSuccess.html
@@ -61,7 +61,10 @@
                                     (UTC -11:00) American Samoa, Niue
                                  </option>
                                  <option value="-10">
-                                    (UTC -10:00) Hawaii, Cook Islands, Marquesas Islands
+                                    (UTC -10:00) Hawaii, Cook Islands
+                                 </option>
+                                 <option value="-9.5">
+                                    (UTC -09:30) Marquesas Islands
                                  </option>
                                  <option value="-9">
                                     (UTC -09:00) Gambier Islands, Alaska
@@ -129,17 +132,29 @@
                                  <option value="6">
                                     (UTC +06:00) Almaty, Dhaka, Yekaterinburg
                                  </option>
+                                 <option value="6.5">
+                                    (UTC +06:30) Yangon
+                                 </option>
                                  <option value="7">
                                     (UTC +07:00) Jakarta, Bangkok, Novosibirsk, Hanoi
                                  </option>
                                  <option value="8">
                                     (UTC +08:00) Perth, Beijing, Manila, Singapore, Kuala Lumpur, Denpasar, Krasnoyarsk
                                  </option>
+                                 <option value="8.75">
+                                    (UTC +08:45) Eucla
+                                 </option>
                                  <option value="9">
                                     (UTC +09:00) Seoul, Tokyo, Pyongyang, Ambon, Irkutsk
                                  </option>
+                                 <option value="9.5">
+                                    (UTC +09:30) Adelaide
+                                 </option>
                                  <option value="10">
                                     (UTC +10:00) Canberra, Yakutsk, Port Moresby
+                                 </option>
+                                 <option value="10.5">
+                                    (UTC +10:30) Lord Howe Islands
                                  </option>
                                  <option value="11">
                                     (UTC +11:00) Vladivostok, Noumea
@@ -147,8 +162,14 @@
                                  <option value="12">
                                     (UTC +12:00) Auckland, Suva
                                  </option>
+                                 <option value="12.75">
+                                    (UTC +12:45) Chatham Islands
+                                 </option>
                                  <option value="13">
                                     (UTC +13:00) Phoenix Islands, Tokelau, Tonga
+                                 </option>
+                                 <option value="14">
+                                    (UTC +14:00) Line Islands
                                  </option>
                               </select>
                            </div>

--- a/src/test/resources/pages/instructorFeedbackRubricQuestionEdit.html
+++ b/src/test/resources/pages/instructorFeedbackRubricQuestionEdit.html
@@ -61,7 +61,10 @@
                                     (UTC -11:00) American Samoa, Niue
                                  </option>
                                  <option value="-10">
-                                    (UTC -10:00) Hawaii, Cook Islands, Marquesas Islands
+                                    (UTC -10:00) Hawaii, Cook Islands
+                                 </option>
+                                 <option value="-9.5">
+                                    (UTC -09:30) Marquesas Islands
                                  </option>
                                  <option value="-9">
                                     (UTC -09:00) Gambier Islands, Alaska
@@ -129,17 +132,29 @@
                                  <option value="6">
                                     (UTC +06:00) Almaty, Dhaka, Yekaterinburg
                                  </option>
+                                 <option value="6.5">
+                                    (UTC +06:30) Yangon
+                                 </option>
                                  <option value="7">
                                     (UTC +07:00) Jakarta, Bangkok, Novosibirsk, Hanoi
                                  </option>
                                  <option value="8">
                                     (UTC +08:00) Perth, Beijing, Manila, Singapore, Kuala Lumpur, Denpasar, Krasnoyarsk
                                  </option>
+                                 <option value="8.75">
+                                    (UTC +08:45) Eucla
+                                 </option>
                                  <option value="9">
                                     (UTC +09:00) Seoul, Tokyo, Pyongyang, Ambon, Irkutsk
                                  </option>
+                                 <option value="9.5">
+                                    (UTC +09:30) Adelaide
+                                 </option>
                                  <option value="10">
                                     (UTC +10:00) Canberra, Yakutsk, Port Moresby
+                                 </option>
+                                 <option value="10.5">
+                                    (UTC +10:30) Lord Howe Islands
                                  </option>
                                  <option value="11">
                                     (UTC +11:00) Vladivostok, Noumea
@@ -147,8 +162,14 @@
                                  <option value="12">
                                     (UTC +12:00) Auckland, Suva
                                  </option>
+                                 <option value="12.75">
+                                    (UTC +12:45) Chatham Islands
+                                 </option>
                                  <option value="13">
                                     (UTC +13:00) Phoenix Islands, Tokelau, Tonga
+                                 </option>
+                                 <option value="14">
+                                    (UTC +14:00) Line Islands
                                  </option>
                               </select>
                            </div>

--- a/src/test/resources/pages/instructorFeedbackRubricQuestionEditChoiceSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackRubricQuestionEditChoiceSuccess.html
@@ -61,7 +61,10 @@
                                     (UTC -11:00) American Samoa, Niue
                                  </option>
                                  <option value="-10">
-                                    (UTC -10:00) Hawaii, Cook Islands, Marquesas Islands
+                                    (UTC -10:00) Hawaii, Cook Islands
+                                 </option>
+                                 <option value="-9.5">
+                                    (UTC -09:30) Marquesas Islands
                                  </option>
                                  <option value="-9">
                                     (UTC -09:00) Gambier Islands, Alaska
@@ -129,17 +132,29 @@
                                  <option value="6">
                                     (UTC +06:00) Almaty, Dhaka, Yekaterinburg
                                  </option>
+                                 <option value="6.5">
+                                    (UTC +06:30) Yangon
+                                 </option>
                                  <option value="7">
                                     (UTC +07:00) Jakarta, Bangkok, Novosibirsk, Hanoi
                                  </option>
                                  <option value="8">
                                     (UTC +08:00) Perth, Beijing, Manila, Singapore, Kuala Lumpur, Denpasar, Krasnoyarsk
                                  </option>
+                                 <option value="8.75">
+                                    (UTC +08:45) Eucla
+                                 </option>
                                  <option value="9">
                                     (UTC +09:00) Seoul, Tokyo, Pyongyang, Ambon, Irkutsk
                                  </option>
+                                 <option value="9.5">
+                                    (UTC +09:30) Adelaide
+                                 </option>
                                  <option value="10">
                                     (UTC +10:00) Canberra, Yakutsk, Port Moresby
+                                 </option>
+                                 <option value="10.5">
+                                    (UTC +10:30) Lord Howe Islands
                                  </option>
                                  <option value="11">
                                     (UTC +11:00) Vladivostok, Noumea
@@ -147,8 +162,14 @@
                                  <option value="12">
                                     (UTC +12:00) Auckland, Suva
                                  </option>
+                                 <option value="12.75">
+                                    (UTC +12:45) Chatham Islands
+                                 </option>
                                  <option value="13">
                                     (UTC +13:00) Phoenix Islands, Tokelau, Tonga
+                                 </option>
+                                 <option value="14">
+                                    (UTC +14:00) Line Islands
                                  </option>
                               </select>
                            </div>

--- a/src/test/resources/pages/instructorFeedbackRubricQuestionEditDescriptionSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackRubricQuestionEditDescriptionSuccess.html
@@ -61,7 +61,10 @@
                                     (UTC -11:00) American Samoa, Niue
                                  </option>
                                  <option value="-10">
-                                    (UTC -10:00) Hawaii, Cook Islands, Marquesas Islands
+                                    (UTC -10:00) Hawaii, Cook Islands
+                                 </option>
+                                 <option value="-9.5">
+                                    (UTC -09:30) Marquesas Islands
                                  </option>
                                  <option value="-9">
                                     (UTC -09:00) Gambier Islands, Alaska
@@ -129,17 +132,29 @@
                                  <option value="6">
                                     (UTC +06:00) Almaty, Dhaka, Yekaterinburg
                                  </option>
+                                 <option value="6.5">
+                                    (UTC +06:30) Yangon
+                                 </option>
                                  <option value="7">
                                     (UTC +07:00) Jakarta, Bangkok, Novosibirsk, Hanoi
                                  </option>
                                  <option value="8">
                                     (UTC +08:00) Perth, Beijing, Manila, Singapore, Kuala Lumpur, Denpasar, Krasnoyarsk
                                  </option>
+                                 <option value="8.75">
+                                    (UTC +08:45) Eucla
+                                 </option>
                                  <option value="9">
                                     (UTC +09:00) Seoul, Tokyo, Pyongyang, Ambon, Irkutsk
                                  </option>
+                                 <option value="9.5">
+                                    (UTC +09:30) Adelaide
+                                 </option>
                                  <option value="10">
                                     (UTC +10:00) Canberra, Yakutsk, Port Moresby
+                                 </option>
+                                 <option value="10.5">
+                                    (UTC +10:30) Lord Howe Islands
                                  </option>
                                  <option value="11">
                                     (UTC +11:00) Vladivostok, Noumea
@@ -147,8 +162,14 @@
                                  <option value="12">
                                     (UTC +12:00) Auckland, Suva
                                  </option>
+                                 <option value="12.75">
+                                    (UTC +12:45) Chatham Islands
+                                 </option>
                                  <option value="13">
                                     (UTC +13:00) Phoenix Islands, Tokelau, Tonga
+                                 </option>
+                                 <option value="14">
+                                    (UTC +14:00) Line Islands
                                  </option>
                               </select>
                            </div>

--- a/src/test/resources/pages/instructorFeedbackRubricQuestionEditSubQuestionSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackRubricQuestionEditSubQuestionSuccess.html
@@ -61,7 +61,10 @@
                                     (UTC -11:00) American Samoa, Niue
                                  </option>
                                  <option value="-10">
-                                    (UTC -10:00) Hawaii, Cook Islands, Marquesas Islands
+                                    (UTC -10:00) Hawaii, Cook Islands
+                                 </option>
+                                 <option value="-9.5">
+                                    (UTC -09:30) Marquesas Islands
                                  </option>
                                  <option value="-9">
                                     (UTC -09:00) Gambier Islands, Alaska
@@ -129,17 +132,29 @@
                                  <option value="6">
                                     (UTC +06:00) Almaty, Dhaka, Yekaterinburg
                                  </option>
+                                 <option value="6.5">
+                                    (UTC +06:30) Yangon
+                                 </option>
                                  <option value="7">
                                     (UTC +07:00) Jakarta, Bangkok, Novosibirsk, Hanoi
                                  </option>
                                  <option value="8">
                                     (UTC +08:00) Perth, Beijing, Manila, Singapore, Kuala Lumpur, Denpasar, Krasnoyarsk
                                  </option>
+                                 <option value="8.75">
+                                    (UTC +08:45) Eucla
+                                 </option>
                                  <option value="9">
                                     (UTC +09:00) Seoul, Tokyo, Pyongyang, Ambon, Irkutsk
                                  </option>
+                                 <option value="9.5">
+                                    (UTC +09:30) Adelaide
+                                 </option>
                                  <option value="10">
                                     (UTC +10:00) Canberra, Yakutsk, Port Moresby
+                                 </option>
+                                 <option value="10.5">
+                                    (UTC +10:30) Lord Howe Islands
                                  </option>
                                  <option value="11">
                                     (UTC +11:00) Vladivostok, Noumea
@@ -147,8 +162,14 @@
                                  <option value="12">
                                     (UTC +12:00) Auckland, Suva
                                  </option>
+                                 <option value="12.75">
+                                    (UTC +12:45) Chatham Islands
+                                 </option>
                                  <option value="13">
                                     (UTC +13:00) Phoenix Islands, Tokelau, Tonga
+                                 </option>
+                                 <option value="14">
+                                    (UTC +14:00) Line Islands
                                  </option>
                               </select>
                            </div>

--- a/src/test/resources/pages/instructorFeedbackRubricQuestionEditSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackRubricQuestionEditSuccess.html
@@ -61,7 +61,10 @@
                                     (UTC -11:00) American Samoa, Niue
                                  </option>
                                  <option value="-10">
-                                    (UTC -10:00) Hawaii, Cook Islands, Marquesas Islands
+                                    (UTC -10:00) Hawaii, Cook Islands
+                                 </option>
+                                 <option value="-9.5">
+                                    (UTC -09:30) Marquesas Islands
                                  </option>
                                  <option value="-9">
                                     (UTC -09:00) Gambier Islands, Alaska
@@ -129,17 +132,29 @@
                                  <option value="6">
                                     (UTC +06:00) Almaty, Dhaka, Yekaterinburg
                                  </option>
+                                 <option value="6.5">
+                                    (UTC +06:30) Yangon
+                                 </option>
                                  <option value="7">
                                     (UTC +07:00) Jakarta, Bangkok, Novosibirsk, Hanoi
                                  </option>
                                  <option value="8">
                                     (UTC +08:00) Perth, Beijing, Manila, Singapore, Kuala Lumpur, Denpasar, Krasnoyarsk
                                  </option>
+                                 <option value="8.75">
+                                    (UTC +08:45) Eucla
+                                 </option>
                                  <option value="9">
                                     (UTC +09:00) Seoul, Tokyo, Pyongyang, Ambon, Irkutsk
                                  </option>
+                                 <option value="9.5">
+                                    (UTC +09:30) Adelaide
+                                 </option>
                                  <option value="10">
                                     (UTC +10:00) Canberra, Yakutsk, Port Moresby
+                                 </option>
+                                 <option value="10.5">
+                                    (UTC +10:30) Lord Howe Islands
                                  </option>
                                  <option value="11">
                                     (UTC +11:00) Vladivostok, Noumea
@@ -147,8 +162,14 @@
                                  <option value="12">
                                     (UTC +12:00) Auckland, Suva
                                  </option>
+                                 <option value="12.75">
+                                    (UTC +12:45) Chatham Islands
+                                 </option>
                                  <option value="13">
                                     (UTC +13:00) Phoenix Islands, Tokelau, Tonga
+                                 </option>
+                                 <option value="14">
+                                    (UTC +14:00) Line Islands
                                  </option>
                               </select>
                            </div>

--- a/src/test/resources/pages/instructorFeedbackTeamPeerEvalTemplateAddSuccess.html
+++ b/src/test/resources/pages/instructorFeedbackTeamPeerEvalTemplateAddSuccess.html
@@ -61,7 +61,10 @@
                                     (UTC -11:00) American Samoa, Niue
                                  </option>
                                  <option value="-10">
-                                    (UTC -10:00) Hawaii, Cook Islands, Marquesas Islands
+                                    (UTC -10:00) Hawaii, Cook Islands
+                                 </option>
+                                 <option value="-9.5">
+                                    (UTC -09:30) Marquesas Islands
                                  </option>
                                  <option value="-9">
                                     (UTC -09:00) Gambier Islands, Alaska
@@ -129,17 +132,29 @@
                                  <option value="6">
                                     (UTC +06:00) Almaty, Dhaka, Yekaterinburg
                                  </option>
+                                 <option value="6.5">
+                                    (UTC +06:30) Yangon
+                                 </option>
                                  <option value="7">
                                     (UTC +07:00) Jakarta, Bangkok, Novosibirsk, Hanoi
                                  </option>
                                  <option selected="selected" value="8">
                                     (UTC +08:00) Perth, Beijing, Manila, Singapore, Kuala Lumpur, Denpasar, Krasnoyarsk
                                  </option>
+                                 <option value="8.75">
+                                    (UTC +08:45) Eucla
+                                 </option>
                                  <option value="9">
                                     (UTC +09:00) Seoul, Tokyo, Pyongyang, Ambon, Irkutsk
                                  </option>
+                                 <option value="9.5">
+                                    (UTC +09:30) Adelaide
+                                 </option>
                                  <option value="10">
                                     (UTC +10:00) Canberra, Yakutsk, Port Moresby
+                                 </option>
+                                 <option value="10.5">
+                                    (UTC +10:30) Lord Howe Islands
                                  </option>
                                  <option value="11">
                                     (UTC +11:00) Vladivostok, Noumea
@@ -147,8 +162,14 @@
                                  <option value="12">
                                     (UTC +12:00) Auckland, Suva
                                  </option>
+                                 <option value="12.75">
+                                    (UTC +12:45) Chatham Islands
+                                 </option>
                                  <option value="13">
                                     (UTC +13:00) Phoenix Islands, Tokelau, Tonga
+                                 </option>
+                                 <option value="14">
+                                    (UTC +14:00) Line Islands
                                  </option>
                               </select>
                            </div>

--- a/src/test/resources/pages/instructorFeedbackUnpublishSuccessful.html
+++ b/src/test/resources/pages/instructorFeedbackUnpublishSuccessful.html
@@ -79,7 +79,10 @@
                                     (UTC -11:00) American Samoa, Niue
                                  </option>
                                  <option value="-10">
-                                    (UTC -10:00) Hawaii, Cook Islands, Marquesas Islands
+                                    (UTC -10:00) Hawaii, Cook Islands
+                                 </option>
+                                 <option value="-9.5">
+                                    (UTC -09:30) Marquesas Islands
                                  </option>
                                  <option value="-9">
                                     (UTC -09:00) Gambier Islands, Alaska
@@ -147,17 +150,29 @@
                                  <option value="6">
                                     (UTC +06:00) Almaty, Dhaka, Yekaterinburg
                                  </option>
+                                 <option value="6.5">
+                                    (UTC +06:30) Yangon
+                                 </option>
                                  <option value="7">
                                     (UTC +07:00) Jakarta, Bangkok, Novosibirsk, Hanoi
                                  </option>
                                  <option value="8">
                                     (UTC +08:00) Perth, Beijing, Manila, Singapore, Kuala Lumpur, Denpasar, Krasnoyarsk
                                  </option>
+                                 <option value="8.75">
+                                    (UTC +08:45) Eucla
+                                 </option>
                                  <option value="9">
                                     (UTC +09:00) Seoul, Tokyo, Pyongyang, Ambon, Irkutsk
                                  </option>
+                                 <option value="9.5">
+                                    (UTC +09:30) Adelaide
+                                 </option>
                                  <option value="10">
                                     (UTC +10:00) Canberra, Yakutsk, Port Moresby
+                                 </option>
+                                 <option value="10.5">
+                                    (UTC +10:30) Lord Howe Islands
                                  </option>
                                  <option value="11">
                                     (UTC +11:00) Vladivostok, Noumea
@@ -165,8 +180,14 @@
                                  <option value="12">
                                     (UTC +12:00) Auckland, Suva
                                  </option>
+                                 <option value="12.75">
+                                    (UTC +12:45) Chatham Islands
+                                 </option>
                                  <option value="13">
                                     (UTC +13:00) Phoenix Islands, Tokelau, Tonga
+                                 </option>
+                                 <option value="14">
+                                    (UTC +14:00) Line Islands
                                  </option>
                               </select>
                            </div>

--- a/src/test/resources/pages/newlyJoinedInstructorFeedbackSessionPublished.html
+++ b/src/test/resources/pages/newlyJoinedInstructorFeedbackSessionPublished.html
@@ -76,7 +76,10 @@
                                     (UTC -11:00) American Samoa, Niue
                                  </option>
                                  <option value="-10">
-                                    (UTC -10:00) Hawaii, Cook Islands, Marquesas Islands
+                                    (UTC -10:00) Hawaii, Cook Islands
+                                 </option>
+                                 <option value="-9.5">
+                                    (UTC -09:30) Marquesas Islands
                                  </option>
                                  <option value="-9">
                                     (UTC -09:00) Gambier Islands, Alaska
@@ -144,17 +147,29 @@
                                  <option value="6">
                                     (UTC +06:00) Almaty, Dhaka, Yekaterinburg
                                  </option>
+                                 <option value="6.5">
+                                    (UTC +06:30) Yangon
+                                 </option>
                                  <option value="7">
                                     (UTC +07:00) Jakarta, Bangkok, Novosibirsk, Hanoi
                                  </option>
                                  <option value="8">
                                     (UTC +08:00) Perth, Beijing, Manila, Singapore, Kuala Lumpur, Denpasar, Krasnoyarsk
                                  </option>
+                                 <option value="8.75">
+                                    (UTC +08:45) Eucla
+                                 </option>
                                  <option value="9">
                                     (UTC +09:00) Seoul, Tokyo, Pyongyang, Ambon, Irkutsk
                                  </option>
+                                 <option value="9.5">
+                                    (UTC +09:30) Adelaide
+                                 </option>
                                  <option value="10">
                                     (UTC +10:00) Canberra, Yakutsk, Port Moresby
+                                 </option>
+                                 <option value="10.5">
+                                    (UTC +10:30) Lord Howe Islands
                                  </option>
                                  <option value="11">
                                     (UTC +11:00) Vladivostok, Noumea
@@ -162,8 +177,14 @@
                                  <option value="12">
                                     (UTC +12:00) Auckland, Suva
                                  </option>
+                                 <option value="12.75">
+                                    (UTC +12:45) Chatham Islands
+                                 </option>
                                  <option value="13">
                                     (UTC +13:00) Phoenix Islands, Tokelau, Tonga
+                                 </option>
+                                 <option value="14">
+                                    (UTC +14:00) Line Islands
                                  </option>
                               </select>
                            </div>

--- a/src/test/resources/pages/newlyJoinedInstructorFeedbackSessionRemind.html
+++ b/src/test/resources/pages/newlyJoinedInstructorFeedbackSessionRemind.html
@@ -76,7 +76,10 @@
                                     (UTC -11:00) American Samoa, Niue
                                  </option>
                                  <option value="-10">
-                                    (UTC -10:00) Hawaii, Cook Islands, Marquesas Islands
+                                    (UTC -10:00) Hawaii, Cook Islands
+                                 </option>
+                                 <option value="-9.5">
+                                    (UTC -09:30) Marquesas Islands
                                  </option>
                                  <option value="-9">
                                     (UTC -09:00) Gambier Islands, Alaska
@@ -144,17 +147,29 @@
                                  <option value="6">
                                     (UTC +06:00) Almaty, Dhaka, Yekaterinburg
                                  </option>
+                                 <option value="6.5">
+                                    (UTC +06:30) Yangon
+                                 </option>
                                  <option value="7">
                                     (UTC +07:00) Jakarta, Bangkok, Novosibirsk, Hanoi
                                  </option>
                                  <option value="8">
                                     (UTC +08:00) Perth, Beijing, Manila, Singapore, Kuala Lumpur, Denpasar, Krasnoyarsk
                                  </option>
+                                 <option value="8.75">
+                                    (UTC +08:45) Eucla
+                                 </option>
                                  <option value="9">
                                     (UTC +09:00) Seoul, Tokyo, Pyongyang, Ambon, Irkutsk
                                  </option>
+                                 <option value="9.5">
+                                    (UTC +09:30) Adelaide
+                                 </option>
                                  <option value="10">
                                     (UTC +10:00) Canberra, Yakutsk, Port Moresby
+                                 </option>
+                                 <option value="10.5">
+                                    (UTC +10:30) Lord Howe Islands
                                  </option>
                                  <option value="11">
                                     (UTC +11:00) Vladivostok, Noumea
@@ -162,8 +177,14 @@
                                  <option value="12">
                                     (UTC +12:00) Auckland, Suva
                                  </option>
+                                 <option value="12.75">
+                                    (UTC +12:45) Chatham Islands
+                                 </option>
                                  <option value="13">
                                     (UTC +13:00) Phoenix Islands, Tokelau, Tonga
+                                 </option>
+                                 <option value="14">
+                                    (UTC +14:00) Line Islands
                                  </option>
                               </select>
                            </div>

--- a/src/test/resources/pages/newlyJoinedInstructorFeedbackSessionSuccessEdited.html
+++ b/src/test/resources/pages/newlyJoinedInstructorFeedbackSessionSuccessEdited.html
@@ -61,7 +61,10 @@
                                     (UTC -11:00) American Samoa, Niue
                                  </option>
                                  <option value="-10">
-                                    (UTC -10:00) Hawaii, Cook Islands, Marquesas Islands
+                                    (UTC -10:00) Hawaii, Cook Islands
+                                 </option>
+                                 <option value="-9.5">
+                                    (UTC -09:30) Marquesas Islands
                                  </option>
                                  <option value="-9">
                                     (UTC -09:00) Gambier Islands, Alaska
@@ -129,17 +132,29 @@
                                  <option value="6">
                                     (UTC +06:00) Almaty, Dhaka, Yekaterinburg
                                  </option>
+                                 <option value="6.5">
+                                    (UTC +06:30) Yangon
+                                 </option>
                                  <option value="7">
                                     (UTC +07:00) Jakarta, Bangkok, Novosibirsk, Hanoi
                                  </option>
                                  <option selected="selected" value="8">
                                     (UTC +08:00) Perth, Beijing, Manila, Singapore, Kuala Lumpur, Denpasar, Krasnoyarsk
                                  </option>
+                                 <option value="8.75">
+                                    (UTC +08:45) Eucla
+                                 </option>
                                  <option value="9">
                                     (UTC +09:00) Seoul, Tokyo, Pyongyang, Ambon, Irkutsk
                                  </option>
+                                 <option value="9.5">
+                                    (UTC +09:30) Adelaide
+                                 </option>
                                  <option value="10">
                                     (UTC +10:00) Canberra, Yakutsk, Port Moresby
+                                 </option>
+                                 <option value="10.5">
+                                    (UTC +10:30) Lord Howe Islands
                                  </option>
                                  <option value="11">
                                     (UTC +11:00) Vladivostok, Noumea
@@ -147,8 +162,14 @@
                                  <option value="12">
                                     (UTC +12:00) Auckland, Suva
                                  </option>
+                                 <option value="12.75">
+                                    (UTC +12:45) Chatham Islands
+                                 </option>
                                  <option value="13">
                                     (UTC +13:00) Phoenix Islands, Tokelau, Tonga
+                                 </option>
+                                 <option value="14">
+                                    (UTC +14:00) Line Islands
                                  </option>
                               </select>
                            </div>

--- a/src/test/resources/pages/newlyJoinedInstructorFeedbackSessionUnpublished.html
+++ b/src/test/resources/pages/newlyJoinedInstructorFeedbackSessionUnpublished.html
@@ -76,7 +76,10 @@
                                     (UTC -11:00) American Samoa, Niue
                                  </option>
                                  <option value="-10">
-                                    (UTC -10:00) Hawaii, Cook Islands, Marquesas Islands
+                                    (UTC -10:00) Hawaii, Cook Islands
+                                 </option>
+                                 <option value="-9.5">
+                                    (UTC -09:30) Marquesas Islands
                                  </option>
                                  <option value="-9">
                                     (UTC -09:00) Gambier Islands, Alaska
@@ -144,17 +147,29 @@
                                  <option value="6">
                                     (UTC +06:00) Almaty, Dhaka, Yekaterinburg
                                  </option>
+                                 <option value="6.5">
+                                    (UTC +06:30) Yangon
+                                 </option>
                                  <option value="7">
                                     (UTC +07:00) Jakarta, Bangkok, Novosibirsk, Hanoi
                                  </option>
                                  <option value="8">
                                     (UTC +08:00) Perth, Beijing, Manila, Singapore, Kuala Lumpur, Denpasar, Krasnoyarsk
                                  </option>
+                                 <option value="8.75">
+                                    (UTC +08:45) Eucla
+                                 </option>
                                  <option value="9">
                                     (UTC +09:00) Seoul, Tokyo, Pyongyang, Ambon, Irkutsk
                                  </option>
+                                 <option value="9.5">
+                                    (UTC +09:30) Adelaide
+                                 </option>
                                  <option value="10">
                                     (UTC +10:00) Canberra, Yakutsk, Port Moresby
+                                 </option>
+                                 <option value="10.5">
+                                    (UTC +10:30) Lord Howe Islands
                                  </option>
                                  <option value="11">
                                     (UTC +11:00) Vladivostok, Noumea
@@ -162,8 +177,14 @@
                                  <option value="12">
                                     (UTC +12:00) Auckland, Suva
                                  </option>
+                                 <option value="12.75">
+                                    (UTC +12:45) Chatham Islands
+                                 </option>
                                  <option value="13">
                                     (UTC +13:00) Phoenix Islands, Tokelau, Tonga
+                                 </option>
+                                 <option value="14">
+                                    (UTC +14:00) Line Islands
                                  </option>
                               </select>
                            </div>

--- a/src/test/resources/pages/newlyJoinedInstructorFeedbacksPage.html
+++ b/src/test/resources/pages/newlyJoinedInstructorFeedbacksPage.html
@@ -76,7 +76,10 @@
                                     (UTC -11:00) American Samoa, Niue
                                  </option>
                                  <option value="-10">
-                                    (UTC -10:00) Hawaii, Cook Islands, Marquesas Islands
+                                    (UTC -10:00) Hawaii, Cook Islands
+                                 </option>
+                                 <option value="-9.5">
+                                    (UTC -09:30) Marquesas Islands
                                  </option>
                                  <option value="-9">
                                     (UTC -09:00) Gambier Islands, Alaska
@@ -144,17 +147,29 @@
                                  <option value="6">
                                     (UTC +06:00) Almaty, Dhaka, Yekaterinburg
                                  </option>
+                                 <option value="6.5">
+                                    (UTC +06:30) Yangon
+                                 </option>
                                  <option value="7">
                                     (UTC +07:00) Jakarta, Bangkok, Novosibirsk, Hanoi
                                  </option>
                                  <option value="8">
                                     (UTC +08:00) Perth, Beijing, Manila, Singapore, Kuala Lumpur, Denpasar, Krasnoyarsk
                                  </option>
+                                 <option value="8.75">
+                                    (UTC +08:45) Eucla
+                                 </option>
                                  <option value="9">
                                     (UTC +09:00) Seoul, Tokyo, Pyongyang, Ambon, Irkutsk
                                  </option>
+                                 <option value="9.5">
+                                    (UTC +09:30) Adelaide
+                                 </option>
                                  <option value="10">
                                     (UTC +10:00) Canberra, Yakutsk, Port Moresby
+                                 </option>
+                                 <option value="10.5">
+                                    (UTC +10:30) Lord Howe Islands
                                  </option>
                                  <option value="11">
                                     (UTC +11:00) Vladivostok, Noumea
@@ -162,8 +177,14 @@
                                  <option value="12">
                                     (UTC +12:00) Auckland, Suva
                                  </option>
+                                 <option value="12.75">
+                                    (UTC +12:45) Chatham Islands
+                                 </option>
                                  <option value="13">
                                     (UTC +13:00) Phoenix Islands, Tokelau, Tonga
+                                 </option>
+                                 <option value="14">
+                                    (UTC +14:00) Line Islands
                                  </option>
                               </select>
                            </div>


### PR DESCRIPTION
Fixes #4467 
As mentioned in the method documentation, the time zones are first taken from [here](https://en.wikipedia.org/wiki/List_of_UTC_time_offsets) and then verified from [here](http://www.timeanddate.com/time/zones/) (this is not exactly what's written, but I found verifying from this site much easier).