### PR TITLE
admin activity log: wrong user time zone reported #4525

### DIFF
--- a/src/main/java/teammates/ui/controller/AdminActivityLogPageAction.java
+++ b/src/main/java/teammates/ui/controller/AdminActivityLogPageAction.java
@@ -118,6 +118,12 @@ public class AdminActivityLogPageAction extends Action {
         if (data.isPersonSpecified()) {
             String targetUserGoogleId = data.getPersonSpecified();
             targetTimeZone = getLocalTimeZoneForRequest(targetUserGoogleId, "");
+            // if cannot find the user or the user is unregistered
+            if (targetTimeZone == Const.DOUBLE_UNINITIALIZED) {
+                if (data.hasCourseIdInQuery()) {
+                    targetTimeZone = getLocalTimeZoneForUnregisteredUserRequest(data.getCourseId());
+                }
+            }
         } else {
             targetTimeZone = Const.SystemParams.ADMIN_TIMZE_ZONE_DOUBLE;
         }
@@ -130,7 +136,7 @@ public class AdminActivityLogPageAction extends Action {
         if (targetTimeZone != Const.DOUBLE_UNINITIALIZED) {
             status += "on <b>" + timeInUserTimeZone + "</b> in Local Time Zone (" + targetTimeZone + ").<br>";
         } else {
-            status += timeInUserTimeZone;
+            status += timeInUserTimeZone + ".<br>";
         }
         
         // the "Search More" button to continue searching from the previous fromDate 

--- a/src/main/java/teammates/ui/controller/AdminActivityLogPageAction.java
+++ b/src/main/java/teammates/ui/controller/AdminActivityLogPageAction.java
@@ -47,6 +47,7 @@ public class AdminActivityLogPageAction extends Action {
             searchTimeOffset = "";
         }
         String filterQuery = getRequestParamValue("filterQuery");
+        String courseIdFromSearchPage = getRequestParamValue("courseId");
         
         String logRoleFromAjax = getRequestParamValue("logRole");
         String logGoogleIdFromAjax = getRequestParamValue("logGoogleId");
@@ -90,7 +91,7 @@ public class AdminActivityLogPageAction extends Action {
             }
             logs = searchLogsWithTimeIncrement(data);
         }
-        generateStatusMessage(data, logs);
+        generateStatusMessage(data, logs, courseIdFromSearchPage);
         data.init(ifShowAll, ifShowTestData, logs);
         
         if (searchTimeOffset.isEmpty()) {
@@ -100,7 +101,7 @@ public class AdminActivityLogPageAction extends Action {
         return createAjaxResult(data);
     }
     
-    private void generateStatusMessage(AdminActivityLogPageData data, List<ActivityLogEntry> logs) {
+    private void generateStatusMessage(AdminActivityLogPageData data, List<ActivityLogEntry> logs, String courseId) {
         String status = "Total Logs gone through in last search: " + totalLogsSearched + "<br>";
         status += "Total Relevant Logs found in last search: " + logs.size() + "<br>";
         
@@ -118,10 +119,11 @@ public class AdminActivityLogPageAction extends Action {
         if (data.isPersonSpecified()) {
             String targetUserGoogleId = data.getPersonSpecified();
             targetTimeZone = getLocalTimeZoneForRequest(targetUserGoogleId, "");
-            // if cannot find the user or the user is unregistered
+
             if (targetTimeZone == Const.DOUBLE_UNINITIALIZED) {
-                if (data.hasCourseIdInQuery()) {
-                    targetTimeZone = getLocalTimeZoneForUnregisteredUserRequest(data.getCourseId());
+                // if the user is unregistered, try finding the timezone by course id passed from Search page
+                if ((courseId != null) && (!courseId.isEmpty())) {
+                    targetTimeZone = getLocalTimeZoneForUnregisteredUserRequest(courseId);
                 }
             }
         } else {

--- a/src/main/java/teammates/ui/controller/AdminActivityLogPageData.java
+++ b/src/main/java/teammates/ui/controller/AdminActivityLogPageData.java
@@ -430,6 +430,9 @@ public class AdminActivityLogPageData extends PageData {
         public boolean isInfoInQuery;
         public String[] infoValues;
         
+        private boolean isCourseInQuery;
+        private String courseValue;
+        
         public QueryParameters() {
             isRequestInQuery = false;
             isResponseInQuery = false;
@@ -437,6 +440,7 @@ public class AdminActivityLogPageData extends PageData {
             isRoleInQuery = false;
             isCutoffInQuery = false;
             isInfoInQuery = false;
+            isCourseInQuery = false;
         }
         
         /**
@@ -455,6 +459,9 @@ public class AdminActivityLogPageData extends PageData {
             } else if (label.equals("role")) {
                 isRoleInQuery = true;
                 roleValues = values;
+            } else if (label.equals("course")) {
+                isCourseInQuery = true;
+                courseValue = values[0];
             } else if (label.equals("time")) {
                 isCutoffInQuery = true;
                 cutoffValue = Long.parseLong(values[0]);
@@ -494,7 +501,19 @@ public class AdminActivityLogPageData extends PageData {
             return null;
         }
     }
-
+    
+    public boolean hasCourseIdInQuery() {
+        return ((q != null) && (q.isCourseInQuery));
+    }
+    
+    public String getCourseId() {
+        if (q != null) {
+            return q.courseValue;
+        } else {
+            return null;
+        }
+    }
+    
     public boolean isFromDateSpecifiedInQuery() {
         return isFromDateSpecifiedInQuery;
     }

--- a/src/main/java/teammates/ui/controller/AdminActivityLogPageData.java
+++ b/src/main/java/teammates/ui/controller/AdminActivityLogPageData.java
@@ -430,9 +430,6 @@ public class AdminActivityLogPageData extends PageData {
         public boolean isInfoInQuery;
         public String[] infoValues;
         
-        private boolean isCourseInQuery;
-        private String courseValue;
-        
         public QueryParameters() {
             isRequestInQuery = false;
             isResponseInQuery = false;
@@ -440,7 +437,6 @@ public class AdminActivityLogPageData extends PageData {
             isRoleInQuery = false;
             isCutoffInQuery = false;
             isInfoInQuery = false;
-            isCourseInQuery = false;
         }
         
         /**
@@ -459,9 +455,6 @@ public class AdminActivityLogPageData extends PageData {
             } else if (label.equals("role")) {
                 isRoleInQuery = true;
                 roleValues = values;
-            } else if (label.equals("course")) {
-                isCourseInQuery = true;
-                courseValue = values[0];
             } else if (label.equals("time")) {
                 isCutoffInQuery = true;
                 cutoffValue = Long.parseLong(values[0]);
@@ -497,18 +490,6 @@ public class AdminActivityLogPageData extends PageData {
     public String getPersonSpecified() {
         if (q != null) {
             return q.personValue;
-        } else {
-            return null;
-        }
-    }
-    
-    public boolean hasCourseIdInQuery() {
-        return ((q != null) && (q.isCourseInQuery));
-    }
-    
-    public String getCourseId() {
-        if (q != null) {
-            return q.courseValue;
         } else {
             return null;
         }

--- a/src/main/java/teammates/ui/controller/AdminSearchPageData.java
+++ b/src/main/java/teammates/ui/controller/AdminSearchPageData.java
@@ -124,11 +124,11 @@ public class AdminSearchPageData extends PageData {
         String availableIdString = "";
         
         if (instructor.googleId != null && !instructor.googleId.trim().isEmpty()) {
-            availableIdString = instructor.googleId;
+            availableIdString = "person:" + instructor.googleId;
         } else if (instructor.name != null && !instructor.name.trim().isEmpty()) {
-            availableIdString = instructor.name;
+            availableIdString = "person:" + instructor.name + " AND course:" + instructor.courseId;
         } else if (instructor.email != null && !instructor.email.trim().isEmpty()) {
-            availableIdString = instructor.email;
+            availableIdString = "person:" + instructor.email + " AND course:" + instructor.courseId;
         }
         
         return availableIdString;
@@ -184,11 +184,11 @@ public class AdminSearchPageData extends PageData {
         String availableIdString = "";
         
         if (student.googleId != null && !student.googleId.trim().isEmpty()) {
-            availableIdString = student.googleId;
+            availableIdString = "person:" + student.googleId;
         } else if (student.name != null && !student.name.trim().isEmpty()) {
-            availableIdString = student.name;
+            availableIdString = "person:" + student.name + " AND course:" + student.course;
         } else if (student.email != null && !student.email.trim().isEmpty()) {
-            availableIdString = student.email;
+            availableIdString = "person:" + student.email + " AND course:" + student.course;
         }
         
         return availableIdString;

--- a/src/main/java/teammates/ui/controller/AdminSearchPageData.java
+++ b/src/main/java/teammates/ui/controller/AdminSearchPageData.java
@@ -126,9 +126,9 @@ public class AdminSearchPageData extends PageData {
         if (instructor.googleId != null && !instructor.googleId.trim().isEmpty()) {
             availableIdString = "person:" + instructor.googleId;
         } else if (instructor.name != null && !instructor.name.trim().isEmpty()) {
-            availableIdString = "person:" + instructor.name + " AND course:" + instructor.courseId;
+            availableIdString = "person:" + instructor.name;
         } else if (instructor.email != null && !instructor.email.trim().isEmpty()) {
-            availableIdString = "person:" + instructor.email + " AND course:" + instructor.courseId;
+            availableIdString = "person:" + instructor.email;
         }
         
         return availableIdString;
@@ -186,9 +186,9 @@ public class AdminSearchPageData extends PageData {
         if (student.googleId != null && !student.googleId.trim().isEmpty()) {
             availableIdString = "person:" + student.googleId;
         } else if (student.name != null && !student.name.trim().isEmpty()) {
-            availableIdString = "person:" + student.name + " AND course:" + student.course;
+            availableIdString = "person:" + student.name;
         } else if (student.email != null && !student.email.trim().isEmpty()) {
-            availableIdString = "person:" + student.email + " AND course:" + student.course;
+            availableIdString = "person:" + student.email;
         }
         
         return availableIdString;

--- a/src/main/webapp/WEB-INF/tags/admin/activity/filterPanel.tag
+++ b/src/main/webapp/WEB-INF/tags/admin/activity/filterPanel.tag
@@ -76,13 +76,12 @@
                     <div class="form-group">
                         <div class="col-md-12">
                             <div class="form-control-static">
-                                <strong>Possible Labels:</strong>&nbsp;from, to, person, role, course, request, response, version,time,info<br>
+                                <strong>Possible Labels:</strong>&nbsp;from, to, person, role, request, response, version,time,info<br>
                                 <ul>
                                     <li>E.g. from: 13/03/13</li>
                                     <li>E.g. to: 13/03/13</li>
                                     <li>E.g. person: teammates.coord</li>
                                     <li>E.g. role: Instructor, Student, Unregistered</li>
-                                    <li>E.g. course: instructor1.tes-demo</li>
                                     <li>E.g. request: InstructorEval, StudentHome, evaluationclosingreminders</li>
                                     <li>E.g. response: Pageload, System Error Report, Delete Course</li>
                                     <li>E.g. version: 4.15, 4.16</li>

--- a/src/main/webapp/WEB-INF/tags/admin/activity/filterPanel.tag
+++ b/src/main/webapp/WEB-INF/tags/admin/activity/filterPanel.tag
@@ -76,12 +76,13 @@
                     <div class="form-group">
                         <div class="col-md-12">
                             <div class="form-control-static">
-                                <strong>Possible Labels:</strong>&nbsp;from, to, person, role, request, response, version,time,info<br>
+                                <strong>Possible Labels:</strong>&nbsp;from, to, person, role, course, request, response, version,time,info<br>
                                 <ul>
                                     <li>E.g. from: 13/03/13</li>
                                     <li>E.g. to: 13/03/13</li>
                                     <li>E.g. person: teammates.coord</li>
                                     <li>E.g. role: Instructor, Student, Unregistered</li>
+                                    <li>E.g. course: instructor1.tes-demo</li>
                                     <li>E.g. request: InstructorEval, StudentHome, evaluationclosingreminders</li>
                                     <li>E.g. response: Pageload, System Error Report, Delete Course</li>
                                     <li>E.g. version: 4.15, 4.16</li>

--- a/src/main/webapp/WEB-INF/tags/admin/search/instructorRow.tag
+++ b/src/main/webapp/WEB-INF/tags/admin/search/instructorRow.tag
@@ -39,7 +39,7 @@
                         
                     <span class="glyphicon glyphicon-zoom-in"></span>View Recent Actions
                 </button>
-                <input type="hidden" name="filterQuery" value="person:${instructor.viewRecentActionsId}">
+                <input type="hidden" name="filterQuery" value="${instructor.viewRecentActionsId}">
             </form>
         </c:if>
     </td>

--- a/src/main/webapp/WEB-INF/tags/admin/search/instructorRow.tag
+++ b/src/main/webapp/WEB-INF/tags/admin/search/instructorRow.tag
@@ -40,6 +40,7 @@
                     <span class="glyphicon glyphicon-zoom-in"></span>View Recent Actions
                 </button>
                 <input type="hidden" name="filterQuery" value="${instructor.viewRecentActionsId}">
+                <input type="hidden" name="courseId" value="${instructor.courseId}">
             </form>
         </c:if>
     </td>

--- a/src/main/webapp/WEB-INF/tags/admin/search/studentRow.tag
+++ b/src/main/webapp/WEB-INF/tags/admin/search/studentRow.tag
@@ -52,7 +52,7 @@
                     <span class="glyphicon glyphicon-zoom-in"></span>View Recent Actions
                 </button>                                 
                                                 
-                <input type="hidden" name="filterQuery" value="person:${student.viewRecentActionsId}">
+                <input type="hidden" name="filterQuery" value="${student.viewRecentActionsId}">
             </form>
         </c:if>
         

--- a/src/main/webapp/WEB-INF/tags/admin/search/studentRow.tag
+++ b/src/main/webapp/WEB-INF/tags/admin/search/studentRow.tag
@@ -53,6 +53,7 @@
                 </button>                                 
                                                 
                 <input type="hidden" name="filterQuery" value="${student.viewRecentActionsId}">
+                <input type="hidden" name="courseId" value="${student.courseId}">
             </form>
         </c:if>
         


### PR DESCRIPTION
fix #4525

The issue happens only when the user is unregistered and his name is used in the query instead of his google id. Therefore, to solve this, I introduce "course" attribute to the query to indicate the course that unregistered user is belonged to. The query to search for activities of the user will be done via Search page by clicking on "View recent actions".

@kanghj could you review this?