### PR TITLE
Several test cases failing on live server due to a login issue #4565

### DIFF
--- a/src/test/java/teammates/test/cases/ui/browsertests/StudentFeedbackSubmitPageUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/StudentFeedbackSubmitPageUiTest.java
@@ -364,7 +364,7 @@ public class StudentFeedbackSubmitPageUiTest extends BaseUiTestCase {
         submitPage.verifyHtmlMainContent("/studentFeedbackSubmitPageFullyFilled.html");
 
         ______TS("create new response for unreg student");
-
+        submitPage.logout();
         submitPage = loginToStudentFeedbackSubmitPage(testData.students.get("DropOut"), "Open Session");
 
         submitPage.fillResponseTextBox(1, 0, "Test Self Feedback");

--- a/src/test/java/teammates/test/pageobjects/AppPage.java
+++ b/src/test/java/teammates/test/pageobjects/AppPage.java
@@ -396,6 +396,7 @@ public abstract class AppPage {
      */
     public static void logout(Browser currentBrowser){
         currentBrowser.driver.get(TestProperties.inst().TEAMMATES_URL + Const.ViewURIs.LOGOUT);
+        currentBrowser.selenium.waitForPageToLoad(TestProperties.inst().TEST_TIMEOUT_PAGELOAD);
         currentBrowser.isAdminLoggedIn = false;
     }
     


### PR DESCRIPTION
Fixes #4565

Explanation: if the test navigates to the next page before going to the logout link generated by appengine in logout.jsp, then the user remains logged in, triggering an exception when the test expects a log in page. 

For the feedback submission page, if the user is still logged in and goes to the submission page for unregistered student, the test is logged out and redirected to the login page