### PR TITLE
Use $(document).on('ready'... instead of onload #3769

### DIFF
--- a/src/main/webapp/WEB-INF/tags/instructor/instructorPage.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/instructorPage.tag
@@ -4,8 +4,7 @@
 <%@ attribute name="pageTitle" required="true" %>
 <%@ attribute name="jsIncludes" %>
 <%@ attribute name="bodyTitle" required="true" %>
-<%@ attribute name="bodyOnload" %>
-<t:page pageTitle="${pageTitle}" bodyTitle="${bodyTitle}" bodyOnload="${bodyOnload}">
+<t:page pageTitle="${pageTitle}" bodyTitle="${bodyTitle}">
     <jsp:attribute name="jsIncludes">
         ${jsIncludes}
     </jsp:attribute>

--- a/src/main/webapp/WEB-INF/tags/instructor/instructorPageCustom.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/instructorPageCustom.tag
@@ -5,14 +5,12 @@
 <%@ attribute name="pageTitle" required="true" %>
 <%@ attribute name="jsIncludes" %>
 <%@ attribute name="bodyTitle" required="true" %>
-<%@ attribute name="bodyOnload" %>
-
 <%@ attribute name="altNavBar" %>
 <%@ attribute name="altFooter" %>
 <c:set var="defaultNavBar"><ti:navBar /></c:set>
 <c:set var="defaultFooter"><t:bodyFooter /></c:set>
 
-<t:page pageTitle="${pageTitle}" bodyTitle="${bodyTitle}" bodyOnload="${bodyOnload}">
+<t:page pageTitle="${pageTitle}" bodyTitle="${bodyTitle}">
     <jsp:attribute name="jsIncludes">
         ${jsIncludes}
     </jsp:attribute>

--- a/src/main/webapp/WEB-INF/tags/page.tag
+++ b/src/main/webapp/WEB-INF/tags/page.tag
@@ -5,7 +5,6 @@
 <%@ attribute name="navBar" required="true" fragment="true" %>
 <%@ attribute name="bodyTitle" required="true" %>
 <%@ attribute name="bodyFooter" required="true" fragment="true" %>
-<%@ attribute name="bodyOnload" %>
 <!DOCTYPE html>
 <html>
 <head>
@@ -35,7 +34,7 @@
 
     <jsp:invoke fragment="jsIncludes" />
 </head>
-<body ${bodyOnload}>
+<body>
     <jsp:invoke fragment="navBar" />
     <div class="container" id="mainContent">
         <t:bodyHeader title="${bodyTitle}" />

--- a/src/main/webapp/js/adminSearch.js
+++ b/src/main/webapp/js/adminSearch.js
@@ -1,4 +1,5 @@
 $(document).ready(function() {
+    $(".fslink").hide();
 
 	$("#rebuildButton").click(function() {
 
@@ -119,7 +120,3 @@ function adminSearchCollapseAllInstructors(){
 	$(".fslink_instructor").hide();
 	$(".instructorRow").attr("class", "instructorRow");
 }
-
-onload = function() {
-	$(".fslink").hide();
-};

--- a/src/main/webapp/js/instructor.js
+++ b/src/main/webapp/js/instructor.js
@@ -6,11 +6,7 @@
 // Initial load-up
 //-----------------------------------------------------------------------------
 
-var onLoadFunction = function() {
-    if (typeof doPageSpecificOnload !== 'undefined') {
-        doPageSpecificOnload();
-    };
-    
+$(document).ready(function() {
     bindErrorImages('.profile-pic-icon-hover, .profile-pic-icon-click');
     
     // bind the show picture onclick events
@@ -18,13 +14,7 @@ var onLoadFunction = function() {
     
     // bind the show picture onhover events
     bindStudentPhotoHoverLink('.profile-pic-icon-hover');
-};
-
-if (window.addEventListener) {
-    window.addEventListener('load', onLoadFunction);
-} else {
-    window.attachEvent('onload', onLoadFunction);
-}
+});
 
 //-----------------------------------------------------------------------------
 

--- a/src/main/webapp/js/instructorFeedbackEdit.js
+++ b/src/main/webapp/js/instructorFeedbackEdit.js
@@ -1,3 +1,9 @@
+$(document).ready(function() {
+    readyFeedbackEditPage();
+    bindUncommonSettingsEvents();
+    updateUncommonSettingsInfo();
+    hideUncommonPanels();
+});
 
 /**
  * This function is called on edit page load.
@@ -525,33 +531,31 @@ function prepareQuestionForm(type) {
  * cannot select an invalid combination.
  */
 function formatCheckBoxes() {
-    $(document).ready(function() {
-        // TODO: change class -> name?
-        $('input[class*="answerCheckbox"]').change(function() {
-            if (!$(this).is(':checked')) {
-                $(this).parent().parent().find('input[class*="giverCheckbox"]')
-                                         .prop('checked', false);
-                $(this).parent().parent().find('input[class*="recipientCheckbox"]')
-                                         .prop('checked', false);
-            }
-        });
-        $('input[class*="giverCheckbox"]').change(function() {
-            if ($(this).is(':checked')) {
-                $(this).parent().parent().find('input[class*="answerCheckbox"]')
-                                         .prop('checked', true)
-                                         .trigger('change');
-            }
-        });
-        $('input[class*="recipientCheckbox"]').change(function() {
-            if ($(this).is(':checked')) {
-                $(this).parent().parent().find('input[class*="answerCheckbox"]')
-                                         .prop('checked', true);
-            }
-        });
-        $('input[name=receiverLeaderCheckbox]').change(function () {
-            $(this).parent().parent().find('input[name=receiverFollowerCheckbox]')
-                                     .prop('checked', $(this).prop('checked'));
-        });
+    // TODO: change class -> name?
+    $('input[class*="answerCheckbox"]').change(function() {
+        if (!$(this).is(':checked')) {
+            $(this).parent().parent().find('input[class*="giverCheckbox"]')
+                                     .prop('checked', false);
+            $(this).parent().parent().find('input[class*="recipientCheckbox"]')
+                                     .prop('checked', false);
+        }
+    });
+    $('input[class*="giverCheckbox"]').change(function() {
+        if ($(this).is(':checked')) {
+            $(this).parent().parent().find('input[class*="answerCheckbox"]')
+                                     .prop('checked', true)
+                                     .trigger('change');
+        }
+    });
+    $('input[class*="recipientCheckbox"]').change(function() {
+        if ($(this).is(':checked')) {
+            $(this).parent().parent().find('input[class*="answerCheckbox"]')
+                                     .prop('checked', true);
+        }
+    });
+    $('input[name=receiverLeaderCheckbox]').change(function () {
+        $(this).parent().parent().find('input[name=receiverFollowerCheckbox]')
+                                 .prop('checked', $(this).prop('checked'));
     });
 }
 

--- a/src/main/webapp/js/instructorFeedbackResults.js
+++ b/src/main/webapp/js/instructorFeedbackResults.js
@@ -267,8 +267,7 @@ function displayAjaxRetryMessageForPanelHeading($element) {
     $element.html(ajaxErrorStart + warningSign + errorMsg + chevronDown + ajaxErrorEnd);
 }
 
-
-window.onload = function() {
+$(document).ready(function() {
     var participantPanelType = 'div.panel.panel-primary,div.panel.panel-default';
 
     $('a[id^="collapse-panels-button-section-"]').on('click', function() {
@@ -287,10 +286,7 @@ window.onload = function() {
         var panels = $(this).closest('.panel-warning').children('.panel-collapse').find(participantPanelType).children('.panel-collapse');
         toggleCollapse(this, panels);
     });
-};
 
-// Set on ready events
-$(document).ready(function() {
     $('#results-search-box').keyup(function(e) {
         updateResultsFilter();
     });

--- a/src/main/webapp/js/instructorFeedbacks.js
+++ b/src/main/webapp/js/instructorFeedbacks.js
@@ -216,7 +216,7 @@ function readyFeedbackPage() {
     formatResponsesVisibilityGroup();
     collapseIfPrivateSession();
 
-    window.doPageSpecificOnload = selectDefaultTimeOptions();
+    selectDefaultTimeOptions();
     loadSessionsByAjax();
     bindUncommonSettingsEvents();
     updateUncommonSettingsInfo();

--- a/src/main/webapp/js/instructorFeedbacksSpecific.js
+++ b/src/main/webapp/js/instructorFeedbacksSpecific.js
@@ -1,0 +1,3 @@
+$(document).ready(function() {
+	readyFeedbackPage();
+});

--- a/src/main/webapp/jsp/instructorFeedbackEdit.jsp
+++ b/src/main/webapp/jsp/instructorFeedbackEdit.jsp
@@ -20,17 +20,10 @@
     <script type="text/javascript" src="/js/instructorFeedbackEdit.js"></script>
 </c:set>
 
-<c:set var="onload">
-    onload="readyFeedbackEditPage();
-    bindUncommonSettingsEvents();
-    updateUncommonSettingsInfo();
-    hideUncommonPanels();"
-</c:set>
-
 <c:set var="EMPTY_FEEDBACK_SESSION_MESSAGE">
  <%= Const.StatusMessages.FEEDBACK_QUESTION_EMPTY %>
 </c:set>
-<ti:instructorPage pageTitle="TEAMMATES - Instructor" bodyTitle="Edit Feedback Session" jsIncludes="${jsIncludes}" bodyOnload="${onload}">
+<ti:instructorPage pageTitle="TEAMMATES - Instructor" bodyTitle="Edit Feedback Session" jsIncludes="${jsIncludes}">
     
     <feedbacks:feedbackSessionsForm fsForm="${data.fsForm}" />
      

--- a/src/main/webapp/jsp/instructorFeedbacks.jsp
+++ b/src/main/webapp/jsp/instructorFeedbacks.jsp
@@ -14,8 +14,9 @@
     <script type="text/javascript" src="/js/instructorFeedbackAjaxRemindModal.js"></script>
     <script type="text/javascript" src="/js/instructorFeedbacksAjax.js"></script>
     <script type="text/javascript" src="/js/instructorFeedbacks.js"></script>
+    <script type="text/javascript" src="/js/instructorFeedbacksSpecific.js"></script>
 </c:set>
-<ti:instructorPage pageTitle="TEAMMATES - Instructor" bodyTitle="Add New Feedback Session" jsIncludes="${jsIncludes}" bodyOnload="onload=\"readyFeedbackPage();\"">
+<ti:instructorPage pageTitle="TEAMMATES - Instructor" bodyTitle="Add New Feedback Session" jsIncludes="${jsIncludes}">
     
     <c:if test="${!data.usingAjax}">
         <feedbacks:feedbackSessionsForm fsForm="${data.newFsForm}"/>

--- a/src/test/resources/pages/instructorFeedbackEditEmpty.html
+++ b/src/test/resources/pages/instructorFeedbackEditEmpty.html
@@ -33,10 +33,7 @@
          <script src="/js/instructorFeedbackEdit.js" type="text/javascript">
          </script>
       </head>
-      <body onload="readyFeedbackEditPage();
-    bindUncommonSettingsEvents();
-    updateUncommonSettingsInfo();
-    hideUncommonPanels();">
+      <body>
          <div class="navbar navbar-inverse navbar-fixed-top" role="navigation">
             <div class="container">
                <div class="navbar-header">

--- a/src/test/resources/pages/instructorFeedbackEditManuallyPublished.html
+++ b/src/test/resources/pages/instructorFeedbackEditManuallyPublished.html
@@ -33,10 +33,7 @@
          <script src="/js/instructorFeedbackEdit.js" type="text/javascript">
          </script>
       </head>
-      <body onload="readyFeedbackEditPage();
-    bindUncommonSettingsEvents();
-    updateUncommonSettingsInfo();
-    hideUncommonPanels();">
+      <body>
          <div class="navbar navbar-inverse navbar-fixed-top" role="navigation">
             <div class="container">
                <div class="navbar-header">

--- a/src/test/resources/pages/instructorFeedbackEmptyAll.html
+++ b/src/test/resources/pages/instructorFeedbackEmptyAll.html
@@ -38,8 +38,10 @@
          </script>
          <script src="/js/instructorFeedbacks.js" type="text/javascript">
          </script>
+         <script src="/js/instructorFeedbacksSpecific.js" type="text/javascript">
+         </script>
       </head>
-      <body onload="readyFeedbackPage();">
+      <body>
          <div class="navbar navbar-inverse navbar-fixed-top" role="navigation">
             <div class="container">
                <div class="navbar-header">


### PR DESCRIPTION
Fixes #3769 
I kept the two `onload`s on `index.js` and `checkBrowserVersion.js` because the only file that uses both, `index.html`, doesn't use jQuery, perhaps rightly so because `index.html` intends to check for compatibility as well.