### PR TITLE
Optimize inefficient processes in HtmlHelper #4608

### DIFF
--- a/src/test/java/teammates/test/driver/HtmlHelper.java
+++ b/src/test/java/teammates/test/driver/HtmlHelper.java
@@ -255,22 +255,12 @@ public class HtmlHelper {
     }
     
     private static boolean isVoidElement(String elementName){
-        return elementName.equals("area")
-                || elementName.equals("base")
-                || elementName.equals("br")
-                || elementName.equals("col")
-                || elementName.equals("command")
-                || elementName.equals("embed")
+        return elementName.equals("br")
                 || elementName.equals("hr")
                 || elementName.equals("img")
                 || elementName.equals("input")
-                || elementName.equals("keygen")
                 || elementName.equals("link")
-                || elementName.equals("meta")
-                || elementName.equals("param")
-                || elementName.equals("source")
-                || elementName.equals("track")
-                || elementName.equals("wbr");
+                || elementName.equals("meta");
     }
 
 }

--- a/src/test/java/teammates/test/driver/HtmlHelper.java
+++ b/src/test/java/teammates/test/driver/HtmlHelper.java
@@ -13,6 +13,8 @@ import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
 import teammates.common.util.Config;
+import teammates.common.util.Const;
+import teammates.common.util.FileHelper;
 
 public class HtmlHelper {
     
@@ -45,17 +47,39 @@ public class HtmlHelper {
     
     private static boolean assertSameHtml(String expected, String actual, boolean isPart,
                                           boolean isDifferenceToBeShown) {
-        String processedExpected = convertToStandardHtml(expected, isPart);
+        String processedExpected = standardizeLineBreaks(expected);
         String processedActual = convertToStandardHtml(actual, isPart);
 
-        if (!AssertHelper.isContainsRegex(processedExpected, processedActual)) {
+        if (areSameHtmls(processedExpected, processedActual)) {
+            return true;
+        }
+        
+        // the first failure might be caused by non-standardized conversion
+        processedExpected = convertToStandardHtml(expected, isPart);
+
+        if (areSameHtmls(processedExpected, processedActual)) {
+            return true;
+        } else {
+            // if it still fails, then it is a failure after all
             if (isDifferenceToBeShown) {
                 assertEquals("<expected>\n" + processedExpected + "</expected>",
                              "<actual>\n" + processedActual + "</actual>");
             }
             return false;
         }
-        return true;
+    }
+    
+    private static boolean areSameHtmls(String expected, String actual) {
+        return AssertHelper.isContainsRegex(expected, actual);
+    }
+    
+    /**
+     * {@link FileHelper#readFile} uses the system's line separator as line break,
+     * while {@link #convertToStandardHtml} uses LF <code>\n</code> character.
+     * Standardize by replacing each line separator with LF character.
+     */
+    private static String standardizeLineBreaks(String expected) {
+        return expected.replace(Const.EOL, "\n");
     }
 
     /**

--- a/src/test/java/teammates/test/driver/HtmlHelper.java
+++ b/src/test/java/teammates/test/driver/HtmlHelper.java
@@ -182,8 +182,19 @@ public class HtmlHelper {
     }
     
     private static boolean checkForAttributeWithSpecificValue(Node attribute, String attrType, String attrValue) {
-        return attribute.getNodeName().equalsIgnoreCase(attrType)
-                && attribute.getNodeValue().contains(attrValue);
+        if (attribute.getNodeName().equalsIgnoreCase(attrType)) {
+            return attrType.equals("class") ? isClassContainingValue(attrValue, attribute.getNodeValue())
+                                            : attribute.getNodeValue().equals(attrValue);
+        } else {
+            return false;
+        }
+    }
+    
+    private static boolean isClassContainingValue(String expected, String actual) {
+        return actual.equals(expected)
+                || actual.startsWith(expected + " ")
+                || actual.endsWith(" " + expected)
+                || actual.contains(" " + expected + " ");
     }
 
     private static String getNodeOpeningTag(Node currentNode) {


### PR DESCRIPTION
Fixes #4608 

Two significant sources of the slow-ness:
1. There's _four_ times looping for each div when trying to check if it's ignored or not.
2. The expected HTML files are converted to standard HTML. This is redundant; during regeneration they _have_ been converted to standard HTML.

And more optimizations are achieved by bypassing unnecessary boolean checks, like the unused void elements.