### PR TITLE
Users go to old home page when trying to submit for new course #4572

### DIFF
--- a/src/main/java/teammates/common/datatransfer/StudentAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/StudentAttributes.java
@@ -8,7 +8,6 @@ import java.util.Comparator;
 import java.util.List;
 
 import teammates.common.util.Assumption;
-import teammates.common.util.Config;
 import teammates.common.util.Const;
 import teammates.common.util.FieldValidator;
 import teammates.common.util.Sanitizer;
@@ -130,7 +129,7 @@ public class StudentAttributes extends EntityAttributes {
     }
 
     public String getRegistrationUrl() {
-        return new Url(Config.APP_URL + Const.ActionURIs.STUDENT_COURSE_JOIN_NEW)
+        return new Url(Const.ActionURIs.STUDENT_COURSE_JOIN_NEW)
                                            .withRegistrationKey(StringHelper.encrypt(key))
                                            .withStudentEmail(email)
                                            .withCourseId(course)

--- a/src/main/java/teammates/common/util/Sanitizer.java
+++ b/src/main/java/teammates/common/util/Sanitizer.java
@@ -131,6 +131,32 @@ public class Sanitizer {
         }
     }
     
+    /**
+     * Sanitizes the given URL for the parameter {@link Const.ParamsNames.NEXT_URL}.
+     * The following characters will be sanitized:
+     * <ul>
+     * <li>&, to prevent the parameters of the next URL from being considered as
+     *     part of the original URL</li>
+     * <li>%2B (encoded +), to prevent Google from decoding it back to +,
+     *     which is used to encode whitespace in some cases</li>
+     * <li>%23 (encoded #), to prevent Google from decoding it back to #,
+     *     which is used to traverse the HTML document to a certain id</li>
+     * </ul>
+     */
+    public static String sanitizeForNextUrl(String url) {
+        return url.replace("&", "${amp}").replace("%2B", "${plus}").replace("%23", "${hash}");
+    }
+    
+    /**
+     * Recovers the URL from sanitization due to {@link #sanitizeForNextUrl}.
+     * In addition, any un-encoded whitespace (they may be there due to Google's 
+     * behind-the-screen decoding process) will be encoded again to +.
+     */
+    public static String desanitizeFromNextUrl(String url) {
+        return url.replace("${amp}", "&").replace("${plus}", "%2B").replace("${hash}", "%23")
+                  .replace(" ", "+");
+    }
+    
     public static String sanitizeForRichText(String richText) {
         if (richText == null) {
             return null;

--- a/src/main/java/teammates/logic/core/Emails.java
+++ b/src/main/java/teammates/logic/core/Emails.java
@@ -836,7 +836,7 @@ public class Emails {
 
         String joinUrl;
         if (s != null) {    
-            joinUrl = s.getRegistrationUrl();
+            joinUrl = Config.APP_URL + s.getRegistrationUrl();
         } else {
             joinUrl = "{The join link unique for each student appears here}";
         }
@@ -852,7 +852,7 @@ public class Emails {
 
         String joinUrl;
         if (s != null) {    
-            joinUrl = s.getRegistrationUrl();
+            joinUrl = Config.APP_URL + s.getRegistrationUrl();
         } else {
             joinUrl = "{The join link unique for each student appears here}";
         }

--- a/src/main/java/teammates/ui/controller/Action.java
+++ b/src/main/java/teammates/ui/controller/Action.java
@@ -238,10 +238,8 @@ public abstract class Action {
                 
                 throw new UnauthorizedAccessException("Unregistered user for a page that needs one");
             } else if (isPageNotCourseJoinRelated() && doesRegkeyBelongToUnregisteredStudent() && isUserLoggedIn) {
-                Url redirectUrl = new Url(Const.ViewURIs.LOGOUT)
-                                      .withParam(Const.ParamsNames.NEXT_URL, requestUrl)
-                                      .withUserId(StringHelper.encrypt(account.googleId)); 
-                
+                Url redirectUrl = new Url(student.getRegistrationUrl())
+                                      .withParam(Const.ParamsNames.NEXT_URL, requestUrl);
                 setRedirectPage(redirectUrl.toString());
                 return null;
             }

--- a/src/main/java/teammates/ui/controller/Action.java
+++ b/src/main/java/teammates/ui/controller/Action.java
@@ -15,7 +15,6 @@ import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.UnauthorizedAccessException;
 import teammates.common.util.ActivityLogEntry;
 import teammates.common.util.Assumption;
-import teammates.common.util.Config;
 import teammates.common.util.Const;
 import teammates.common.util.Const.StatusMessageColor;
 import teammates.common.util.HttpRequestHelper;
@@ -239,7 +238,7 @@ public abstract class Action {
                 
                 throw new UnauthorizedAccessException("Unregistered user for a page that needs one");
             } else if (isPageNotCourseJoinRelated() && doesRegkeyBelongToUnregisteredStudent() && isUserLoggedIn) {
-                Url redirectUrl = new Url(Config.APP_URL + student.getRegistrationUrl())
+                Url redirectUrl = new Url(student.getRegistrationUrl())
                                       .withParam(Const.ParamsNames.NEXT_URL, requestUrl);
                 setRedirectPage(redirectUrl.toString());
                 return null;

--- a/src/main/java/teammates/ui/controller/Action.java
+++ b/src/main/java/teammates/ui/controller/Action.java
@@ -15,6 +15,7 @@ import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.exception.UnauthorizedAccessException;
 import teammates.common.util.ActivityLogEntry;
 import teammates.common.util.Assumption;
+import teammates.common.util.Config;
 import teammates.common.util.Const;
 import teammates.common.util.Const.StatusMessageColor;
 import teammates.common.util.HttpRequestHelper;
@@ -238,7 +239,7 @@ public abstract class Action {
                 
                 throw new UnauthorizedAccessException("Unregistered user for a page that needs one");
             } else if (isPageNotCourseJoinRelated() && doesRegkeyBelongToUnregisteredStudent() && isUserLoggedIn) {
-                Url redirectUrl = new Url(student.getRegistrationUrl())
+                Url redirectUrl = new Url(Config.APP_URL + student.getRegistrationUrl())
                                       .withParam(Const.ParamsNames.NEXT_URL, requestUrl);
                 setRedirectPage(redirectUrl.toString());
                 return null;

--- a/src/main/java/teammates/ui/controller/AdminSearchPageData.java
+++ b/src/main/java/teammates/ui/controller/AdminSearchPageData.java
@@ -11,6 +11,7 @@ import teammates.common.datatransfer.InstructorAttributes;
 import teammates.common.datatransfer.InstructorSearchResultBundle;
 import teammates.common.datatransfer.StudentAttributes;
 import teammates.common.datatransfer.StudentSearchResultBundle;
+import teammates.common.util.Config;
 import teammates.common.util.Sanitizer;
 import teammates.common.util.StringHelper;
 import teammates.ui.template.AdminSearchInstructorRow;
@@ -197,7 +198,7 @@ public class AdminSearchPageData extends PageData {
     private AdminSearchStudentLinks createStudentLinks(StudentAttributes student) {
         String detailsPageLink = studentRecordsPageLinkMap.get(student.getIdentificationString());
         String homePageLink = studentIdToHomePageLinkMap.get(student.googleId);
-        String courseJoinLink = student.getRegistrationUrl();
+        String courseJoinLink = Config.APP_URL + student.getRegistrationUrl();
         
         return new AdminSearchStudentLinks(detailsPageLink, homePageLink, courseJoinLink);
     }

--- a/src/main/java/teammates/ui/controller/PageData.java
+++ b/src/main/java/teammates/ui/controller/PageData.java
@@ -19,6 +19,7 @@ import teammates.common.datatransfer.FeedbackSessionAttributes;
 import teammates.common.datatransfer.InstructorAttributes;
 import teammates.common.datatransfer.StudentAttributes;
 import teammates.common.exception.EntityDoesNotExistException;
+import teammates.common.util.Config;
 import teammates.common.util.Const;
 import teammates.common.util.Sanitizer;
 import teammates.common.util.StringHelper;
@@ -317,7 +318,7 @@ public class PageData {
         String link = Const.ActionURIs.STUDENT_HOME_PAGE;
         link = addUserIdToUrl(link);
         if (isUnregistered) {
-            link = Url.addParamToUrl(student.getRegistrationUrl(), Const.ParamsNames.NEXT_URL, link);
+            link = Url.addParamToUrl(Config.APP_URL + student.getRegistrationUrl(), Const.ParamsNames.NEXT_URL, link);
         }
         return link;
     }
@@ -338,7 +339,7 @@ public class PageData {
         String link = Const.ActionURIs.STUDENT_PROFILE_PAGE;
         link = addUserIdToUrl(link);
         if (isUnregistered) {
-            link = Url.addParamToUrl(student.getRegistrationUrl(), Const.ParamsNames.NEXT_URL, link);
+            link = Url.addParamToUrl(Config.APP_URL + student.getRegistrationUrl(), Const.ParamsNames.NEXT_URL, link);
         }
         return link;
     }
@@ -359,7 +360,7 @@ public class PageData {
         String link = Const.ActionURIs.STUDENT_COMMENTS_PAGE;
         link = addUserIdToUrl(link);
         if (isUnregistered) {
-            link = Url.addParamToUrl(student.getRegistrationUrl(), Const.ParamsNames.NEXT_URL, link);
+            link = Url.addParamToUrl(Config.APP_URL + student.getRegistrationUrl(), Const.ParamsNames.NEXT_URL, link);
         }
         return link;
     }

--- a/src/main/java/teammates/ui/controller/StudentCourseJoinAction.java
+++ b/src/main/java/teammates/ui/controller/StudentCourseJoinAction.java
@@ -3,6 +3,7 @@ package teammates.ui.controller;
 import teammates.common.exception.EntityDoesNotExistException;
 import teammates.common.util.Assumption;
 import teammates.common.util.Const;
+import teammates.common.util.Sanitizer;
 import teammates.common.util.Url;
 import teammates.logic.api.Logic;
 
@@ -34,8 +35,9 @@ public class StudentCourseJoinAction extends Action {
         
         String confirmUrl = Const.ActionURIs.STUDENT_COURSE_JOIN_AUTHENTICATED 
                 + "?" + Const.ParamsNames.REGKEY + "=" + regkey 
-                + "&" + Const.ParamsNames.NEXT_URL + "=" + nextUrl;
-        data = new StudentCourseJoinConfirmationPageData(account, student, confirmUrl, Logic.getLogoutUrl(confirmUrl));
+                + "&" + Const.ParamsNames.NEXT_URL + "=" + Sanitizer.sanitizeForNextUrl(nextUrl);
+        data = new StudentCourseJoinConfirmationPageData(account, student, confirmUrl,
+                                                         Logic.getLogoutUrl(Sanitizer.sanitizeForNextUrl(confirmUrl)));
         excludeStudentDetailsFromResponseParams();
         
         return createShowPageResult(

--- a/src/main/java/teammates/ui/controller/StudentCourseJoinAction.java
+++ b/src/main/java/teammates/ui/controller/StudentCourseJoinAction.java
@@ -39,10 +39,12 @@ public class StudentCourseJoinAction extends Action {
         String nextUrlType = getPageTypeOfUrl(nextUrl);
         // the student is redirected to join page because he/she is not registered in the course
         boolean isRedirectResult = !Const.SystemParams.PAGES_ACCESSIBLE_WITHOUT_REGISTRATION.contains(nextUrlType);
+        boolean isNextUrlAccessibleWithoutLogin =
+                        Const.SystemParams.PAGES_ACCESSIBLE_WITHOUT_GOOGLE_LOGIN.contains(nextUrlType);
         String courseId = student.course;
         data = new StudentCourseJoinConfirmationPageData(account, student, confirmUrl,
                                                          Logic.getLogoutUrl(Sanitizer.sanitizeForNextUrl(confirmUrl)),
-                                                         isRedirectResult, courseId);
+                                                         isRedirectResult, courseId, isNextUrlAccessibleWithoutLogin);
         excludeStudentDetailsFromResponseParams();
         
         return createShowPageResult(

--- a/src/main/java/teammates/ui/controller/StudentCourseJoinAction.java
+++ b/src/main/java/teammates/ui/controller/StudentCourseJoinAction.java
@@ -36,8 +36,13 @@ public class StudentCourseJoinAction extends Action {
         String confirmUrl = Const.ActionURIs.STUDENT_COURSE_JOIN_AUTHENTICATED 
                 + "?" + Const.ParamsNames.REGKEY + "=" + regkey 
                 + "&" + Const.ParamsNames.NEXT_URL + "=" + Sanitizer.sanitizeForNextUrl(nextUrl);
+        String nextUrlType = getPageTypeOfUrl(nextUrl);
+        // the student is redirected to join page because he/she is not registered in the course
+        boolean isRedirectResult = !Const.SystemParams.PAGES_ACCESSIBLE_WITHOUT_REGISTRATION.contains(nextUrlType);
+        String courseId = student.course;
         data = new StudentCourseJoinConfirmationPageData(account, student, confirmUrl,
-                                                         Logic.getLogoutUrl(Sanitizer.sanitizeForNextUrl(confirmUrl)));
+                                                         Logic.getLogoutUrl(Sanitizer.sanitizeForNextUrl(confirmUrl)),
+                                                         isRedirectResult, courseId);
         excludeStudentDetailsFromResponseParams();
         
         return createShowPageResult(
@@ -64,4 +69,21 @@ public class StudentCourseJoinAction extends Action {
         
         return createRedirectResult(redirectUrl);
     }
+    
+    /**
+     * Gets the page type out of a URL, e.g the type of 
+     * <code>/page/xyz?param1=value1&amp;param2=value2</code> is <code>/page/xyz</code>.
+     * The page type is assumed to be in the form of /page/ followed by alphabets
+     * (case-insensitive) only, as per the design of {@link Const.ActionURIs}.
+     */
+    public static String getPageTypeOfUrl(String url) {
+        /* 
+         * Regex meaning: from the beginning of the string, tries to match /page/
+         * followed by one or more case-insensitive alphabets, followed by ? and
+         * any amount of any character until the end of the string.
+         * Returns everything before ? if matches or the original string otherwise.
+         */
+        return url.replaceFirst("^(/page/[A-Za-z]+)\\?.*$", "$1");
+    }
+    
 }

--- a/src/main/java/teammates/ui/controller/StudentCourseJoinConfirmationPageData.java
+++ b/src/main/java/teammates/ui/controller/StudentCourseJoinConfirmationPageData.java
@@ -7,16 +7,18 @@ public class StudentCourseJoinConfirmationPageData extends PageData {
     private String confirmUrl;
     private String logoutUrl;
     private boolean redirectResult;
+    private boolean nextUrlAccessibleWithoutLogin;
     private String courseId;
     
     public StudentCourseJoinConfirmationPageData(AccountAttributes account, StudentAttributes student,
                                                  String confirmUrl, String logoutUrl, boolean redirectResult,
-                                                 String courseId) {
+                                                 String courseId, boolean nextUrlAccessibleWithoutLogin) {
         super(account, student);
         this.confirmUrl = confirmUrl;
         this.logoutUrl = logoutUrl;
         this.redirectResult = redirectResult;
         this.courseId = courseId;
+        this.nextUrlAccessibleWithoutLogin = nextUrlAccessibleWithoutLogin;
     }
 
     public String getConfirmUrl() {
@@ -34,4 +36,9 @@ public class StudentCourseJoinConfirmationPageData extends PageData {
     public String getCourseId() {
         return courseId;
     }
+    
+    public boolean isNextUrlAccessibleWithoutLogin() {
+        return nextUrlAccessibleWithoutLogin;
+    }
+    
 }

--- a/src/main/java/teammates/ui/controller/StudentCourseJoinConfirmationPageData.java
+++ b/src/main/java/teammates/ui/controller/StudentCourseJoinConfirmationPageData.java
@@ -6,12 +6,17 @@ import teammates.common.datatransfer.StudentAttributes;
 public class StudentCourseJoinConfirmationPageData extends PageData {
     private String confirmUrl;
     private String logoutUrl;
+    private boolean redirectResult;
+    private String courseId;
     
     public StudentCourseJoinConfirmationPageData(AccountAttributes account, StudentAttributes student,
-                                                 String confirmUrl, String logoutUrl) {
+                                                 String confirmUrl, String logoutUrl, boolean redirectResult,
+                                                 String courseId) {
         super(account, student);
         this.confirmUrl = confirmUrl;
         this.logoutUrl = logoutUrl;
+        this.redirectResult = redirectResult;
+        this.courseId = courseId;
     }
 
     public String getConfirmUrl() {
@@ -20,5 +25,13 @@ public class StudentCourseJoinConfirmationPageData extends PageData {
 
     public String getLogoutUrl() {
         return logoutUrl;
+    }
+    
+    public boolean isRedirectResult() {
+        return redirectResult;
+    }
+    
+    public String getCourseId() {
+        return courseId;
     }
 }

--- a/src/main/webapp/jsp/studentCourseJoinConfirmation.jsp
+++ b/src/main/webapp/jsp/studentCourseJoinConfirmation.jsp
@@ -23,9 +23,8 @@
 	            <c:choose>
 	                <c:when test="${data.redirectResult}">
 	                    If you wish to register as <strong>${data.account.googleId}</strong>, please confirm below to complete your registration.
-	                    <br>If you wish to register with another Google ID or do not wish to register for this course, please
-	                    <a href="${data.logoutUrl}">log out</a>
-	                    , log in with your desired Google ID if necessary, and navigate to the link sent to you via email again.
+	                    <br>If you wish to register with another Google ID<c:if test="${data.nextUrlAccessibleWithoutLogin}"> or do not wish to register for this course</c:if>, please
+	                    <a href="${data.logoutUrl}">log out</a>, log in with your desired Google ID<c:if test="${data.nextUrlAccessibleWithoutLogin}"> if necessary</c:if>, and navigate to the link again.
 	                    <br>
 	                </c:when>
 	                <c:otherwise>

--- a/src/main/webapp/jsp/studentCourseJoinConfirmation.jsp
+++ b/src/main/webapp/jsp/studentCourseJoinConfirmation.jsp
@@ -15,18 +15,47 @@
 	    </div>
 	    <div class="panel-body">
 	        <p>
-	            You are currently logged in as <span><strong>${data.account.googleId}</strong></span>. 
-	            <br>If this is not you please <a href="${data.logoutUrl}">log out</a> and re-login using your own Google account.
-	            <br>If this is you, please confirm below to complete your registration.
+	            You are currently logged in as <span><strong>${data.account.googleId}</strong></span>.
+	            <c:if test="${data.redirectResult}">
+	                You have been redirected to this page because you navigated to a link for the course <strong>${data.courseId}</strong>, which you have not been registered in.
+	            </c:if>
 	            <br>
+	            <c:choose>
+	                <c:when test="${data.redirectResult}">
+	                    If you wish to register as <strong>${data.account.googleId}</strong>, please confirm below to complete your registration.
+	                    <br>If you wish to register with another Google ID or do not wish to register for this course, please
+	                    <a href="${data.logoutUrl}">log out</a>
+	                    , log in with your desired Google ID if necessary, and navigate to the link sent to you via email again.
+	                    <br>
+	                </c:when>
+	                <c:otherwise>
+	                    If this is not you please <a href="${data.logoutUrl}">log out</a> and re-login using your own Google account.
+	                    <br>If this is you, please confirm below to complete your registration.
+	                    <br>
+	                </c:otherwise>
+	            </c:choose>
 	        </p>
 	        <div class="align-center">
-	            <a href="${data.confirmUrl}" 
-	                class="btn btn-success"
-	                id="button_confirm">Yes, this is my account</a>
-	            <a href="${data.logoutUrl}" 
-	                class="btn btn-danger"
-	                id="button_cancel">No, this is not my account</a>
+	            <a href="${data.confirmUrl}" class="btn btn-success" id="button_confirm">
+	                <c:choose>
+	                    <c:when test="${data.redirectResult}">
+	                        Register as <strong>${data.account.googleId}</strong>
+	                    </c:when>
+	                    <c:otherwise>
+	                        Yes, this is my account
+	                    </c:otherwise>
+	                </c:choose>
+	            </a>
+	            <a href="${data.logoutUrl}" class="btn btn-danger" id="button_cancel">
+	                <c:choose>
+	                    <c:when test="${data.redirectResult}">
+	                        Do not register as <strong>${data.account.googleId}</strong>
+	                    </c:when>
+	                    <c:otherwise>
+	                        No, this is not my account
+	                    </c:otherwise>
+	                </c:choose>
+	            </a>
 	        </div>
 	        
 	    </div>

--- a/src/test/java/teammates/test/cases/common/StudentAttributesTest.java
+++ b/src/test/java/teammates/test/cases/common/StudentAttributesTest.java
@@ -23,7 +23,6 @@ import org.testng.annotations.Test;
 import teammates.common.datatransfer.StudentAttributes;
 import teammates.common.datatransfer.StudentAttributes.UpdateStatus;
 import teammates.common.exception.TeammatesException;
-import teammates.common.util.Config;
 import teammates.common.util.Const;
 import teammates.common.util.FieldValidator;
 import teammates.common.util.StringHelper;
@@ -283,7 +282,7 @@ public class StudentAttributesTest extends BaseTestCase {
         StudentAttributes sd = new StudentAttributes("sect 1", "team 1", "name 1", "email@email.com",
                                                      "comment 1", "course1");
         sd.key = "testkey";
-        String regUrl = new Url(Config.APP_URL + Const.ActionURIs.STUDENT_COURSE_JOIN_NEW)
+        String regUrl = new Url(Const.ActionURIs.STUDENT_COURSE_JOIN_NEW)
                                 .withRegistrationKey(StringHelper.encrypt("testkey"))
                                 .withStudentEmail("email@email.com")
                                 .withCourseId("course1")

--- a/src/test/java/teammates/test/cases/logic/EmailsTest.java
+++ b/src/test/java/teammates/test/cases/logic/EmailsTest.java
@@ -288,7 +288,7 @@ public class EmailsTest extends BaseComponentTestCase {
                 email.getSubject());
 
         // check email body
-        String joinUrl = s.getRegistrationUrl();
+        String joinUrl = Config.APP_URL + s.getRegistrationUrl();
         String emailBody = email.getContent().toString();
 
         AssertHelper.assertContainsRegex("Hello " + s.name + "{*}course <i>" + c.name

--- a/src/test/java/teammates/test/cases/ui/StudentCourseJoinActionTest.java
+++ b/src/test/java/teammates/test/cases/ui/StudentCourseJoinActionTest.java
@@ -3,6 +3,8 @@ package teammates.test.cases.ui;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertFalse;
 
+import static teammates.ui.controller.StudentCourseJoinAction.getPageTypeOfUrl;
+
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -108,6 +110,22 @@ public class StudentCourseJoinActionTest extends BaseActionTest {
         // delete the new student
         studentsDb.deleteStudentWithoutDocument(newStudentData.course, newStudentData.email);
 
+    }
+    
+    @Test
+    public void testGetUrlType() {
+        assertEquals("/page/somePage", getPageTypeOfUrl("/page/somePage"));
+        assertEquals("/page/somePage", getPageTypeOfUrl("/page/somePage?key=abcdef"));
+        // captures the nearest ?
+        assertEquals("/page/somePage", getPageTypeOfUrl("/page/somePage?key=abcdef&next=/page/anotherPage?"));
+        // the starting keyword /page/ must be strictly followed
+        assertEquals("/pag/somePage?key=abcdef", getPageTypeOfUrl("/pag/somePage?key=abcdef"));
+        assertEquals("page/somePage?key=abcdef", getPageTypeOfUrl("page/somePage?key=abcdef"));
+        // and must strictly be at the start of the string
+        assertEquals("abc.com/page/somePage?key=abcdef", getPageTypeOfUrl("abc.com/page/somePage?key=abcdef"));
+        // non-alphabet characters are not handled
+        assertEquals("/page/somePage123?key=abcdef", getPageTypeOfUrl("/page/somePage123?key=abcdef"));
+        assertEquals("/page/somePage/somePage?key=abcdef", getPageTypeOfUrl("/page/somePage/somePage?key=abcdef"));
     }
 
     private StudentCourseJoinAction getAction(String... params)

--- a/src/test/java/teammates/test/cases/ui/browsertests/StudentFeedbackQuestionSubmitPageUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/StudentFeedbackQuestionSubmitPageUiTest.java
@@ -51,9 +51,9 @@ public class StudentFeedbackQuestionSubmitPageUiTest extends BaseUiTestCase {
 
     private void testContent() throws Exception {
 
-        AppPage.logout(browser);
-        
         ______TS("unreg student");
+        
+        AppPage.logout(browser);
         
         fqOpen = BackDoor.getFeedbackQuestion("SFQSubmitUiT.CS2104", "Open Session", 1);
         fqClosed = BackDoor.getFeedbackQuestion("SFQSubmitUiT.CS2104", "Closed Session", 1);

--- a/src/test/java/teammates/test/cases/ui/browsertests/StudentFeedbackResultsPageUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/StudentFeedbackResultsPageUiTest.java
@@ -35,6 +35,22 @@ public class StudentFeedbackResultsPageUiTest extends BaseUiTestCase {
 
     @Test
     public void testAll() throws Exception {
+
+        ______TS("unreg student");
+
+        AppPage.logout(browser);
+        
+        // Open Session
+        StudentAttributes unreg = testData.students.get("DropOut");
+        resultsPage = loginToStudentFeedbackResultsPage(unreg, "Open Session");
+        resultsPage.verifyHtmlMainContent("/unregisteredStudentFeedbackResultsPageOpen.html");
+
+        // Mcq Session
+        resultsPage = loginToStudentFeedbackResultsPage(unreg, "MCQ Session");
+
+        // This is the full HTML verification for Unregistered Student Feedback Results Page, the rest can all be verifyMainHtml
+        resultsPage.verifyHtml("/unregisteredStudentFeedbackResultsPageMCQ.html");
+
         ______TS("no responses");
 
         resultsPage = loginToStudentFeedbackResultsPage("Alice", "Empty Session");
@@ -102,19 +118,6 @@ public class StudentFeedbackResultsPageUiTest extends BaseUiTestCase {
         resultsPage = loginToStudentFeedbackResultsPage("Alice", "CONTRIB Session");
         resultsPage.verifyHtmlMainContent("/studentFeedbackResultsPageCONTRIB.html");
 
-        ______TS("unreg student");
-
-        // should automatically logout.
-        // Open Session
-        StudentAttributes unreg = testData.students.get("DropOut");
-        resultsPage = loginToStudentFeedbackResultsPage(unreg, "Open Session");
-        resultsPage.verifyHtmlMainContent("/unregisteredStudentFeedbackResultsPageOpen.html");
-
-        // Mcq Session
-        resultsPage = loginToStudentFeedbackResultsPage(unreg, "MCQ Session");
-
-        // This is the full HTML verification for Unregistered Student Feedback Results Page, the rest can all be verifyMainHtml
-        resultsPage.verifyHtml("/unregisteredStudentFeedbackResultsPageMCQ.html");
     }
 
     @AfterClass

--- a/src/test/java/teammates/test/cases/ui/browsertests/StudentFeedbackSubmitPageUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/StudentFeedbackSubmitPageUiTest.java
@@ -78,8 +78,11 @@ public class StudentFeedbackSubmitPageUiTest extends BaseUiTestCase {
     }
 
     private void testContent() {
+
         ______TS("unreg student");
 
+        AppPage.logout(browser);
+        
         submitPage = loginToStudentFeedbackSubmitPage(testData.students.get("DropOut"), "Open Session");
 
         // This is the full HTML verification for Unregistered Student Feedback Submit Page, the rest can all be verifyMainHtml

--- a/src/test/java/teammates/test/pageobjects/AppPage.java
+++ b/src/test/java/teammates/test/pageobjects/AppPage.java
@@ -382,6 +382,17 @@ public abstract class AppPage {
         return changePageType(StudentCommentsPage.class);
     }
 
+    public LoginPage clickLoginAsStudentButton() {
+        WebElement loginButton = browser.driver.findElement(By.id("btnStudentLogin"));
+        loginButton.click();
+        waitForPageToLoad();
+        if (TestProperties.inst().isDevServer()) {
+            return changePageType(DevServerLoginPage.class);
+        } else {
+            return changePageType(GoogleLoginPage.class);
+        }
+    }
+
     /**
      * Equivalent to clicking the 'logout' link in the top menu of the page.
      * @return 

--- a/src/test/java/teammates/test/pageobjects/DevServerLoginPage.java
+++ b/src/test/java/teammates/test/pageobjects/DevServerLoginPage.java
@@ -58,11 +58,16 @@ public class DevServerLoginPage extends LoginPage {
 
     @Override
     public StudentHomePage loginAsStudent(String username, String password) {
+        return loginAsStudent(username, password, StudentHomePage.class);
+    }
+
+    @Override
+    public <T extends AppPage> T loginAsStudent(String username, String password, Class<T> typeOfPage) {
         fillTextBox(emailTextBox, username);
         loginButton.click();
         waitForPageToLoad();
         browser.isAdminLoggedIn = false;
-        return changePageType(StudentHomePage.class);
+        return changePageType(typeOfPage);
     }
 
     @Override

--- a/src/test/java/teammates/test/pageobjects/GoogleLoginPage.java
+++ b/src/test/java/teammates/test/pageobjects/GoogleLoginPage.java
@@ -59,10 +59,15 @@ public class GoogleLoginPage extends LoginPage {
 
     @Override
     public StudentHomePage loginAsStudent(String username, String password) {
+        return loginAsStudent(username, password, StudentHomePage.class);
+    }
+
+    @Override
+    public <T extends AppPage> T loginAsStudent(String username, String password, Class<T> typeOfPage) {
         completeGoogleLoginSteps(username, password);
-        StudentHomePage homePage = changePageType(StudentHomePage.class);
+        T page = changePageType(typeOfPage);
         browser.isAdminLoggedIn = false;
-        return homePage;
+        return page;
     }
 
     private void completeGoogleLoginSteps(String username, String password) {

--- a/src/test/java/teammates/test/pageobjects/LoginPage.java
+++ b/src/test/java/teammates/test/pageobjects/LoginPage.java
@@ -12,6 +12,7 @@ public abstract class LoginPage extends AppPage {
     public abstract AppPage loginAsInstructorUnsuccessfully(String userName, String password);
     
     public abstract StudentHomePage loginAsStudent(String username, String password);
+    public abstract <T extends AppPage> T loginAsStudent(String username, String password, Class<T> typeOfPage);
 
     public abstract StudentCourseJoinConfirmationPage loginAsJoiningStudent(String username, String password);
     public abstract InstructorCourseJoinConfirmationPage loginAsJoiningInstructor(String username, String password);

--- a/src/test/java/teammates/test/pageobjects/StudentCourseJoinConfirmationPage.java
+++ b/src/test/java/teammates/test/pageobjects/StudentCourseJoinConfirmationPage.java
@@ -3,6 +3,8 @@ package teammates.test.pageobjects;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 
+import teammates.test.driver.TestProperties;
+
 public class StudentCourseJoinConfirmationPage extends AppPage {
     @FindBy(id = "button_confirm")
     protected WebElement confirmButton;
@@ -20,14 +22,28 @@ public class StudentCourseJoinConfirmationPage extends AppPage {
     }
 
     public StudentHomePage clickConfirmButton() {
+        return clickConfirmButton(StudentHomePage.class);
+    }
+    
+    public <T extends AppPage> T clickConfirmButton(Class<T> typeOfPage) {
         confirmButton.click();
         waitForPageToLoad();
-        return changePageType(StudentHomePage.class);
+        return changePageType(typeOfPage);
     }
     
     public String clickCancelButtonAndGetSourceOfDestination() {
         cancelButton.click();
         waitForPageToLoad();
         return browser.driver.getPageSource();
+    }
+    
+    public LoginPage clickCancelButton() {
+        cancelButton.click();
+        waitForPageToLoad();
+        if (TestProperties.inst().isDevServer()) {
+            return changePageType(DevServerLoginPage.class);
+        } else {
+            return changePageType(GoogleLoginPage.class);
+        }
     }
 }

--- a/src/test/resources/pages/studentCourseJoinConfirmationLoggedInHTML.html
+++ b/src/test/resources/pages/studentCourseJoinConfirmationLoggedInHTML.html
@@ -36,7 +36,7 @@
                <a href="${test.url}/_ah/logout?continue=${continue.url}">
                   log out
                </a>
-               , log in with your desired Google ID if necessary, and navigate to the link sent to you via email again.
+               , log in with your desired Google ID if necessary, and navigate to the link again.
                <br/>
             </p>
             <div class="align-center">

--- a/src/test/resources/pages/studentCourseJoinConfirmationLoggedInHTML.html
+++ b/src/test/resources/pages/studentCourseJoinConfirmationLoggedInHTML.html
@@ -1,0 +1,58 @@
+   <div class="container" id="mainContent">
+      <div id="topOfPage">
+      </div>
+      <div id="statusMessage" style="display: none;">
+      </div>
+      <br/>
+      <div class="panel panel-primary panel-narrow">
+         <div class="panel-heading">
+            <h4>
+               Confirm your Google account
+            </h4>
+         </div>
+         <div class="panel-body">
+            <p>
+               You are currently logged in as
+               <span>
+                  <strong>
+                     ${test.student1}
+                  </strong>
+               </span>
+               .
+	            
+	                You have been redirected to this page because you navigated to a link for the course
+               <strong>
+                  SFResultsUiT.CS2104
+               </strong>
+               , which you have not been registered in.
+               <br/>
+               If you wish to register as
+               <strong>
+                  ${test.student1}
+               </strong>
+               , please confirm below to complete your registration.
+               <br/>
+               If you wish to register with another Google ID or do not wish to register for this course, please
+               <a href="${test.url}/_ah/logout?continue=${continue.url}">
+                  log out
+               </a>
+               , log in with your desired Google ID if necessary, and navigate to the link sent to you via email again.
+               <br/>
+            </p>
+            <div class="align-center">
+               <a class="btn btn-success" href="/page/studentCourseJoinAuthenticated?key=${regkey.enc}&next=/page/studentFeedbackResultsPage?courseid=SFResultsUiT.CS2104${amp}studentemail=drop.out%40gmail.tmt${amp}fsname=First+Session${amp}key=${regkey.enc}" id="button_confirm">
+                  Register as
+                  <strong>
+                     ${test.student1}
+                  </strong>
+               </a>
+               <a class="btn btn-danger" href="${test.url}/_ah/logout?continue=${continue.url}" id="button_cancel">
+                  Do not register as
+                  <strong>
+                     ${test.student1}
+                  </strong>
+               </a>
+            </div>
+         </div>
+      </div>
+   </div>

--- a/src/test/resources/pages/studentFeedbackResultsPageNewlyRegistered.html
+++ b/src/test/resources/pages/studentFeedbackResultsPageNewlyRegistered.html
@@ -1,0 +1,367 @@
+   <div class="container" id="mainContent">
+      <div id="topOfPage">
+      </div>
+      <h1>
+         Feedback Results - Student
+      </h1>
+      <br/>
+      <div class="well well-plain">
+         <div class="panel-body">
+            <div class="form-horizontal">
+               <div class="panel-heading">
+                  <div class="form-group">
+                     <label class="col-sm-2 control-label">
+                        Course ID:
+                     </label>
+                     <div class="col-sm-10">
+                        <p class="form-control-static">
+                           SFResultsUiT.CS2104
+                        </p>
+                     </div>
+                  </div>
+                  <div class="form-group">
+                     <label class="col-sm-2 control-label">
+                        Session:
+                     </label>
+                     <div class="col-sm-10">
+                        <p class="form-control-static">
+                           First Session
+                        </p>
+                     </div>
+                  </div>
+                  <div class="form-group">
+                     <label class="col-sm-2 control-label">
+                        Opening time:
+                     </label>
+                     <div class="col-sm-10">
+                        <p class="form-control-static">
+                           Sun, 01 Apr 2012, 11:59 PM
+                        </p>
+                     </div>
+                  </div>
+                  <div class="form-group">
+                     <label class="col-sm-2 control-label">
+                        Closing time:
+                     </label>
+                     <div class="col-sm-10">
+                        <p class="form-control-static">
+                           Sat, 30 Apr 2016, 11:59 PM
+                        </p>
+                     </div>
+                  </div>
+               </div>
+            </div>
+         </div>
+      </div>
+      <br/>
+      <div class="alert alert-success" id="statusMessage">
+         You have been successfully added to the course [SFResultsUiT.CS2104] Programming Language Concepts.
+         <br/>
+         You have received feedback from others. Please see below.
+      </div>
+      <script src="/js/statusMessage.js" type="text/javascript">
+      </script>
+      <br/>
+      <div class="panel panel-default">
+         <div class="panel-heading">
+            <h4>
+               Question 1:
+               <span class="text-preserve-space">
+                  What is the best selling point of your product?
+               </span>
+            </h4>
+            <div class="panel panel-primary">
+               <div class="panel-heading">
+                  <b>
+                     To:
+                  </b>
+                  Alice Betsy
+               </div>
+               <table class="table">
+                  <tbody>
+                     <tr class="resultSubheader">
+                        <td>
+                           <span class="bold">
+                              <b>
+                                 From:
+                              </b>
+                           </span>
+                           Anonymous student 227201833
+                        </td>
+                     </tr>
+                     <tr>
+                        <td class="text-preserve-space">
+                           Alice self feedback.
+                        </td>
+                     </tr>
+                     <tr>
+                        <td>
+                           <ul class="list-group comment-list">
+                              <li class="list-group-item list-group-item-warning" id="responseCommentRow-${comment.id}">
+                                 <div id="commentBar-${comment.id}">
+                                    <span class="text-muted">
+                                       From: SFResultsUiT.instr@gmail.tmt [Tue, 01 Mar 2016, 23:59:00 UTC] (last edited by SFResultsUiT.instr@gmail.tmt at Wed, 02 Mar 2016, 23:59:00 UTC)
+                                    </span>
+                                 </div>
+                                 <div id="plainCommentText-${comment.id}" style="margin-left: 15px;">
+                                    Instructor first comment to Alice
+                                 </div>
+                              </li>
+                              <li class="list-group-item list-group-item-warning" id="responseCommentRow-${comment.id}">
+                                 <div id="commentBar-${comment.id}">
+                                    <span class="text-muted">
+                                       From: SFResultsUiT.instr@gmail.tmt [Wed, 02 Mar 2016, 23:59:00 UTC]
+                                    </span>
+                                 </div>
+                                 <div id="plainCommentText-${comment.id}" style="margin-left: 15px;">
+                                    Instructor second comment to Alice
+                                 </div>
+                              </li>
+                           </ul>
+                        </td>
+                     </tr>
+                  </tbody>
+               </table>
+            </div>
+         </div>
+      </div>
+      <br/>
+      <div class="panel panel-default">
+         <div class="panel-heading">
+            <h4>
+               Question 2:
+               <span class="text-preserve-space">
+                  Rate 3 other students' products
+               </span>
+            </h4>
+            <div class="panel panel-info">
+               <div class="panel-heading">
+                  <b>
+                     To:
+                  </b>
+                  Alice Betsy
+               </div>
+               <table class="table">
+                  <tbody>
+                     <tr class="resultSubheader">
+                        <td>
+                           <span class="bold">
+                              <b>
+                                 From:
+                              </b>
+                           </span>
+                           You
+                        </td>
+                     </tr>
+                     <tr>
+                        <td class="text-preserve-space">
+                           Response to Alice from Dropout.
+                        </td>
+                     </tr>
+                  </tbody>
+               </table>
+            </div>
+            <div class="panel panel-primary">
+               <div class="panel-heading">
+                  <b>
+                     To:
+                  </b>
+                  Anonymous student 1426103091
+               </div>
+               <table class="table">
+                  <tbody>
+                     <tr class="resultSubheader">
+                        <td>
+                           <span class="bold">
+                              <b>
+                                 From:
+                              </b>
+                           </span>
+                           Anonymous student 227201833
+                        </td>
+                     </tr>
+                     <tr>
+                        <td class="text-preserve-space">
+                           Response to Danny.
+                        </td>
+                     </tr>
+                  </tbody>
+               </table>
+            </div>
+            <div class="panel panel-primary">
+               <div class="panel-heading">
+                  <b>
+                     To:
+                  </b>
+                  Anonymous student 410339386
+               </div>
+               <table class="table">
+                  <tbody>
+                     <tr class="resultSubheader">
+                        <td>
+                           <span class="bold">
+                              <b>
+                                 From:
+                              </b>
+                           </span>
+                           Anonymous student 227201833
+                        </td>
+                     </tr>
+                     <tr>
+                        <td class="text-preserve-space">
+                           Response to Benny.
+                        </td>
+                     </tr>
+                  </tbody>
+               </table>
+            </div>
+            <div class="panel panel-info">
+               <div class="panel-heading">
+                  <b>
+                     To:
+                  </b>
+                  Benny Charles
+               </div>
+               <table class="table">
+                  <tbody>
+                     <tr class="resultSubheader">
+                        <td>
+                           <span class="bold">
+                              <b>
+                                 From:
+                              </b>
+                           </span>
+                           You
+                        </td>
+                     </tr>
+                     <tr>
+                        <td class="text-preserve-space">
+                           Response to Benny from Dropout.
+                        </td>
+                     </tr>
+                  </tbody>
+               </table>
+            </div>
+            <div class="panel panel-info">
+               <div class="panel-heading">
+                  <b>
+                     To:
+                  </b>
+                  Danny Engrid
+               </div>
+               <table class="table">
+                  <tbody>
+                     <tr class="resultSubheader">
+                        <td>
+                           <span class="bold">
+                              <b>
+                                 From:
+                              </b>
+                           </span>
+                           You
+                        </td>
+                     </tr>
+                     <tr>
+                        <td class="text-preserve-space">
+                           Response to Danny from Dropout.
+                        </td>
+                     </tr>
+                  </tbody>
+               </table>
+            </div>
+            <div class="panel panel-primary">
+               <div class="panel-heading">
+                  <b>
+                     To:
+                  </b>
+                  You
+               </div>
+               <table class="table">
+                  <tbody>
+                     <tr class="resultSubheader">
+                        <td>
+                           <span class="bold">
+                              <b>
+                                 From:
+                              </b>
+                           </span>
+                           Anonymous student 227201833
+                        </td>
+                     </tr>
+                     <tr>
+                        <td class="text-preserve-space">
+                           Response to Dropout.
+                        </td>
+                     </tr>
+                  </tbody>
+               </table>
+            </div>
+         </div>
+      </div>
+      <br/>
+      <div class="panel panel-default">
+         <div class="panel-heading">
+            <h4>
+               Question 3:
+               <span class="text-preserve-space">
+                  Give feedback to 3 other teams.
+               </span>
+            </h4>
+            <div class="panel panel-primary">
+               <div class="panel-heading">
+                  <b>
+                     To:
+                  </b>
+                  Team 1
+               </div>
+               <table class="table">
+                  <tbody>
+                     <tr class="resultSubheader">
+                        <td>
+                           <span class="bold">
+                              <b>
+                                 From:
+                              </b>
+                           </span>
+                           Your Team (Team 2)
+                        </td>
+                     </tr>
+                     <tr>
+                        <td class="text-preserve-space">
+                           Team 2 (danny) to team 1
+                        </td>
+                     </tr>
+                  </tbody>
+               </table>
+            </div>
+            <div class="panel panel-primary">
+               <div class="panel-heading">
+                  <b>
+                     To:
+                  </b>
+                  Your Team (Team 2)
+               </div>
+               <table class="table">
+                  <tbody>
+                     <tr class="resultSubheader">
+                        <td>
+                           <span class="bold">
+                              <b>
+                                 From:
+                              </b>
+                           </span>
+                           Team 1
+                        </td>
+                     </tr>
+                     <tr>
+                        <td class="text-preserve-space">
+                           alice to team 2
+                        </td>
+                     </tr>
+                  </tbody>
+               </table>
+            </div>
+         </div>
+      </div>
+      <br/>
+   </div>


### PR DESCRIPTION
Fixes #4572 and fixes #4562 (the test failure in the latter has the same cause).
This issue also highlights our alarming failure in handling next URL. Just doing what is suggested [here](https://github.com/TEAMMATES/repo/issues/4572#issuecomment-157297754) is insufficient.
1. `nextUrl` can be anything from the pages that do not require Google login (they are defined in `Const.SystemParams`) for this to happen.
2. Instead of just status message, it is better to change the content of the box entirely because the intention of confirming the Google ID is not exactly the same:
![image](https://cloud.githubusercontent.com/assets/7261051/11238546/66c037a6-8e21-11e5-9a8a-c471aa908f4e.png)
3. True enough, encoding the URL doesn't work because behind the screen Google does its own encoding and decoding. One (and maybe the only) workaround is replacing dangerous characters (i.e `&`, `+`, `#`) with placeholders and revert them back afterwards.

Tested and passed in both dev and staging, but will need more time to design test case(s) for this one. Feel free to review the change in functional codes, though.