### PR TITLE
Popovers in tests are not being ignored #3947

### DIFF
--- a/src/test/java/teammates/test/cases/ui/browsertests/InstructorStudentListPageUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/InstructorStudentListPageUiTest.java
@@ -18,7 +18,6 @@ import teammates.common.util.ThreadHelper;
 import teammates.common.util.Url;
 import teammates.common.util.Utils;
 import teammates.test.driver.BackDoor;
-import teammates.test.driver.TestProperties;
 import teammates.test.pageobjects.Browser;
 import teammates.test.pageobjects.BrowserPool;
 import teammates.test.pageobjects.InstructorCourseDetailsPage;
@@ -157,18 +156,14 @@ public class InstructorStudentListPageUiTest extends BaseUiTestCase {
         viewPage.checkCourse(1);
 
         viewPage.clickShowPhoto(student.course, student.name);
-        viewPage.verifyProfilePhotoIsDefault(student.course, student.name);
-        viewPage.verifyPopoverPicture(student.course, student.name,
-                                      TestProperties.inst().TEAMMATES_URL + "/images/profile_picture_default.png");
+        viewPage.verifyProfilePhoto(student.course, student.name, Const.SystemParams.DEFAULT_PROFILE_PICTURE_PATH);
 
         ______TS("student has uploaded an image");
 
         StudentAttributes student2 = testData.students.get("Student3Course3");
-
         viewPage.clickShowPhoto(student2.course, student2.name);
-        // wait for previous pop-over to disappear.
-        ThreadHelper.waitFor(500);
-
+        viewPage.verifyProfilePhoto(student2.course, student2.name,
+                                    Const.ActionURIs.STUDENT_PROFILE_PICTURE + "?" + Const.ParamsNames.STUDENT_EMAIL);
         viewPage.verifyHtmlMainContent("/instructorStudentListPageWithPicture.html");
     }
 

--- a/src/test/java/teammates/test/driver/HtmlHelper.java
+++ b/src/test/java/teammates/test/driver/HtmlHelper.java
@@ -90,9 +90,9 @@ public class HtmlHelper {
         if (currentNode.getNodeType() == Node.TEXT_NODE) {
             String text = currentNode.getNodeValue().trim();
             return text.isEmpty() ? "" : indentation + text + "\n";
-        } else if (isToolTip(currentNode)) {
-            return "";
-        } else if (Config.STUDENT_MOTD_URL.isEmpty() && isMotdWrapper(currentNode)) {
+        } else if (isToolTip(currentNode)
+                   || isPopOver(currentNode)
+                   || (Config.STUDENT_MOTD_URL.isEmpty() && isMotdWrapper(currentNode))) {
             return "";
         } else if (isMotdContainer(currentNode)) {
             return indentation + "${studentmotd.container}\n";
@@ -146,6 +146,13 @@ public class HtmlHelper {
      */
     private static boolean isToolTip(Node currentNode) {
         return checkForNodeWithSpecificAttributeValue(currentNode, "div", "class", "tooltip");
+    }
+    
+    /**
+     * Checks for popovers (i.e any <code>div</code> with class <code>popover</code> in it)
+     */
+    private static boolean isPopOver(Node currentNode) {
+        return checkForNodeWithSpecificAttributeValue(currentNode, "div", "class", "popover");
     }
     
     /**

--- a/src/test/java/teammates/test/pageobjects/AppPage.java
+++ b/src/test/java/teammates/test/pageobjects/AppPage.java
@@ -883,9 +883,6 @@ public abstract class AppPage {
                 .replaceAll("commentBar-[0-9]{16}", "commentBar-\\${comment\\.id}")
                 .replaceAll("plainCommentText-[0-9]{16}", "plainCommentText-\\${comment\\.id}")
                 .replaceAll("commentdelete-[0-9]{16}", "commentdelete-\\${comment\\.id}")
-                // tooltip style
-                .replaceAll("style=\"top: [0-9]{2,4}px; left: [0-9]{2,4}px; display: block;\"",
-                            "style=\"top: \\${tooltip\\.offset}px; left: \\${tooltip\\.offset}px; display: block;\"")                
                 //commentid in url
                 .replaceAll("#[0-9]{16}", "#\\${comment\\.id}")
                 // today's date

--- a/src/test/java/teammates/test/pageobjects/InstructorStudentListPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorStudentListPage.java
@@ -8,7 +8,7 @@ import org.openqa.selenium.interactions.Actions;
 import org.openqa.selenium.support.FindBy;
 
 import teammates.common.util.Const;
-import teammates.test.driver.AssertHelper;
+import teammates.test.driver.TestProperties;
 
 public class InstructorStudentListPage extends AppPage {
 
@@ -106,12 +106,20 @@ public class InstructorStudentListPage extends AppPage {
         displayArchiveOptions.click();
     }
 
-    public void verifyProfilePhotoIsDefault(String courseId, String studentName) {
+    public void verifyProfilePhoto(String courseId, String studentName, String profilePhotoSrc) {
+        profilePhotoSrc = TestProperties.inst().TEAMMATES_URL + profilePhotoSrc;
         String rowId = getStudentRowId(courseId, studentName);
         assertTrue(browser.driver.findElement(By.id("studentphoto-c" + rowId))
                                  .findElement(By.tagName("img"))
                                  .getAttribute("src")
-                                 .contains(Const.SystemParams.DEFAULT_PROFILE_PICTURE_PATH));
+                                 .contains(profilePhotoSrc));
+        WebElement photo = browser.driver.findElement(By.id("studentphoto-c" + rowId))
+                                         .findElement(By.cssSelector(".profile-pic-icon-click > img"));
+        Actions action = new Actions(browser.driver);
+        action.click(photo).build().perform();
+        assertTrue(browser.driver.findElement(By.cssSelector(".popover-content > .profile-pic"))
+                                 .getAttribute("src")
+                                 .contains(profilePhotoSrc));
     }
 
     private int getCourseNumber(String courseId) {
@@ -175,17 +183,6 @@ public class InstructorStudentListPage extends AppPage {
             return "";
         }
         return browser.driver.findElement(locator).getText();
-    }
-
-    public void verifyPopoverPicture(String course, String name, String srcUrl) throws Exception {
-        String rowId = getStudentRowId(course, name);
-        WebElement photo = browser.driver.findElement(By.id("studentphoto-c" + rowId))
-                                         .findElement(By.cssSelector(".profile-pic-icon-click > img"));
-        Actions action = new Actions(browser.driver);
-        action.click(photo).build().perform();
-        AssertHelper.assertContainsRegex(srcUrl,
-                                         browser.driver.findElement(By.cssSelector(".popover-content > .profile-pic"))
-                                                       .getAttribute("src"));
     }
 
 }

--- a/src/test/resources/pages/instructorStudentListPageWithPicture.html
+++ b/src/test/resources/pages/instructorStudentListPageWithPicture.html
@@ -711,15 +711,6 @@
                            <div class="profile-pic-icon-click align-center" data-link="" data-original-title="" title="">
                               <img alt="No Image Given" class="" src="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=instructorWith2Courses"/>
                            </div>
-                           <div class="popover fade top in" style="top: ${tooltip.offset}px; left: ${tooltip.offset}px; display: block;">
-                              <div class="arrow">
-                              </div>
-                              <h3 class="popover-title" style="display: none;">
-                              </h3>
-                              <div class="popover-content">
-                                 <img class="profile-pic" src="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=instructorWith2Courses"/>
-                              </div>
-                           </div>
                         </td>
                         <td class="hidden" id="studentsection-c1.0" style="display: table-cell;">
                            None


### PR DESCRIPTION
Fixes #3947, fixes #3572, fixes #2700 (wow, the number of duplicates).
The existing popup test via HTML comparison in `InstructorStudentListPageUiTest` is now tested with Selenium's web element comparison. It's more fault-tolerant this way.

@junhaoyap, if you please.