### PR TITLE
admin sessions page: show more stats #4598

### DIFF
--- a/src/main/java/teammates/ui/controller/AdminSessionsPageAction.java
+++ b/src/main/java/teammates/ui/controller/AdminSessionsPageAction.java
@@ -18,15 +18,18 @@ import teammates.common.util.StatusMessage;
 import teammates.common.util.TimeHelper;
 import teammates.logic.api.GateKeeper;
 import teammates.logic.api.Logic;
+import teammates.ui.template.InstitutionPanel;
 
 public class AdminSessionsPageAction extends Action {
     
     AdminSessionsPageData data;
 
+    private static final String UNKNOWN_INSTITUTION = "Unknown";
     private Map<String, List<FeedbackSessionAttributes>> map;
     private Map<String, String> sessionToInstructorIdMap = new HashMap<String, String>();
     private int totalOngoingSessions;
     private int totalOpenStatusSessions;
+    private int totalInstitutes;
     private Date rangeStart;
     private Date rangeEnd;
     private double zone;
@@ -77,6 +80,8 @@ public class AdminSessionsPageAction extends Action {
     private void prepareDefaultPageData(Calendar calStart, Calendar calEnd) {        
         this.map = new HashMap<String, List<FeedbackSessionAttributes>>();
         this.totalOngoingSessions = 0;
+        this.totalOpenStatusSessions = 0;
+        this.totalInstitutes = 0;
         this.rangeStart = calStart.getTime();
         this.rangeEnd = calEnd.getTime();
     }
@@ -127,7 +132,8 @@ public class AdminSessionsPageAction extends Action {
     
                 prepareDefaultPageData(calStart, calEnd);
                 data.init(this.map, this.sessionToInstructorIdMap, this.totalOngoingSessions, 
-                     this.totalOpenStatusSessions, this.rangeStart, this.rangeEnd, this.zone, this.isShowAll);
+                     this.totalOpenStatusSessions, this.totalInstitutes, this.rangeStart, 
+                     this.rangeEnd, this.zone, this.isShowAll);
                 return createShowPageResult(Const.ViewURIs.ADMIN_SESSIONS, data);
             }
           
@@ -140,7 +146,8 @@ public class AdminSessionsPageAction extends Action {
 
             prepareDefaultPageData(calStart, calEnd);
             data.init(this.map, this.sessionToInstructorIdMap, this.totalOngoingSessions,  
-                 this.totalOngoingSessions, this.rangeStart, this.rangeEnd, this.zone, this.isShowAll);
+                 this.totalOngoingSessions, this.totalInstitutes, this.rangeStart, 
+                 this.rangeEnd, this.zone, this.isShowAll);
             return createShowPageResult(Const.ViewURIs.ADMIN_SESSIONS, data);
             
         }
@@ -163,8 +170,11 @@ public class AdminSessionsPageAction extends Action {
 
             this.map = new HashMap<String, List<FeedbackSessionAttributes>>();;
             this.totalOngoingSessions = 0;
+            this.totalOpenStatusSessions = 0;
+            this.totalInstitutes = 0;
             data.init(this.map, this.sessionToInstructorIdMap, this.totalOngoingSessions,  
-                      this.totalOpenStatusSessions, this.rangeStart, this.rangeEnd, this.zone, this.isShowAll);
+                      this.totalOpenStatusSessions, this.totalInstitutes, this.rangeStart, 
+                      this.rangeEnd, this.zone, this.isShowAll);
             return createShowPageResult(Const.ViewURIs.ADMIN_SESSIONS, data);
         }
         
@@ -203,6 +213,7 @@ public class AdminSessionsPageAction extends Action {
             }
         }
         this.map = map;
+        this.totalInstitutes = getTotalInstitutes(map);
         statusToAdmin = "Admin Sessions Page Load<br>" +
                         "<span class=\"bold\">Total Ongoing Sessions:</span> " +
                         this.totalOngoingSessions +
@@ -211,7 +222,8 @@ public class AdminSessionsPageAction extends Action {
         
         constructSessionToInstructorIdMap();
         data.init(this.map, this.sessionToInstructorIdMap, this.totalOngoingSessions, 
-                  this.totalOpenStatusSessions, this.rangeStart, this.rangeEnd, this.zone, this.isShowAll);
+                  this.totalOpenStatusSessions, this.totalInstitutes, this.rangeStart, 
+                  this.rangeEnd, this.zone, this.isShowAll);
         return createShowPageResult(Const.ViewURIs.ADMIN_SESSIONS, data);
     }
     
@@ -272,6 +284,18 @@ public class AdminSessionsPageAction extends Action {
             }
         }
         
+        return numOfTotal;
+    }
+    
+    
+    private int getTotalInstitutes(HashMap<String, List<FeedbackSessionAttributes>> map) {
+        
+        int numOfTotal = 0;
+        for (String key : map.keySet()) {
+            if (!key.equals(UNKNOWN_INSTITUTION)) {
+                numOfTotal += 1;
+            }
+        }
         return numOfTotal;
     }
     

--- a/src/main/java/teammates/ui/controller/AdminSessionsPageAction.java
+++ b/src/main/java/teammates/ui/controller/AdminSessionsPageAction.java
@@ -29,6 +29,8 @@ public class AdminSessionsPageAction extends Action {
     private Map<String, String> sessionToInstructorIdMap = new HashMap<String, String>();
     private int totalOngoingSessions;
     private int totalOpenStatusSessions;
+    private int totalClosedStatusSessions;
+    private int totalWaitToOpenStatusSessions;
     private int totalInstitutes;
     private Date rangeStart;
     private Date rangeEnd;
@@ -81,6 +83,8 @@ public class AdminSessionsPageAction extends Action {
         this.map = new HashMap<String, List<FeedbackSessionAttributes>>();
         this.totalOngoingSessions = 0;
         this.totalOpenStatusSessions = 0;
+        this.totalClosedStatusSessions = 0;
+        this.totalOpenStatusSessions = 0;
         this.totalInstitutes = 0;
         this.rangeStart = calStart.getTime();
         this.rangeEnd = calEnd.getTime();
@@ -132,8 +136,9 @@ public class AdminSessionsPageAction extends Action {
     
                 prepareDefaultPageData(calStart, calEnd);
                 data.init(this.map, this.sessionToInstructorIdMap, this.totalOngoingSessions, 
-                     this.totalOpenStatusSessions, this.totalInstitutes, this.rangeStart, 
-                     this.rangeEnd, this.zone, this.isShowAll);
+                          this.totalOpenStatusSessions, this.totalClosedStatusSessions,
+                          this.totalWaitToOpenStatusSessions, this.totalInstitutes, this.rangeStart, 
+                          this.rangeEnd, this.zone, this.isShowAll);
                 return createShowPageResult(Const.ViewURIs.ADMIN_SESSIONS, data);
             }
           
@@ -145,9 +150,9 @@ public class AdminSessionsPageAction extends Action {
                             "<span class=\"bold\"> Error: Missing Parameters</span>";
 
             prepareDefaultPageData(calStart, calEnd);
-            data.init(this.map, this.sessionToInstructorIdMap, this.totalOngoingSessions,  
-                 this.totalOngoingSessions, this.totalInstitutes, this.rangeStart, 
-                 this.rangeEnd, this.zone, this.isShowAll);
+            data.init(this.map, this.sessionToInstructorIdMap, this.totalOngoingSessions,
+                      this.totalOpenStatusSessions, this.totalClosedStatusSessions, this.totalWaitToOpenStatusSessions, 
+                      this.totalInstitutes, this.rangeStart, this.rangeEnd, this.zone, this.isShowAll);
             return createShowPageResult(Const.ViewURIs.ADMIN_SESSIONS, data);
             
         }
@@ -171,10 +176,12 @@ public class AdminSessionsPageAction extends Action {
             this.map = new HashMap<String, List<FeedbackSessionAttributes>>();;
             this.totalOngoingSessions = 0;
             this.totalOpenStatusSessions = 0;
+            this.totalClosedStatusSessions = 0;
+            this.totalWaitToOpenStatusSessions = 0;
             this.totalInstitutes = 0;
             data.init(this.map, this.sessionToInstructorIdMap, this.totalOngoingSessions,  
-                      this.totalOpenStatusSessions, this.totalInstitutes, this.rangeStart, 
-                      this.rangeEnd, this.zone, this.isShowAll);
+                      this.totalOpenStatusSessions, this.totalClosedStatusSessions, this.totalWaitToOpenStatusSessions,
+                      this.totalInstitutes, this.rangeStart, this.rangeEnd, this.zone, this.isShowAll);
             return createShowPageResult(Const.ViewURIs.ADMIN_SESSIONS, data);
         }
         
@@ -186,6 +193,8 @@ public class AdminSessionsPageAction extends Action {
         HashMap<String, List<FeedbackSessionAttributes>> map = new HashMap<String, List<FeedbackSessionAttributes>>();
         this.totalOngoingSessions = allOpenFeedbackSessionsList.size();
         this.totalOpenStatusSessions = getTotalNumOfOpenStatusSession(allOpenFeedbackSessionsList);
+        this.totalClosedStatusSessions = getTotalNumOfCloseStatusSession(allOpenFeedbackSessionsList);
+        this.totalWaitToOpenStatusSessions = getTotalNumOfWaitToOpenStatusSession(allOpenFeedbackSessionsList);
 
         for (FeedbackSessionAttributes fs : allOpenFeedbackSessionsList) {
 
@@ -222,8 +231,8 @@ public class AdminSessionsPageAction extends Action {
         
         constructSessionToInstructorIdMap();
         data.init(this.map, this.sessionToInstructorIdMap, this.totalOngoingSessions, 
-                  this.totalOpenStatusSessions, this.totalInstitutes, this.rangeStart, 
-                  this.rangeEnd, this.zone, this.isShowAll);
+                  this.totalOpenStatusSessions, this.totalClosedStatusSessions, this.totalWaitToOpenStatusSessions,
+                  this.totalInstitutes, this.rangeStart, this.rangeEnd, this.zone, this.isShowAll);
         return createShowPageResult(Const.ViewURIs.ADMIN_SESSIONS, data);
     }
     
@@ -280,6 +289,32 @@ public class AdminSessionsPageAction extends Action {
         int numOfTotal = 0;
         for (FeedbackSessionAttributes sessionAttributes: allOpenFeedbackSessionsList) {
             if (sessionAttributes.isOpened()) {
+                numOfTotal += 1;
+            }
+        }
+        
+        return numOfTotal;
+    }
+    
+    
+    private int getTotalNumOfCloseStatusSession(List<FeedbackSessionAttributes> allOpenFeedbackSessionsList) {
+        
+        int numOfTotal = 0;
+        for (FeedbackSessionAttributes sessionAttributes: allOpenFeedbackSessionsList) {
+            if (sessionAttributes.isClosed()) {
+                numOfTotal += 1;
+            }
+        }
+        
+        return numOfTotal;
+    }
+    
+    
+    private int getTotalNumOfWaitToOpenStatusSession(List<FeedbackSessionAttributes> allOpenFeedbackSessionsList) {
+        
+        int numOfTotal = 0;
+        for (FeedbackSessionAttributes sessionAttributes: allOpenFeedbackSessionsList) {
+            if (sessionAttributes.isWaitingToOpen()) {
                 numOfTotal += 1;
             }
         }

--- a/src/main/java/teammates/ui/controller/AdminSessionsPageAction.java
+++ b/src/main/java/teammates/ui/controller/AdminSessionsPageAction.java
@@ -26,6 +26,7 @@ public class AdminSessionsPageAction extends Action {
     private Map<String, List<FeedbackSessionAttributes>> map;
     private Map<String, String> sessionToInstructorIdMap = new HashMap<String, String>();
     private int totalOngoingSessions;
+    private int totalOpenStatusSessions;
     private Date rangeStart;
     private Date rangeEnd;
     private double zone;
@@ -125,8 +126,8 @@ public class AdminSessionsPageAction extends Action {
                                 "<span class=\"bold\"> Error: invalid filter range</span>";
     
                 prepareDefaultPageData(calStart, calEnd);
-                data.init(this.map, this.sessionToInstructorIdMap, this.totalOngoingSessions,  
-                     this.rangeStart, this.rangeEnd, this.zone, this.isShowAll);
+                data.init(this.map, this.sessionToInstructorIdMap, this.totalOngoingSessions, 
+                     this.totalOpenStatusSessions, this.rangeStart, this.rangeEnd, this.zone, this.isShowAll);
                 return createShowPageResult(Const.ViewURIs.ADMIN_SESSIONS, data);
             }
           
@@ -139,7 +140,7 @@ public class AdminSessionsPageAction extends Action {
 
             prepareDefaultPageData(calStart, calEnd);
             data.init(this.map, this.sessionToInstructorIdMap, this.totalOngoingSessions,  
-                      this.rangeStart, this.rangeEnd, this.zone, this.isShowAll);
+                 this.totalOngoingSessions, this.rangeStart, this.rangeEnd, this.zone, this.isShowAll);
             return createShowPageResult(Const.ViewURIs.ADMIN_SESSIONS, data);
             
         }
@@ -163,7 +164,7 @@ public class AdminSessionsPageAction extends Action {
             this.map = new HashMap<String, List<FeedbackSessionAttributes>>();;
             this.totalOngoingSessions = 0;
             data.init(this.map, this.sessionToInstructorIdMap, this.totalOngoingSessions,  
-                      this.rangeStart, this.rangeEnd, this.zone, this.isShowAll);
+                      this.totalOpenStatusSessions, this.rangeStart, this.rangeEnd, this.zone, this.isShowAll);
             return createShowPageResult(Const.ViewURIs.ADMIN_SESSIONS, data);
         }
         
@@ -174,6 +175,7 @@ public class AdminSessionsPageAction extends Action {
     private ActionResult createAdminSessionPageResult(List<FeedbackSessionAttributes> allOpenFeedbackSessionsList) {
         HashMap<String, List<FeedbackSessionAttributes>> map = new HashMap<String, List<FeedbackSessionAttributes>>();
         this.totalOngoingSessions = allOpenFeedbackSessionsList.size();
+        this.totalOpenStatusSessions = getTotalNumOfOpenStatusSession(allOpenFeedbackSessionsList);
 
         for (FeedbackSessionAttributes fs : allOpenFeedbackSessionsList) {
 
@@ -203,11 +205,13 @@ public class AdminSessionsPageAction extends Action {
         this.map = map;
         statusToAdmin = "Admin Sessions Page Load<br>" +
                         "<span class=\"bold\">Total Ongoing Sessions:</span> " +
-                        this.totalOngoingSessions;
+                        this.totalOngoingSessions +
+                        "<span class=\"bold\">Total Opened Sessions:</span> " + 
+                        this.totalOpenStatusSessions;
         
         constructSessionToInstructorIdMap();
         data.init(this.map, this.sessionToInstructorIdMap, this.totalOngoingSessions, 
-                  this.rangeStart, this.rangeEnd, this.zone, this.isShowAll);
+                  this.totalOpenStatusSessions, this.rangeStart, this.rangeEnd, this.zone, this.isShowAll);
         return createShowPageResult(Const.ViewURIs.ADMIN_SESSIONS, data);
     }
     
@@ -256,6 +260,19 @@ public class AdminSessionsPageAction extends Action {
         }
         
         return null;
+    }
+    
+    
+    private int getTotalNumOfOpenStatusSession(List<FeedbackSessionAttributes> allOpenFeedbackSessionsList) {
+        
+        int numOfTotal = 0;
+        for (FeedbackSessionAttributes sessionAttributes: allOpenFeedbackSessionsList) {
+            if (sessionAttributes.isOpened()) {
+                numOfTotal += 1;
+            }
+        }
+        
+        return numOfTotal;
     }
     
     

--- a/src/main/java/teammates/ui/controller/AdminSessionsPageData.java
+++ b/src/main/java/teammates/ui/controller/AdminSessionsPageData.java
@@ -21,6 +21,8 @@ public class AdminSessionsPageData extends PageData {
     private static final String UNKNOWN_INSTITUTION = "Unknown";
     private int totalOngoingSessions;
     private int totalOpenStatusSessions;
+    private int totalClosedStatusSessions;
+    private int totalWaitToOpenStatusSessions;
     private int totalInstitutes;
     private Date rangeStart;
     private Date rangeEnd;
@@ -36,10 +38,13 @@ public class AdminSessionsPageData extends PageData {
     
     public void init(
             Map<String, List<FeedbackSessionAttributes>> map, Map<String, String> sessionToInstructorIdMap, 
-            int totalOngoingSessions, int totalOpenStatusSessions, int totalInstitutes, Date rangeStart, Date rangeEnd, double zone, boolean isShowAll) {
+            int totalOngoingSessions, int totalOpenStatusSessions, int totalClosedStatusSessions,
+            int totalWaitToOpenStatusSessions, int totalInstitutes, Date rangeStart, Date rangeEnd, double zone, boolean isShowAll) {
 
         this.totalOngoingSessions = totalOngoingSessions;
         this.totalOpenStatusSessions = totalOpenStatusSessions;
+        this.totalClosedStatusSessions = totalClosedStatusSessions;
+        this.totalWaitToOpenStatusSessions = totalWaitToOpenStatusSessions;
         this.totalInstitutes = totalInstitutes;
         this.rangeStart = rangeStart;
         this.rangeEnd = rangeEnd;
@@ -55,6 +60,14 @@ public class AdminSessionsPageData extends PageData {
     
     public int getTotalOpenStatusSessions() {
         return totalOpenStatusSessions;
+    }
+    
+    public int getTotalClosedStatusSessions() {
+        return totalClosedStatusSessions;
+    }
+    
+    public int getTotalWaitToOpenStatusSessions() {
+        return totalWaitToOpenStatusSessions;
     }
     
     public int gettotalInstitutes() {

--- a/src/main/java/teammates/ui/controller/AdminSessionsPageData.java
+++ b/src/main/java/teammates/ui/controller/AdminSessionsPageData.java
@@ -20,6 +20,7 @@ import teammates.ui.template.InstitutionPanel;
 public class AdminSessionsPageData extends PageData {
     private static final String UNKNOWN_INSTITUTION = "Unknown";
     private int totalOngoingSessions;
+    private int totalOpenStatusSessions;
     private Date rangeStart;
     private Date rangeEnd;
     private double zone;
@@ -34,9 +35,10 @@ public class AdminSessionsPageData extends PageData {
     
     public void init(
             Map<String, List<FeedbackSessionAttributes>> map, Map<String, String> sessionToInstructorIdMap, 
-            int totalOngoingSessions, Date rangeStart, Date rangeEnd, double zone, boolean isShowAll) {
+            int totalOngoingSessions, int totalOpenStatusSessions, Date rangeStart, Date rangeEnd, double zone, boolean isShowAll) {
 
         this.totalOngoingSessions = totalOngoingSessions;
+        this.totalOpenStatusSessions = totalOpenStatusSessions;
         this.rangeStart = rangeStart;
         this.rangeEnd = rangeEnd;
         this.zone = zone;
@@ -47,6 +49,10 @@ public class AdminSessionsPageData extends PageData {
 
     public int getTotalOngoingSessions() {
         return totalOngoingSessions;
+    }
+    
+    public int getTotalOpenStatusSessions() {
+        return totalOpenStatusSessions;
     }
 
     public int getTableCount() {

--- a/src/main/java/teammates/ui/controller/AdminSessionsPageData.java
+++ b/src/main/java/teammates/ui/controller/AdminSessionsPageData.java
@@ -21,6 +21,7 @@ public class AdminSessionsPageData extends PageData {
     private static final String UNKNOWN_INSTITUTION = "Unknown";
     private int totalOngoingSessions;
     private int totalOpenStatusSessions;
+    private int totalInstitutes;
     private Date rangeStart;
     private Date rangeEnd;
     private double zone;
@@ -35,10 +36,11 @@ public class AdminSessionsPageData extends PageData {
     
     public void init(
             Map<String, List<FeedbackSessionAttributes>> map, Map<String, String> sessionToInstructorIdMap, 
-            int totalOngoingSessions, int totalOpenStatusSessions, Date rangeStart, Date rangeEnd, double zone, boolean isShowAll) {
+            int totalOngoingSessions, int totalOpenStatusSessions, int totalInstitutes, Date rangeStart, Date rangeEnd, double zone, boolean isShowAll) {
 
         this.totalOngoingSessions = totalOngoingSessions;
         this.totalOpenStatusSessions = totalOpenStatusSessions;
+        this.totalInstitutes = totalInstitutes;
         this.rangeStart = rangeStart;
         this.rangeEnd = rangeEnd;
         this.zone = zone;
@@ -53,6 +55,10 @@ public class AdminSessionsPageData extends PageData {
     
     public int getTotalOpenStatusSessions() {
         return totalOpenStatusSessions;
+    }
+    
+    public int gettotalInstitutes() {
+        return totalInstitutes;
     }
 
     public int getTableCount() {

--- a/src/main/webapp/jsp/adminSessions.jsp
+++ b/src/main/webapp/jsp/adminSessions.jsp
@@ -16,7 +16,10 @@
         <small> 
             Total: ${data.totalOngoingSessions} &nbsp; &nbsp;
             Opened: ${data.totalOpenStatusSessions} &nbsp; &nbsp;
-            Institutions: ${data.totalInstitutes} 
+            Closed: ${data.totalClosedStatusSessions} &nbsp; &nbsp;
+            Waiting To Open: ${data.totalWaitToOpenStatusSessions} 
+            <br> 
+            Institutions: ${data.totalInstitutes} &nbsp; &nbsp;
             <br>
             ${data.rangeStartString}&nbsp;&nbsp;
             <span class="glyphicon glyphicon-resize-horizontal"></span>&nbsp;&nbsp;${data.rangeEndString}

--- a/src/main/webapp/jsp/adminSessions.jsp
+++ b/src/main/webapp/jsp/adminSessions.jsp
@@ -18,6 +18,8 @@
             <br>
             Opened: ${data.totalOpenStatusSessions}
             <br>
+            Institutions: ${data.totalInstitutes}
+            <br>
             ${data.rangeStartString}&nbsp;&nbsp;
             <span class="glyphicon glyphicon-resize-horizontal"></span>&nbsp;&nbsp;${data.rangeEndString}
             &nbsp;${data.timeZoneAsString}

--- a/src/main/webapp/jsp/adminSessions.jsp
+++ b/src/main/webapp/jsp/adminSessions.jsp
@@ -14,11 +14,9 @@
 <ta:adminPage bodyTitle="Ongoing Sessions" pageTitle="TEAMMATES - Administrator Sessions" jsIncludes="${jsIncludes}">
     <h1>
         <small> 
-            Ongoing: ${data.totalOngoingSessions}
-            <br>
-            Opened: ${data.totalOpenStatusSessions}
-            <br>
-            Institutions: ${data.totalInstitutes}
+            Total: ${data.totalOngoingSessions} &nbsp; &nbsp;
+            Opened: ${data.totalOpenStatusSessions} &nbsp; &nbsp;
+            Institutions: ${data.totalInstitutes} 
             <br>
             ${data.rangeStartString}&nbsp;&nbsp;
             <span class="glyphicon glyphicon-resize-horizontal"></span>&nbsp;&nbsp;${data.rangeEndString}

--- a/src/main/webapp/jsp/adminSessions.jsp
+++ b/src/main/webapp/jsp/adminSessions.jsp
@@ -14,8 +14,10 @@
 <ta:adminPage bodyTitle="Ongoing Sessions" pageTitle="TEAMMATES - Administrator Sessions" jsIncludes="${jsIncludes}">
     <h1>
         <small> 
-            Total: ${data.totalOngoingSessions}
-            <br> 
+            Ongoing: ${data.totalOngoingSessions}
+            <br>
+            Opened: ${data.totalOpenStatusSessions}
+            <br>
             ${data.rangeStartString}&nbsp;&nbsp;
             <span class="glyphicon glyphicon-resize-horizontal"></span>&nbsp;&nbsp;${data.rangeEndString}
             &nbsp;${data.timeZoneAsString}

--- a/src/main/webapp/jsp/adminSessions.jsp
+++ b/src/main/webapp/jsp/adminSessions.jsp
@@ -17,8 +17,7 @@
             Total: ${data.totalOngoingSessions} &nbsp; &nbsp;
             Opened: ${data.totalOpenStatusSessions} &nbsp; &nbsp;
             Closed: ${data.totalClosedStatusSessions} &nbsp; &nbsp;
-            Waiting To Open: ${data.totalWaitToOpenStatusSessions} 
-            <br> 
+            Waiting To Open: ${data.totalWaitToOpenStatusSessions} &nbsp; &nbsp;
             Institutions: ${data.totalInstitutes} &nbsp; &nbsp;
             <br>
             ${data.rangeStartString}&nbsp;&nbsp;


### PR DESCRIPTION
Fix #4598 
Change "Total" in admin status to "Ongoing"
Add "Opened" field which shows total number of sessions that are under "Opened" status.
Add "Institutions" field which shows total number of institutions (exclude "unknown"). 
<img width="1155" alt="screen shot 2015-12-27 at 11 16 41 pm" src="https://cloud.githubusercontent.com/assets/7552874/12010796/ef767974-acef-11e5-9f69-1ed1e4d9d715.png">
