### PR TITLE
admin activity log: Give a way to search more logs when searching for activities of a user #4511

### DIFF
--- a/src/main/java/teammates/ui/controller/AdminActivityLogPageAction.java
+++ b/src/main/java/teammates/ui/controller/AdminActivityLogPageAction.java
@@ -85,7 +85,7 @@ public class AdminActivityLogPageAction extends Action {
         
         List<ActivityLogEntry> logs = getAppLogs(query, data);
         
-        data.init(offset, filterQuery, ifShowAll, ifShowTestData, logs);
+        data.init(offset, ifShowAll, ifShowTestData, logs);
         
         if (offset == null) {
             return createShowPageResult(Const.ViewURIs.ADMIN_ACTIVITY_LOG, data);
@@ -101,8 +101,13 @@ public class AdminActivityLogPageAction extends Action {
         query.includeAppLogs(includeAppLogs);
         query.batchSize(1000);
         query.minLogLevel(LogLevel.INFO);
-        query.startTimeMillis(data.getFromDate());
-        query.endTimeMillis(data.getToDate());
+        
+        // if the query is empty, the default 24-hour limit will be applied 
+        // or a searching period is stated in the query, it will be applied as well.
+        if (data.getFilterQuery().isEmpty() || (!data.hasDefaultSearchPeriod())) {
+            query.startTimeMillis(data.getFromDate());
+            query.endTimeMillis(data.getToDate());
+        }
         
         try {
             query.majorVersionIds(getVersionIdsForQuery(versions));

--- a/src/main/java/teammates/ui/controller/AdminActivityLogPageAction.java
+++ b/src/main/java/teammates/ui/controller/AdminActivityLogPageAction.java
@@ -190,6 +190,7 @@ public class AdminActivityLogPageAction extends Action {
         Iterable<RequestLogs> records = LogServiceFactory.getLogService().fetch(query);
         boolean isFirstRow = true;
         ActivityLogEntry earliestLogChecked = null;
+        boolean stillHasLog = false;
         for (RequestLogs record : records) {
             
             totalLogsSearched ++;
@@ -197,12 +198,14 @@ public class AdminActivityLogPageAction extends Action {
             
             //End the search if we hit limits
             if (totalLogsSearched >= MAX_LOGSEARCH_LIMIT) {
+                stillHasLog = true; 
                 break;
             }
             if (currentLogsInPage >= LOGS_PER_PAGE) {
+                stillHasLog = true;
                 break;
             }
-            
+
             //fetch application log
             List<AppLogLine> appLogLines = record.getAppLogLines();
             for (AppLogLine appLog : appLogLines) {
@@ -265,7 +268,7 @@ public class AdminActivityLogPageAction extends Action {
         }
         
         //link for Next button, will fetch older logs
-        if (totalLogsSearched >= MAX_LOGSEARCH_LIMIT) {
+        if ((totalLogsSearched >= MAX_LOGSEARCH_LIMIT) || (!stillHasLog)) {
             // extends the search space one more day
             long oneDayBefore = data.getFromDate() - ONE_DAY_IN_MILLIS;
             status += "<br><span class=\"red\">&nbsp;&nbsp;Maximum amount of logs per request have been searched.</span><br>";

--- a/src/main/java/teammates/ui/controller/AdminActivityLogPageAction.java
+++ b/src/main/java/teammates/ui/controller/AdminActivityLogPageAction.java
@@ -210,6 +210,7 @@ public class AdminActivityLogPageAction extends Action {
             List<AppLogLine> appLogLines = record.getAppLogLines();
             for (AppLogLine appLog : appLogLines) {
                 if (currentLogsInPage >= LOGS_PER_PAGE) {
+                    stillHasLog = true;
                     break;
                 }
                 String logMsg = appLog.getLogMessage();
@@ -268,16 +269,16 @@ public class AdminActivityLogPageAction extends Action {
         }
         
         //link for Next button, will fetch older logs
-        if ((totalLogsSearched >= MAX_LOGSEARCH_LIMIT) || (!stillHasLog)) {
+        if (currentLogsInPage >= LOGS_PER_PAGE) {   
+            status += "<button class=\"btn-link\" id=\"button_older\" onclick=\"submitFormAjax('" + lastOffset + "');\">Older Logs </button>";              
+        } else if ((totalLogsSearched >= MAX_LOGSEARCH_LIMIT) || (!stillHasLog)) {
             // extends the search space one more day
             long oneDayBefore = data.getFromDate() - ONE_DAY_IN_MILLIS;
             status += "<br><span class=\"red\">&nbsp;&nbsp;Maximum amount of logs per request have been searched.</span><br>";
             status += "<button class=\"btn-link\" id=\"button_older\" onclick=\"submitFormAjax('" + lastOffset + "', "+ oneDayBefore +");\">Search More</button>";           
         }
         
-        if (currentLogsInPage >= LOGS_PER_PAGE) {   
-            status += "<button class=\"btn-link\" id=\"button_older\" onclick=\"submitFormAjax('" + lastOffset + "');\">Older Logs </button>";              
-        }
+        
         
         status += "<input id=\"ifShowAll\" type=\"hidden\" value=\""+ data.getIfShowAll() +"\"/>";
         status += "<input id=\"ifShowTestData\" type=\"hidden\" value=\""+ data.getIfShowTestData() +"\"/>";

--- a/src/main/java/teammates/ui/controller/AdminActivityLogPageAction.java
+++ b/src/main/java/teammates/ui/controller/AdminActivityLogPageAction.java
@@ -109,9 +109,6 @@ public class AdminActivityLogPageAction extends Action {
         query.includeAppLogs(includeAppLogs);
         query.batchSize(1000);
         query.minLogLevel(LogLevel.INFO);
-        
-        // if the query is empty, the default 24-hour limit will be applied 
-        // or a searching period is stated in the query, it will be applied as well.
         query.startTimeMillis(data.getFromDate());
         query.endTimeMillis(data.getToDate());
         

--- a/src/main/java/teammates/ui/controller/AdminActivityLogPageAction.java
+++ b/src/main/java/teammates/ui/controller/AdminActivityLogPageAction.java
@@ -31,6 +31,7 @@ public class AdminActivityLogPageAction extends Action {
     private boolean includeAppLogs = true;
     private static final int LOGS_PER_PAGE = 50;
     private static final int MAX_LOGSEARCH_LIMIT = 15000;
+    private static final int ONE_DAY_IN_MILLIS = 24*60*60*1000;
     
     @Override
     protected ActionResult execute() throws EntityDoesNotExistException{
@@ -39,6 +40,10 @@ public class AdminActivityLogPageAction extends Action {
         
         AdminActivityLogPageData data = new AdminActivityLogPageData(account);
         
+        String startSearchTime = getRequestParamValue("startSearchTime");
+        if (startSearchTime == null) {
+            startSearchTime = "";
+        }
         String offset = getRequestParamValue("offset");
         String pageChange = getRequestParamValue("pageChange");
         String filterQuery = getRequestParamValue("filterQuery");
@@ -80,6 +85,9 @@ public class AdminActivityLogPageAction extends Action {
         }
         //This is used to parse the filterQuery. If the query is not parsed, the filter function would ignore the query
         data.generateQueryParameters(filterQuery);
+        if (!startSearchTime.isEmpty()) {
+            data.setFromDate(Long.parseLong(startSearchTime));
+        }
         
         LogQuery query = buildQuery(offset, data);
         
@@ -263,8 +271,10 @@ public class AdminActivityLogPageAction extends Action {
         
         //link for Next button, will fetch older logs
         if (totalLogsSearched >= MAX_LOGSEARCH_LIMIT) {
+            // extends the search space one more day
+            long oneDayBefore = data.getFromDate() - ONE_DAY_IN_MILLIS;
             status += "<br><span class=\"red\">&nbsp;&nbsp;Maximum amount of logs per request have been searched.</span><br>";
-            status += "<button class=\"btn-link\" id=\"button_older\" onclick=\"submitFormAjax('" + lastOffset + "');\">Search More</button>";           
+            status += "<button class=\"btn-link\" id=\"button_older\" onclick=\"submitFormAjax('" + lastOffset + ", "+ oneDayBefore +"');\">Search More</button>";           
         }
         
         if (currentLogsInPage >= LOGS_PER_PAGE) {   

--- a/src/main/java/teammates/ui/controller/AdminActivityLogPageAction.java
+++ b/src/main/java/teammates/ui/controller/AdminActivityLogPageAction.java
@@ -112,10 +112,8 @@ public class AdminActivityLogPageAction extends Action {
         
         // if the query is empty, the default 24-hour limit will be applied 
         // or a searching period is stated in the query, it will be applied as well.
-        if (data.getFilterQuery().isEmpty() || (!data.hasDefaultSearchPeriod())) {
-            query.startTimeMillis(data.getFromDate());
-            query.endTimeMillis(data.getToDate());
-        }
+        query.startTimeMillis(data.getFromDate());
+        query.endTimeMillis(data.getToDate());
         
         try {
             query.majorVersionIds(getVersionIdsForQuery(versions));

--- a/src/main/java/teammates/ui/controller/AdminActivityLogPageAction.java
+++ b/src/main/java/teammates/ui/controller/AdminActivityLogPageAction.java
@@ -118,16 +118,8 @@ public class AdminActivityLogPageAction extends Action {
         if (data.isPersonSpecified()) {
             String targetUserGoogleId = data.getPersonSpecified();
             targetTimeZone = getLocalTimeZoneForRequest(targetUserGoogleId, "");
-        }
-        
-        if (targetTimeZone == Const.DOUBLE_UNINITIALIZED) { // if no person is specified or the person doesn't really exist
-            if ((logs.size() >= RELEVANT_LOGS_PER_PAGE) && (earliestLogChecked != null)) {
-                String userGoogleId = earliestLogChecked.getGoogleId();
-                String userRole = earliestLogChecked.getRole();
-                targetTimeZone = this.getLocalTimeZoneInfo(userGoogleId, userRole);
-            } else {
-                targetTimeZone = Const.SystemParams.ADMIN_TIMZE_ZONE_DOUBLE;
-            }
+        } else {
+            targetTimeZone = Const.SystemParams.ADMIN_TIMZE_ZONE_DOUBLE;
         }
         
         double adminTimeZone = Const.SystemParams.ADMIN_TIMZE_ZONE_DOUBLE;

--- a/src/main/java/teammates/ui/controller/AdminActivityLogPageAction.java
+++ b/src/main/java/teammates/ui/controller/AdminActivityLogPageAction.java
@@ -272,7 +272,7 @@ public class AdminActivityLogPageAction extends Action {
             // extends the search space one more day
             long oneDayBefore = data.getFromDate() - ONE_DAY_IN_MILLIS;
             status += "<br><span class=\"red\">&nbsp;&nbsp;Maximum amount of logs per request have been searched.</span><br>";
-            status += "<button class=\"btn-link\" id=\"button_older\" onclick=\"submitFormAjax('" + lastOffset + ", "+ oneDayBefore +"');\">Search More</button>";           
+            status += "<button class=\"btn-link\" id=\"button_older\" onclick=\"submitFormAjax('" + lastOffset + "', "+ oneDayBefore +");\">Search More</button>";           
         }
         
         if (currentLogsInPage >= LOGS_PER_PAGE) {   

--- a/src/main/java/teammates/ui/controller/AdminActivityLogPageAction.java
+++ b/src/main/java/teammates/ui/controller/AdminActivityLogPageAction.java
@@ -255,17 +255,16 @@ public class AdminActivityLogPageAction extends Action {
             }
         }
         
-        if (earliestLogChecked != null) {
-            double adminTimeZone = Const.SystemParams.ADMIN_TIMZE_ZONE_DOUBLE;
-            String timeInAdminTimeZone = computeLocalTime(adminTimeZone, String.valueOf(earliestSearchTime));
-            String timeInUserTimeZone =  computeLocalTime(targetTimeZone, String.valueOf(earliestSearchTime));
-            status += "The earliest log entry checked on <b>" + timeInAdminTimeZone + "</b> in Admin Time Zone (" 
-                      + adminTimeZone + ") and ";
-            if (targetTimeZone != Const.DOUBLE_UNINITIALIZED) {
-                status += "on <b>" + timeInUserTimeZone + "</b> in Local Time Zone (" + targetTimeZone + ").<br>";
-            } else {
-                status += timeInUserTimeZone;
-            }
+        
+        double adminTimeZone = Const.SystemParams.ADMIN_TIMZE_ZONE_DOUBLE;
+        String timeInAdminTimeZone = computeLocalTime(adminTimeZone, String.valueOf(earliestSearchTime));
+        String timeInUserTimeZone =  computeLocalTime(targetTimeZone, String.valueOf(earliestSearchTime));
+        status += "The earliest log entry checked on <b>" + timeInAdminTimeZone + "</b> in Admin Time Zone (" 
+                  + adminTimeZone + ") and ";
+        if (targetTimeZone != Const.DOUBLE_UNINITIALIZED) {
+            status += "on <b>" + timeInUserTimeZone + "</b> in Local Time Zone (" + targetTimeZone + ").<br>";
+        } else {
+            status += timeInUserTimeZone;
         }
         
         //link for Next button, will fetch older logs
@@ -277,8 +276,6 @@ public class AdminActivityLogPageAction extends Action {
             status += "<br><span class=\"red\">&nbsp;&nbsp;Maximum amount of logs per request have been searched.</span><br>";
             status += "<button class=\"btn-link\" id=\"button_older\" onclick=\"submitFormAjax('" + lastOffset + "', "+ oneDayBefore +");\">Search More</button>";           
         }
-        
-        
         
         status += "<input id=\"ifShowAll\" type=\"hidden\" value=\""+ data.getIfShowAll() +"\"/>";
         status += "<input id=\"ifShowTestData\" type=\"hidden\" value=\""+ data.getIfShowTestData() +"\"/>";

--- a/src/main/java/teammates/ui/controller/AdminActivityLogPageAction.java
+++ b/src/main/java/teammates/ui/controller/AdminActivityLogPageAction.java
@@ -142,7 +142,7 @@ public class AdminActivityLogPageAction extends Action {
         }
         
         // the "Search More" button to continue searching from the previous fromDate 
-        status += "<button class=\"btn-link\" id=\"button_older\" onclick=\"submitFormAjax(" + data.getFromDate() + ");\">Search More</button>";
+        status += "<button class=\"btn-link\" id=\"button_older\" onclick=\"submitFormAjax(" + (data.getFromDate() + 1) + ");\">Search More</button>";
         
         status += "<input id=\"ifShowAll\" type=\"hidden\" value=\""+ data.getIfShowAll() +"\"/>";
         status += "<input id=\"ifShowTestData\" type=\"hidden\" value=\""+ data.getIfShowTestData() +"\"/>";
@@ -167,7 +167,7 @@ public class AdminActivityLogPageAction extends Action {
             if (!searchResult.isEmpty()) {
                 appLogs.addAll(searchResult);
             }
-            data.setToDate(data.getFromDate());
+            data.setToDate(data.getFromDate() + 1);
         }
         return appLogs;
     }
@@ -184,7 +184,6 @@ public class AdminActivityLogPageAction extends Action {
         //fetch request log
         Iterable<RequestLogs> records = LogServiceFactory.getLogService().fetch(query);
         for (RequestLogs record : records) {
-            record.getOffset();
             //fetch application log
             List<AppLogLine> appLogLines = record.getAppLogLines();
             for (AppLogLine appLog : appLogLines) {

--- a/src/main/java/teammates/ui/controller/AdminActivityLogPageData.java
+++ b/src/main/java/teammates/ui/controller/AdminActivityLogPageData.java
@@ -23,6 +23,7 @@ public class AdminActivityLogPageData extends PageData {
     private List<String> versions;
     private Long toDateValue;
     private Long fromDateValue;
+    private boolean hasDefaultSearchPeriod;
     private String logLocalTime;
     
     /**
@@ -67,14 +68,13 @@ public class AdminActivityLogPageData extends PageData {
         Calendar fromCalendarDate = TimeHelper.now(0.0);
         fromCalendarDate.add(Calendar.DAY_OF_MONTH, -1);
         
-        fromDateValue = fromCalendarDate.getTimeInMillis();    
+        fromDateValue = fromCalendarDate.getTimeInMillis();
         toDateValue = TimeHelper.now(0.0).getTimeInMillis();
+        hasDefaultSearchPeriod = true;
     }
 
-    public void init(String offset, String filterQuery, boolean ifShowAll,
-                     boolean ifShowTestData, List<ActivityLogEntry> logs) {
+    public void init(String offset, boolean ifShowAll, boolean ifShowTestData, List<ActivityLogEntry> logs) {
         this.offset = offset;
-        this.filterQuery = filterQuery;
         this.ifShowAll = ifShowAll;
         this.ifShowTestData = ifShowTestData;
         this.logs = logs;
@@ -135,7 +135,8 @@ public class AdminActivityLogPageData extends PageData {
      * Creates a QueryParameters object used for filtering
      */
     public void generateQueryParameters(String query) {
-        query = query.toLowerCase();
+        filterQuery = query.trim();
+        query = filterQuery.toLowerCase();
         
         try {
             q = parseQuery(query);
@@ -291,6 +292,7 @@ public class AdminActivityLogPageData extends PageData {
                 Calendar cal = TimeHelper.now(0.0);
                 cal.setTime(d);
                 fromDateValue = cal.getTime().getTime();
+                hasDefaultSearchPeriod = false;
                 
             } else if (label.equals("to")) {
                 SimpleDateFormat sdf = new SimpleDateFormat("dd/MM/yy HH:mm");
@@ -308,6 +310,10 @@ public class AdminActivityLogPageData extends PageData {
         return q;
     }
 
+    public boolean hasDefaultSearchPeriod() {
+        return hasDefaultSearchPeriod;
+    }
+    
     /** 
      * @return possible servlet requests list as html 
      */

--- a/src/main/java/teammates/ui/controller/AdminActivityLogPageData.java
+++ b/src/main/java/teammates/ui/controller/AdminActivityLogPageData.java
@@ -23,7 +23,6 @@ public class AdminActivityLogPageData extends PageData {
     private List<String> versions;
     private Long toDateValue;
     private Long fromDateValue;
-    private boolean hasDefaultSearchPeriod;
     private String logLocalTime;
     
     /**
@@ -70,7 +69,6 @@ public class AdminActivityLogPageData extends PageData {
         
         fromDateValue = fromCalendarDate.getTimeInMillis();
         toDateValue = TimeHelper.now(0.0).getTimeInMillis();
-        hasDefaultSearchPeriod = true;
     }
 
     public void init(String offset, boolean ifShowAll, boolean ifShowTestData, List<ActivityLogEntry> logs) {
@@ -115,7 +113,6 @@ public class AdminActivityLogPageData extends PageData {
     
     public void setFromDate(long startTime) {
         fromDateValue = startTime;
-        hasDefaultSearchPeriod = false;
     }
     
     public long getToDate() {
@@ -297,7 +294,6 @@ public class AdminActivityLogPageData extends PageData {
                 Calendar cal = TimeHelper.now(0.0);
                 cal.setTime(d);
                 fromDateValue = cal.getTime().getTime();
-                hasDefaultSearchPeriod = false;
                 
             } else if (label.equals("to")) {
                 SimpleDateFormat sdf = new SimpleDateFormat("dd/MM/yy HH:mm");
@@ -313,10 +309,6 @@ public class AdminActivityLogPageData extends PageData {
         }
 
         return q;
-    }
-
-    public boolean hasDefaultSearchPeriod() {
-        return hasDefaultSearchPeriod;
     }
     
     /** 

--- a/src/main/java/teammates/ui/controller/AdminActivityLogPageData.java
+++ b/src/main/java/teammates/ui/controller/AdminActivityLogPageData.java
@@ -113,6 +113,11 @@ public class AdminActivityLogPageData extends PageData {
         return fromDateValue;
     }
     
+    public void setFromDate(long startTime) {
+        fromDateValue = startTime;
+        hasDefaultSearchPeriod = false;
+    }
+    
     public long getToDate() {
         return toDateValue;
     }

--- a/src/main/java/teammates/ui/controller/AdminActivityLogPageData.java
+++ b/src/main/java/teammates/ui/controller/AdminActivityLogPageData.java
@@ -15,8 +15,6 @@ import teammates.common.util.Const;
 import teammates.common.util.TimeHelper;
 
 public class AdminActivityLogPageData extends PageData {
-    
-    private String offset;
     private String filterQuery;
     private String queryMessage;
     private List<ActivityLogEntry> logs;
@@ -24,7 +22,7 @@ public class AdminActivityLogPageData extends PageData {
     private Long toDateValue;
     private Long fromDateValue;
     private String logLocalTime;
-    
+    private boolean isFromDateSpecifiedInQuery = false;
     /**
      * This determines whether the logs with requests contained in "excludedLogRequestURIs" below 
      * should be shown. Use "?all=true" in URL to show all logs. This will keep showing all
@@ -71,8 +69,7 @@ public class AdminActivityLogPageData extends PageData {
         toDateValue = TimeHelper.now(0.0).getTimeInMillis();
     }
 
-    public void init(String offset, boolean ifShowAll, boolean ifShowTestData, List<ActivityLogEntry> logs) {
-        this.offset = offset;
+    public void init(boolean ifShowAll, boolean ifShowTestData, List<ActivityLogEntry> logs) {
         this.ifShowAll = ifShowAll;
         this.ifShowTestData = ifShowTestData;
         this.logs = logs;
@@ -85,10 +82,6 @@ public class AdminActivityLogPageData extends PageData {
     
     public boolean getIfShowTestData() {
         return ifShowTestData;
-    }
-    
-    public String getOffset() {
-        return offset;
     }
     
     public String getFilterQuery() {
@@ -119,6 +112,10 @@ public class AdminActivityLogPageData extends PageData {
         return toDateValue;
     }
     
+    public void setToDate(long endTime) {
+        toDateValue = endTime;
+    }
+    
     /**
      * Checks in an array contains a specific value
      * value is converted to lower case before comparing
@@ -147,8 +144,6 @@ public class AdminActivityLogPageData extends PageData {
         }
     }
     
-    
-    
     /**
      * check current log entry should be excluded as rubbish logs 
      * returns false if the logEntry is regarded as rubbish
@@ -168,8 +163,6 @@ public class AdminActivityLogPageData extends PageData {
         
         return false;        
     }
-    
-    
     
     /**
      * Performs the actual filtering, based on QueryParameters
@@ -294,7 +287,8 @@ public class AdminActivityLogPageData extends PageData {
                 Calendar cal = TimeHelper.now(0.0);
                 cal.setTime(d);
                 fromDateValue = cal.getTime().getTime();
-                
+                isFromDateSpecifiedInQuery = true;
+                                                
             } else if (label.equals("to")) {
                 SimpleDateFormat sdf = new SimpleDateFormat("dd/MM/yy HH:mm");
                 sdf.setTimeZone(TimeZone.getTimeZone(Const.SystemParams.ADMIN_TIME_ZONE));
@@ -307,7 +301,6 @@ public class AdminActivityLogPageData extends PageData {
                 q.add(label, values);
             }
         }
-
         return q;
     }
     
@@ -501,4 +494,10 @@ public class AdminActivityLogPageData extends PageData {
             return null;
         }
     }
+
+    public boolean isFromDateSpecifiedInQuery() {
+        return isFromDateSpecifiedInQuery;
+    }
+
+    
 }

--- a/src/main/webapp/WEB-INF/tags/admin/activity/filterPanel.tag
+++ b/src/main/webapp/WEB-INF/tags/admin/activity/filterPanel.tag
@@ -202,9 +202,11 @@
     
      
     <%-- This form is used to store parameters for ajaxloader only --%>
-   <form id="ajaxLoaderDataForm">
-      <input type="hidden" name="offset" value="${offset}">
-       <%-- This parameter determines whether the logs with requests contained in "excludedLogRequestURIs" 
+    <form id="ajaxLoaderDataForm">
+        <input type="hidden" name="offset" value="${offset}">
+        <input type="hidden" name="startSearchTime" value="">
+
+        <%-- This parameter determines whether the logs with requests contained in "excludedLogRequestURIs" 
         in AdminActivityLogPageData should be shown. Use "?all=true" in URL to show all logs. This will keep showing all
         logs despite any action or change in the page unless the the page is reloaded with "?all=false" 
         or simply reloaded with this parameter omitted. --%>

--- a/src/main/webapp/WEB-INF/tags/admin/activity/filterPanel.tag
+++ b/src/main/webapp/WEB-INF/tags/admin/activity/filterPanel.tag
@@ -4,7 +4,6 @@
 <%@ attribute name="actionListAsHtml" required="true" %>
 <%@ attribute name="ifShowAll" required="true" %>
 <%@ attribute name="ifShowTestData" required="true" %>
-<%@ attribute name="offset" required="true" %>
 <%@ attribute name="filterQuery" required="true" %>
 
 <div class="well well-plain">
@@ -203,9 +202,8 @@
      
     <%-- This form is used to store parameters for ajaxloader only --%>
     <form id="ajaxLoaderDataForm">
-        <input type="hidden" name="offset" value="${offset}">
-        <input type="hidden" name="startSearchTime" value="">
-
+        <input type="hidden" name="searchTimeOffset" value="">
+        
         <%-- This parameter determines whether the logs with requests contained in "excludedLogRequestURIs" 
         in AdminActivityLogPageData should be shown. Use "?all=true" in URL to show all logs. This will keep showing all
         logs despite any action or change in the page unless the the page is reloaded with "?all=false" 

--- a/src/main/webapp/js/adminActivityLog.js
+++ b/src/main/webapp/js/adminActivityLog.js
@@ -1,6 +1,3 @@
-var retryTimes = 0;
-var numOfEntriesPerPage = 50;
-
 function toggleReference() {
 	$("#filterReference").toggle("slow");
 	
@@ -51,11 +48,8 @@ function submitLocalTimeAjaxRequest(time, googleId, role, entry){
     });
 }
 
-function submitFormAjax(offset, startSearchTime) {
-	$('input[name=offset]').val(offset);
-	if (typeof startSearchTime != "undefined") {
-		$('input[name=startSearchTime]').val(startSearchTime);
-	}
+function submitFormAjax(searchTimeOffset) {
+	$('input[name=searchTimeOffset]').val(searchTimeOffset);
 	
 	var formObject = $("#ajaxLoaderDataForm");
 	var formData = formObject.serialize();
@@ -83,7 +77,6 @@ function submitFormAjax(offset, startSearchTime) {
                     });
                     
                     updateInfoForRecentActionButton();
-                    clickOlderButtonIfNeeded();
                 } else {
                     setFormErrorMessage(button, data.errorMessage);
                 }
@@ -107,22 +100,3 @@ function updateInfoForRecentActionButton(){
     var isShowTestData = $("#ifShowTestData").val();
     $(".ifShowTestData_for_person").val(isShowTestData);
 }
-
-function clickOlderButtonIfNeeded(){
-    if(retryTimes >= 20){
-        return;
-    }
-
-    var curNumOfEntries = $("#logsTable tbody tr").length;
-    
-    if(curNumOfEntries < numOfEntriesPerPage){
-        if($("#button_older").length){
-            $("#button_older").click();
-            retryTimes ++;
-        }
-    }
-}
-
-$(document).ready(function(){
-	clickOlderButtonIfNeeded();
-});

--- a/src/main/webapp/js/adminActivityLog.js
+++ b/src/main/webapp/js/adminActivityLog.js
@@ -51,8 +51,12 @@ function submitLocalTimeAjaxRequest(time, googleId, role, entry){
     });
 }
 
-function submitFormAjax(offset) {
+function submitFormAjax(offset, startSearchTime) {
 	$('input[name=offset]').val(offset);
+	if (typeof startSearchTime != "undefined") {
+		$('input[name=startSearchTime]').val(startSearchTime);
+	}
+	
 	var formObject = $("#ajaxLoaderDataForm");
 	var formData = formObject.serialize();
 	var button = $('#button_older');

--- a/src/main/webapp/jsp/adminActivityLog.jsp
+++ b/src/main/webapp/jsp/adminActivityLog.jsp
@@ -12,8 +12,7 @@
 
 <ta:adminPage bodyTitle="Admin Activity Log" pageTitle="TEAMMATES - Administrator" jsIncludes="${jsIncludes}">
     <activity:filterPanel excludedLogRequestURIs="${data.excludedLogRequestURIs}" actionListAsHtml="${data.actionListAsHtml}"
-                            ifShowAll="${data.ifShowAll}" ifShowTestData="${data.ifShowTestData}" offset="${data.offset}"
-                            filterQuery="${data.filterQuery}" />
+                            ifShowAll="${data.ifShowAll}" ifShowTestData="${data.ifShowTestData}" filterQuery="${data.filterQuery}" />
 
     <c:if test="${not empty data.queryMessage}">
         <div class="alert alert-danger" id="queryMessage">


### PR DESCRIPTION
Fix #4511

I added one more parameter to the submit form in jsp and javascript to help us keep track the start searching time extended. The start time generated by this function will overwrite the start time in query and it will only be extended by clicking on "Search More" but not "Older Logs".