### PR TITLE
Update and improve GodModeTest #4679

### DIFF
--- a/src/test/java/teammates/test/cases/ui/browsertests/AdminAccountDetailsPageUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/AdminAccountDetailsPageUiTest.java
@@ -34,13 +34,13 @@ public class AdminAccountDetailsPageUiTest extends BaseUiTestCase{
     }
     
     @Test
-    public void testAll(){
+    public void testAll() throws Exception {
         testContent();
         //no links or input validation to check
         testRemoveFromCourseAction();
     }
     
-    public void testContent() {
+    public void testContent() throws Exception {
         
         ______TS("content: typical page");
         
@@ -53,7 +53,7 @@ public class AdminAccountDetailsPageUiTest extends BaseUiTestCase{
 
 
 
-    public void testRemoveFromCourseAction(){
+    public void testRemoveFromCourseAction() throws Exception {
         
         ______TS("action: remove instructor from course");
         

--- a/src/test/java/teammates/test/cases/ui/browsertests/AdminHomePageUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/AdminHomePageUiTest.java
@@ -72,7 +72,7 @@ public class AdminHomePageUiTest extends BaseUiTestCase{
         testCreateInstructorAction();
     }
 
-    private void testContent() {
+    private void testContent() throws Exception {
         
         ______TS("content: typical page");
         

--- a/src/test/java/teammates/test/cases/ui/browsertests/AllAccessControlUiTests.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/AllAccessControlUiTests.java
@@ -149,7 +149,7 @@ public class AllAccessControlUiTests extends BaseUiTestCase {
     }
     
     @Test
-    public void testPubliclyAccessiblePages() {
+    public void testPubliclyAccessiblePages() throws Exception {
         
         ______TS("log out page");
         // has been covered in testUserNotLoggedIn method

--- a/src/test/java/teammates/test/cases/ui/browsertests/FeedbackConstSumOptionQuestionUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/FeedbackConstSumOptionQuestionUiTest.java
@@ -47,7 +47,7 @@ public class FeedbackConstSumOptionQuestionUiTest extends FeedbackQuestionUiTest
         //i.e. results page, submit page.
     }
     
-    private void testEditPage(){
+    private void testEditPage() throws Exception {
         testNewQuestionFrame();
         testInputValidation();
         testCustomizeOptions();
@@ -124,7 +124,7 @@ public class FeedbackConstSumOptionQuestionUiTest extends FeedbackQuestionUiTest
         assertEquals(true, feedbackEditPage.isElementPresent("constSumOptionRow-4--1"));
     }
 
-    public void testAddQuestionAction() {
+    public void testAddQuestionAction() throws Exception {
         ______TS("CONST SUM: add question action success");
         
         feedbackEditPage.fillQuestionBox("const sum qn");
@@ -136,7 +136,7 @@ public class FeedbackConstSumOptionQuestionUiTest extends FeedbackQuestionUiTest
         feedbackEditPage.verifyHtmlMainContent("/instructorFeedbackConstSumOptionQuestionAddSuccess.html");
     }
 
-    public void testEditQuestionAction() {
+    public void testEditQuestionAction() throws Exception {
         ______TS("CONST SUM: edit question success");
 
         assertEquals(true, feedbackEditPage.clickEditQuestionButton(1));

--- a/src/test/java/teammates/test/cases/ui/browsertests/FeedbackConstSumRecipientQuestionUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/FeedbackConstSumRecipientQuestionUiTest.java
@@ -47,7 +47,7 @@ public class FeedbackConstSumRecipientQuestionUiTest extends FeedbackQuestionUiT
         //i.e. results page, submit page.
     }
     
-    private void testEditPage(){
+    private void testEditPage() throws Exception {
         testNewQuestionFrame();
         testInputValidation();
         testCustomizeOptions();
@@ -91,7 +91,7 @@ public class FeedbackConstSumRecipientQuestionUiTest extends FeedbackQuestionUiT
         
     }
 
-    public void testAddQuestionAction() {
+    public void testAddQuestionAction() throws Exception {
         ______TS("CONST SUM: add question action success");
         
         feedbackEditPage.fillQuestionBox("const sum qn");
@@ -103,7 +103,7 @@ public class FeedbackConstSumRecipientQuestionUiTest extends FeedbackQuestionUiT
         feedbackEditPage.verifyHtmlMainContent("/instructorFeedbackConstSumRecipientQuestionAddSuccess.html");
     }
 
-    public void testEditQuestionAction() {
+    public void testEditQuestionAction() throws Exception {
         ______TS("CONST SUM: edit question success");
 
         assertEquals(true, feedbackEditPage.clickEditQuestionButton(1));

--- a/src/test/java/teammates/test/cases/ui/browsertests/FeedbackContributionQuestionUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/FeedbackContributionQuestionUiTest.java
@@ -48,7 +48,7 @@ public class FeedbackContributionQuestionUiTest extends FeedbackQuestionUiTest {
         //i.e. results page, submit page.
     }
     
-    private void testEditPage(){
+    private void testEditPage() throws Exception {
         testNewQuestionFrame();
         testInputValidation();
         testCustomizeOptions();
@@ -91,7 +91,7 @@ public class FeedbackContributionQuestionUiTest extends FeedbackQuestionUiTest {
         
     }
 
-    public void testAddQuestionAction() {
+    public void testAddQuestionAction() throws Exception {
         ______TS("CONTRIB: add question action success");
         
         feedbackEditPage.fillQuestionBox("contrib qn");
@@ -102,7 +102,7 @@ public class FeedbackContributionQuestionUiTest extends FeedbackQuestionUiTest {
         feedbackEditPage.verifyHtmlMainContent("/instructorFeedbackContribQuestionAddSuccess.html");
     }
 
-    public void testEditQuestionAction() {
+    public void testEditQuestionAction() throws Exception {
         ______TS("CONTRIB: edit question success");
 
         assertEquals(true, feedbackEditPage.clickEditQuestionButton(1));

--- a/src/test/java/teammates/test/cases/ui/browsertests/FeedbackMcqQuestionUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/FeedbackMcqQuestionUiTest.java
@@ -48,7 +48,7 @@ public class FeedbackMcqQuestionUiTest extends FeedbackQuestionUiTest {
         //i.e. results page, submit page.
     }
     
-    private void testEditPage(){
+    private void testEditPage() throws Exception {
         testNewQuestionFrame();
         testInputValidation();
         testCustomizeOptions();
@@ -142,7 +142,7 @@ public class FeedbackMcqQuestionUiTest extends FeedbackQuestionUiTest {
         assertEquals(true, feedbackEditPage.isElementPresent("mcqOptionRow-4--1"));
     }
 
-    public void testAddQuestionAction() {
+    public void testAddQuestionAction() throws Exception {
 
         ______TS("MCQ: add question action success");
 
@@ -156,7 +156,7 @@ public class FeedbackMcqQuestionUiTest extends FeedbackQuestionUiTest {
         feedbackEditPage.verifyHtmlMainContent("/instructorFeedbackMcqQuestionAddSuccess.html");
     }
 
-    public void testEditQuestionAction() {
+    public void testEditQuestionAction() throws Exception {
 
         ______TS("MCQ: edit question success");
 

--- a/src/test/java/teammates/test/cases/ui/browsertests/FeedbackMsqQuestionUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/FeedbackMsqQuestionUiTest.java
@@ -48,7 +48,7 @@ public class FeedbackMsqQuestionUiTest extends FeedbackQuestionUiTest {
         //i.e. results page, submit page.
     }
     
-    private void testEditPage(){
+    private void testEditPage() throws Exception {
         testNewQuestionFrame();
         testInputValidation();
         testCustomizeOptions();
@@ -138,7 +138,7 @@ public class FeedbackMsqQuestionUiTest extends FeedbackQuestionUiTest {
         assertEquals(true, feedbackEditPage.isElementPresent("msqOptionRow-4--1"));
     }
 
-    public void testAddQuestionAction() {
+    public void testAddQuestionAction() throws Exception {
 
         ______TS("MSQ: add question action success");
 
@@ -151,7 +151,7 @@ public class FeedbackMsqQuestionUiTest extends FeedbackQuestionUiTest {
         feedbackEditPage.verifyHtmlMainContent("/instructorFeedbackMsqQuestionAddSuccess.html");
     }
 
-    public void testEditQuestionAction() {
+    public void testEditQuestionAction() throws Exception {
 
         ______TS("MSQ: edit question success");
 

--- a/src/test/java/teammates/test/cases/ui/browsertests/FeedbackNumScaleQuestionUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/FeedbackNumScaleQuestionUiTest.java
@@ -47,7 +47,7 @@ public class FeedbackNumScaleQuestionUiTest extends FeedbackQuestionUiTest {
         //i.e. results page, submit page.
     }
     
-    private void testEditPage(){
+    private void testEditPage() throws Exception {
         testNewQuestionFrame();
         testInputValidation();
         testCustomizeOptions();
@@ -148,7 +148,7 @@ public class FeedbackNumScaleQuestionUiTest extends FeedbackQuestionUiTest {
                 feedbackEditPage.getNumScalePossibleValuesString(-1));
     }
 
-    public void testAddQuestionAction() {
+    public void testAddQuestionAction() throws Exception {
         ______TS("NUMSCALE: add question action success");
 
         assertNull(BackDoor.getFeedbackQuestion(courseId, feedbackSessionName, 1));
@@ -159,7 +159,7 @@ public class FeedbackNumScaleQuestionUiTest extends FeedbackQuestionUiTest {
         feedbackEditPage.verifyHtmlMainContent("/instructorFeedbackNumScaleQuestionAddSuccess.html");
     }
 
-    public void testEditQuestionAction() {
+    public void testEditQuestionAction() throws Exception {
         ______TS("NUMSCALE: edit question success");
 
         assertEquals(true, feedbackEditPage.clickEditQuestionButton(1));

--- a/src/test/java/teammates/test/cases/ui/browsertests/FeedbackQuestionUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/FeedbackQuestionUiTest.java
@@ -13,9 +13,9 @@ public abstract class FeedbackQuestionUiTest extends BaseUiTestCase {
 
     public abstract void testCustomizeOptions();
 
-    public abstract void testAddQuestionAction();
+    public abstract void testAddQuestionAction() throws Exception;
 
-    public abstract void testEditQuestionAction();
+    public abstract void testEditQuestionAction() throws Exception;
 
     public abstract void testDeleteQuestionAction();
     

--- a/src/test/java/teammates/test/cases/ui/browsertests/FeedbackRankQuestionUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/FeedbackRankQuestionUiTest.java
@@ -54,7 +54,7 @@ public class FeedbackRankQuestionUiTest extends FeedbackQuestionUiTest {
     
     
     @Test
-    public void testStudentSubmitAndResultsPages() {
+    public void testStudentSubmitAndResultsPages() throws Exception {
         ______TS("Rank submission: input disabled for closed session");
         
         FeedbackSubmitPage submitPage = loginToStudentFeedbackSubmitPage("alice.tmms@FRankUiT.CS4221", "closed");
@@ -207,7 +207,7 @@ public class FeedbackRankQuestionUiTest extends FeedbackQuestionUiTest {
     
     
     @Test
-    public void testInstructorSubmitAndResultsPage() {
+    public void testInstructorSubmitAndResultsPage() throws Exception {
         
         ______TS("Rank submission: input disabled for closed session");
         
@@ -282,7 +282,7 @@ public class FeedbackRankQuestionUiTest extends FeedbackQuestionUiTest {
     
 
     @Test
-    public void testEditPage(){
+    public void testEditPage() throws Exception {
         feedbackEditPage = getFeedbackEditPage();
         testNewQuestionFrame();
         testInputValidation();
@@ -332,7 +332,7 @@ public class FeedbackRankQuestionUiTest extends FeedbackQuestionUiTest {
     }
     
 
-    public void testAddQuestionAction() {
+    public void testAddQuestionAction() throws Exception {
         ______TS("Rank edit: add rank option question action success");
         
         assertNull(BackDoor.getFeedbackQuestion(instructorCourseId, instructorEditFSName, 1));
@@ -386,7 +386,7 @@ public class FeedbackRankQuestionUiTest extends FeedbackQuestionUiTest {
     }
     
 
-    public void testEditQuestionAction() {
+    public void testEditQuestionAction() throws Exception {
         ______TS("rank edit: edit rank options question success");
         assertTrue(feedbackEditPage.clickEditQuestionButton(1));
         

--- a/src/test/java/teammates/test/cases/ui/browsertests/FeedbackRubricQuestionUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/FeedbackRubricQuestionUiTest.java
@@ -61,14 +61,14 @@ public class FeedbackRubricQuestionUiTest extends FeedbackQuestionUiTest {
         testStudentQuestionSubmitPage();
     }
 
-    private void testStudentResultsPage() {
+    private void testStudentResultsPage() throws Exception {
         ______TS("test rubric question student results page");
 
         studentResultsPage = loginToStudentFeedbackResultsPage("alice.tmms@FRubricQnUiT.CS2104", "openSession2");
         studentResultsPage.verifyHtmlMainContent("/studentFeedbackResultsPageRubric.html");
     }
     
-    private void testInstructorResultsPage() {
+    private void testInstructorResultsPage() throws Exception {
         ______TS("test rubric question instructor results page");
 
         // Question view
@@ -116,7 +116,7 @@ public class FeedbackRubricQuestionUiTest extends FeedbackQuestionUiTest {
         
     }
 
-    private void testStudentSubmitPage() {
+    private void testStudentSubmitPage() throws Exception {
         
         ______TS("test rubric question input disabled for closed session");
         
@@ -174,7 +174,7 @@ public class FeedbackRubricQuestionUiTest extends FeedbackQuestionUiTest {
         
     }
 
-    private void testEditPage(){
+    private void testEditPage() throws Exception {
         testNewQuestionFrame();
         testInputValidation();
         testCustomizeOptions();
@@ -208,7 +208,7 @@ public class FeedbackRubricQuestionUiTest extends FeedbackQuestionUiTest {
         
     }
 
-    public void testAddQuestionAction() {
+    public void testAddQuestionAction() throws Exception {
         ______TS("RUBRIC: add question action success");
         
         feedbackEditPage.fillQuestionBox("RUBRIC qn");
@@ -219,7 +219,7 @@ public class FeedbackRubricQuestionUiTest extends FeedbackQuestionUiTest {
         feedbackEditPage.verifyHtmlMainContent("/instructorFeedbackRubricQuestionAddSuccess.html");
     }
 
-    public void testEditQuestionAction() {
+    public void testEditQuestionAction() throws Exception {
         ______TS("RUBRIC: edit question success");
         
         // Click edit button

--- a/src/test/java/teammates/test/cases/ui/browsertests/GodModeTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/GodModeTest.java
@@ -1,6 +1,6 @@
 package teammates.test.cases.ui.browsertests;
 
-import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertNull;
 
 import java.io.File;
 import java.io.FileWriter;
@@ -9,7 +9,6 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import teammates.common.util.Assumption;
 import teammates.common.util.FileHelper;
 import teammates.test.driver.HtmlHelper;
 import teammates.test.driver.TestProperties;
@@ -18,132 +17,127 @@ import teammates.test.pageobjects.Browser;
 import teammates.test.pageobjects.BrowserPool;
 
 public class GodModeTest extends BaseUiTestCase {
+    
+    private static final String PLACEHOLDER_CONTENT = "<div id=\"mainContent\">test</div>";
+    private static final String OUTPUT_FILENAME = "/godmodeOutput.html";
+    private static final String OUTPUT_FILEPATH = TestProperties.TEST_PAGES_FOLDER + OUTPUT_FILENAME;
+    private static final String ACTUAL_FILENAME = "/godmode.html";
+    private static final String ACTUAL_FILEPATH = TestProperties.TEST_PAGES_FOLDER + ACTUAL_FILENAME;
+    private static final String EXPECTED_FILEPATH = TestProperties.TEST_PAGES_FOLDER + "/godmodeExpectedOutput.html";
+    private static final String EXPECTED_PART_FILEPATH = TestProperties.TEST_PAGES_FOLDER + "/godmodeExpectedPartOutput.html";
+    
     private static Browser browser;
     private static AppPage page;
-    private static String initialContent; 
+    private static String initialContent;
 
     @BeforeClass
     public static void classSetUp() throws Exception {
         printTestClassHeader();
-        if (TestProperties.inst().isDevServer()) {
-            injectRealAccountsIntoFile();
-            writeToFile(getOutputFilePath(), 
-                    "<div id='mainContent'>test</div>");
-            browser = BrowserPool.getBrowser();
-            page = AppPage.getNewPageInstance(browser).navigateTo(createLocalUrl("/godmode.html"));
-        }
+        TestProperties.inst().verifyReadyForGodMode();
+        injectContextDependentValuesIntoActualFile();
+        browser = BrowserPool.getBrowser();
+        page = AppPage.getNewPageInstance(browser).navigateTo(createLocalUrl(ACTUAL_FILENAME));
     }
     
-    private static void injectRealAccountsIntoFile() throws Exception {
-        initialContent = FileHelper.readFile(TestProperties.TEST_PAGES_FOLDER + "/godmode.html");
+    private static void injectContextDependentValuesIntoActualFile() throws Exception {
+        initialContent = FileHelper.readFile(ACTUAL_FILEPATH);
         String changedContent = HtmlHelper.injectContextDependentValuesForTest(initialContent);
-        writeToFile(TestProperties.TEST_PAGES_FOLDER + "/godmode.html", changedContent);
+        writeToFile(ACTUAL_FILEPATH, changedContent);
     }
 
     private static void writeToFile(String filePath, String content) throws Exception {
-        try {
-            FileWriter output = new FileWriter(new File(filePath));
-            output.write(content);
-            output.close();
-        } catch (Exception e) {
-            throw e;
-        }
+        FileWriter output = new FileWriter(new File(filePath));
+        output.write(content);
+        output.close();
     }
 
     @Test
     public void testGodMode() throws Exception {
-        if (!TestProperties.inst().isDevServer()) return;
+        
+        System.clearProperty("godmode");
+        assertNull(System.getProperty("godmode"));
         
         ______TS("test verifyHtml");
         
-        System.clearProperty("godmode");
-        Assumption.assertNull(System.getProperty("godmode"));
-        
-        try {
-            // should fail as the expected file "godmodeOutpout
-            page.verifyHtml("/godmodeOutput.html");
-            signalFailureToDetectException(" - Assertion Error");
-        } catch (AssertionError ae) {
-            // expected
-        }
-        
-        System.setProperty("godmode", "true");
-        // automatically generates the file and hence passes
-        page.verifyHtml("/godmodeOutput.html");
-        
-        System.clearProperty("godmode");
-        Assumption.assertNull(System.getProperty("godmode"));
-        
-        // should pass without need for godmode
-        // as the file has already been generated
-        page.verifyHtml("/godmodeOutput.html");
-        
-        String expectedOutputPage = FileHelper.readFile(getExpectedOutputFilePath());
-        String actualOutputPage = FileHelper.readFile(getOutputFilePath());
-        
-        // ensure that the generated file is as expected
-        verifyOutput(expectedOutputPage, actualOutputPage);
+        testGodMode(false);
         
         ______TS("test verifyHtmlMainContent");
-        // repeat the same procedure as above for this
         
-        writeToFile(getOutputFilePath(), 
-                "<div id='mainContent'>test</div>");
+        testGodMode(true);
+        
+    }
+    
+    private void testGodMode(boolean isPart) throws Exception {
         
         try {
-            page.verifyHtml("/godmodeOutput.html");
-            signalFailureToDetectException(" - Assertion Error");
-        } catch (AssertionError ae) {
-            // expected
+            // should fail as the expected output file does not exist
+            verifyHtml(OUTPUT_FILENAME, isPart);
+            signalFailureToDetectException();
+        } catch (Exception e) {
+            ignoreExpectedException();
         }
         
-        System.setProperty("godmode", "true");
-        page.verifyHtmlMainContent("/godmodeOutput.html");
+        // run the God mode with non-existent expected file
+        runGodModeRoutine(isPart);
         
-        System.clearProperty("godmode");
-        Assumption.assertNull(System.getProperty("godmode"));
+        writeToFile(OUTPUT_FILEPATH, PLACEHOLDER_CONTENT);
         
-        page.verifyHtmlMainContent("/godmodeOutput.html");
+        try {
+            // should fail as the expected output file has the wrong content
+            verifyHtml(OUTPUT_FILENAME, isPart);
+            signalFailureToDetectException();
+        } catch (AssertionError ae) {
+            ignoreExpectedException();
+        }
         
-        expectedOutputPage = FileHelper.readFile(getExpectedOutputPartFilePath());
-        actualOutputPage = FileHelper.readFile(getOutputFilePath());
+        // run the God mode with wrong content in expected file
+        runGodModeRoutine(isPart);
         
-        verifyOutput(expectedOutputPage, actualOutputPage);
-        
-        
-    }
-
-    private void verifyOutput(String expected, String actual) {
-        String processedExpectedHtml = HtmlHelper.convertToStandardHtml(expected, true);
-        String processedActualHtml = HtmlHelper.convertToStandardHtml(actual, true);
-        
-        assertEquals(processedExpectedHtml, processedActualHtml);
-    }
-
-    @AfterClass
-    public static void closeClass() throws Exception {
-        BrowserPool.release(browser);
-        System.clearProperty("godmode");
-        writeToFile(TestProperties.TEST_PAGES_FOLDER + "/godmode.html", initialContent);
-        
-        File file = new File(getOutputFilePath());
         // delete the output file generated
-        if(!file.delete()){
-            System.out.println("Delete failed. " + file.getAbsolutePath());
+        deleteFile(OUTPUT_FILEPATH);
+    }
+    
+    private static void deleteFile(String filePath) {
+        File file = new File(filePath);
+        if (!file.delete()) {
+            print("Delete failed: " + file.getAbsolutePath());
             file.deleteOnExit();
         }
     }
+    
+    private void runGodModeRoutine(boolean isPart) throws Exception {
+        
+        System.setProperty("godmode", "true");
+        // automatically generates the file and hence passes
+        verifyHtml(OUTPUT_FILENAME, isPart);
+        
+        System.clearProperty("godmode");
+        assertNull(System.getProperty("godmode"));
+        
+        // should pass without need for godmode as the file has already been generated
+        verifyHtml(OUTPUT_FILENAME, isPart);
+        
+        String expectedOutputPage = FileHelper.readFile(isPart ? EXPECTED_PART_FILEPATH : EXPECTED_FILEPATH);
+        String actualOutputPage = FileHelper.readFile(OUTPUT_FILEPATH);
+        
+        // ensure that the generated file is as expected
+        HtmlHelper.assertSameHtml(expectedOutputPage, actualOutputPage, isPart);
+        
+    }
 
-    private static String getOutputFilePath() throws Exception{
-        return TestProperties.TEST_PAGES_FOLDER + "/godmodeOutput.html";
+    private void verifyHtml(String filePath, boolean isPart) {
+        if (isPart) {
+            page.verifyHtmlMainContent(filePath);
+        } else {
+            page.verifyHtml(filePath);
+        }
     }
-    
-    private static String getExpectedOutputFilePath() {
-        return TestProperties.TEST_PAGES_FOLDER + "/godmodeExpectedOutput.html";
-    }
-    
-    private String getExpectedOutputPartFilePath() {
-        return TestProperties.TEST_PAGES_FOLDER + "/godmodeExpectedPartOutput.html";
+
+    @AfterClass
+    public static void classTearDown() throws Exception {
+        BrowserPool.release(browser);
+        System.clearProperty("godmode");
+        writeToFile(ACTUAL_FILEPATH, initialContent);
     }
 
 }

--- a/src/test/java/teammates/test/cases/ui/browsertests/GodModeTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/GodModeTest.java
@@ -4,6 +4,7 @@ import static org.testng.AssertJUnit.assertNull;
 
 import java.io.File;
 import java.io.FileWriter;
+import java.io.IOException;
 
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -73,7 +74,7 @@ public class GodModeTest extends BaseUiTestCase {
             // should fail as the expected output file does not exist
             verifyHtml(OUTPUT_FILENAME, isPart);
             signalFailureToDetectException();
-        } catch (Exception e) {
+        } catch (IOException e) {
             ignoreExpectedException();
         }
         
@@ -125,7 +126,7 @@ public class GodModeTest extends BaseUiTestCase {
         
     }
 
-    private void verifyHtml(String filePath, boolean isPart) {
+    private void verifyHtml(String filePath, boolean isPart) throws IOException {
         if (isPart) {
             page.verifyHtmlMainContent(filePath);
         } else {

--- a/src/test/java/teammates/test/cases/ui/browsertests/InstructorCourseEditPageUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/InstructorCourseEditPageUiTest.java
@@ -157,7 +157,7 @@ public class InstructorCourseEditPageUiTest extends BaseUiTestCase {
         courseEditPage.verifyStatus(Const.StatusMessages.COURSE_REMINDER_SENT_TO + "InsCrsEdit.newInstr@gmail.tmt");
     }
 
-    private void testAddInstructorAction() {
+    private void testAddInstructorAction() throws Exception {
 
         ______TS("success: add an instructor");
         
@@ -192,7 +192,7 @@ public class InstructorCourseEditPageUiTest extends BaseUiTestCase {
         courseEditPage.verifyStatus((new FieldValidator()).getInvalidityInfo(FieldType.PERSON_NAME, invalidName));
     }
 
-    private void testEditInstructorAction() {
+    private void testEditInstructorAction() throws Exception {
         
         ______TS("failure: ajax error on clicking edit button");
         

--- a/src/test/java/teammates/test/cases/ui/browsertests/InstructorCourseEnrollPageUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/InstructorCourseEnrollPageUiTest.java
@@ -48,7 +48,7 @@ public class InstructorCourseEnrollPageUiTest extends BaseUiTestCase {
         testEnrollAction();
     }
 
-    private void testContent() {
+    private void testContent() throws Exception {
         
         ______TS("typical enroll page");
         

--- a/src/test/java/teammates/test/cases/ui/browsertests/InstructorCourseStudentDetailsPageUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/InstructorCourseStudentDetailsPageUiTest.java
@@ -41,7 +41,7 @@ public class InstructorCourseStudentDetailsPageUiTest extends BaseUiTestCase {
         testContent();
     }
 
-    private void testContent() {
+    private void testContent() throws Exception {
         
         ______TS("content: registered student");
         

--- a/src/test/java/teammates/test/cases/ui/browsertests/InstructorEditStudentFeedbackPageUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/InstructorEditStudentFeedbackPageUiTest.java
@@ -43,7 +43,7 @@ public class InstructorEditStudentFeedbackPageUiTest extends BaseUiTestCase {
         testDeleteResponse();
     }
     
-    public void testEditResponse() {
+    public void testEditResponse() throws Exception {
         ______TS("edit responses");
         
         FeedbackQuestionAttributes fq = BackDoor.getFeedbackQuestion("IESFPTCourse", "First feedback session", 1);
@@ -71,7 +71,7 @@ public class InstructorEditStudentFeedbackPageUiTest extends BaseUiTestCase {
         assertEquals("Good design", fr.getResponseDetails().getAnswerString());
     }
     
-    private void testAddResponse() {
+    private void testAddResponse() throws Exception {
         ______TS("test new response");
         
         submitPage.fillResponseTextBox(2, 0, "4");

--- a/src/test/java/teammates/test/cases/ui/browsertests/InstructorFeedbackEditPageUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/InstructorFeedbackEditPageUiTest.java
@@ -87,7 +87,7 @@ public class InstructorFeedbackEditPageUiTest extends BaseUiTestCase {
         testDeleteSessionAction();
     }
     
-    private void testGeneralQuestionOperations() {
+    private void testGeneralQuestionOperations() throws Exception {
         testCancelNewOrEditQuestion();
         
         testNewQuestionLink();
@@ -110,7 +110,7 @@ public class InstructorFeedbackEditPageUiTest extends BaseUiTestCase {
         testDeleteQuestionAction(1);
     }
 
-    private void testContent() {
+    private void testContent() throws Exception {
 
         ______TS("fresh new page");
 
@@ -206,7 +206,7 @@ public class InstructorFeedbackEditPageUiTest extends BaseUiTestCase {
 
     }
 
-    private void testAddQuestionAction() {
+    private void testAddQuestionAction() throws Exception {
 
         ______TS("add question action success");
 
@@ -225,7 +225,7 @@ public class InstructorFeedbackEditPageUiTest extends BaseUiTestCase {
         assertEquals(true, feedbackEditPage.clickEditQuestionButton(1));
     }
 
-    private void testEditQuestionAction() {
+    private void testEditQuestionAction() throws Exception {
 
         ______TS("edit question 1 to Team-to-Team");
 
@@ -360,7 +360,7 @@ public class InstructorFeedbackEditPageUiTest extends BaseUiTestCase {
         assertEquals(Const.StatusMessages.FEEDBACK_QUESTION_EDITED, feedbackEditPage.getStatus());
     }
 
-    private void testCopyQuestion() {
+    private void testCopyQuestion() throws Exception {
         
         ______TS("Success case: copy questions successfully");
         
@@ -418,7 +418,7 @@ public class InstructorFeedbackEditPageUiTest extends BaseUiTestCase {
         
     }
     
-    private void testPreviewSessionAction() {
+    private void testPreviewSessionAction() throws Exception {
 
         // add questions for previewing
         feedbackEditPage.clickNewQuestionButton();

--- a/src/test/java/teammates/test/cases/ui/browsertests/InstructorFeedbackResultsPageUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/InstructorFeedbackResultsPageUiTest.java
@@ -74,7 +74,7 @@ public class InstructorFeedbackResultsPageUiTest extends BaseUiTestCase {
         testDownloadAction();
     }
 
-    public void testContent() {
+    public void testContent() throws Exception {
 
         ______TS("Typical case: standard session results");
 
@@ -102,7 +102,7 @@ public class InstructorFeedbackResultsPageUiTest extends BaseUiTestCase {
     }
     
     @Test
-    public void testExceptionalCases() {
+    public void testExceptionalCases() throws Exception {
         ______TS("Case where more than 1 question with same question number");
         // results page should be able to load incorrect data and still display it gracefully
         
@@ -162,7 +162,7 @@ public class InstructorFeedbackResultsPageUiTest extends BaseUiTestCase {
 
     }
 
-    public void testSortAction() {
+    public void testSortAction() throws Exception {
 
         ______TS("Typical case: test sort by giver > recipient > question");
         
@@ -274,7 +274,7 @@ public class InstructorFeedbackResultsPageUiTest extends BaseUiTestCase {
     }
     
     @Test
-    public void testVisibilityOptions() {
+    public void testVisibilityOptions() throws Exception {
         ______TS("test sort by giver > recipient > question for second session");
         
         resultsPage = loginToInstructorFeedbackResultsPage("CFResultsUiT.instr", "Unpublished Session");
@@ -448,7 +448,7 @@ public class InstructorFeedbackResultsPageUiTest extends BaseUiTestCase {
         resultsPage.hoverClickAndViewStudentPhotoOnHeading(6, "profile_picture_default.png");
     }
 
-    public void testFilterAction() {
+    public void testFilterAction() throws Exception {
 
         ______TS("Typical case: filter by section A");
 
@@ -529,7 +529,7 @@ public class InstructorFeedbackResultsPageUiTest extends BaseUiTestCase {
 
     }
 
-    public void testSearchScript() {
+    public void testSearchScript() throws Exception {
 
         ______TS("Typical case: test search/filter script");
 
@@ -540,7 +540,7 @@ public class InstructorFeedbackResultsPageUiTest extends BaseUiTestCase {
     }
 
     // TODO unnecessary coupling of FRComments test here. this should be tested separately.
-    public void testFeedbackResponseCommentActions() {
+    public void testFeedbackResponseCommentActions() throws Exception {
 
         resultsPage = loginToInstructorFeedbackResultsPage("CFResultsUiT.instr", "Open Session");
         resultsPage.displayByRecipientGiverQuestion();

--- a/src/test/java/teammates/test/cases/ui/browsertests/InstructorFeedbackSubmitPageUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/InstructorFeedbackSubmitPageUiTest.java
@@ -16,7 +16,6 @@ import teammates.common.datatransfer.FeedbackMsqResponseDetails;
 import teammates.common.datatransfer.FeedbackNumericalScaleResponseDetails;
 import teammates.common.datatransfer.FeedbackQuestionAttributes;
 import teammates.common.datatransfer.StudentAttributes;
-import teammates.common.exception.EnrollException;
 import teammates.common.util.AppUrl;
 import teammates.common.util.Const;
 import teammates.test.driver.BackDoor;
@@ -52,7 +51,7 @@ public class InstructorFeedbackSubmitPageUiTest extends BaseUiTestCase {
         testQuestionTypesSubmitAction();
     }
 
-    private void testContent() {
+    private void testContent() throws Exception {
         ______TS("Awaiting session");
 
         submitPage = loginToInstructorFeedbackSubmitPage("IFSubmitUiT.instr", "Awaiting Session");
@@ -99,7 +98,7 @@ public class InstructorFeedbackSubmitPageUiTest extends BaseUiTestCase {
         assertFalse(submitPage.isElementEnabled("response_submit_button"));
     }
 
-    private void testSubmitAction() {
+    private void testSubmitAction() throws Exception {
         ______TS("create new responses");
 
         submitPage = loginToInstructorFeedbackSubmitPage("IFSubmitUiT.instr", "Open Session");
@@ -572,7 +571,7 @@ public class InstructorFeedbackSubmitPageUiTest extends BaseUiTestCase {
                                                      + qnNumber + "-" + responseNumber));
     }
 
-    private void testModifyData() throws EnrollException {
+    private void testModifyData() throws Exception {
         ______TS("modify data");
 
         // Next, we edit some student data to cover editing of students after creating the responses.

--- a/src/test/java/teammates/test/cases/ui/browsertests/InstructorHomePageUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/InstructorHomePageUiTest.java
@@ -97,7 +97,7 @@ public class InstructorHomePageUiTest extends BaseUiTestCase {
         removeTestDataOnServer(unloadedCourseTestData);
     }
 
-    private void testPersistenceCheck() {
+    private void testPersistenceCheck() throws Exception {
         
         ______TS("persistence check");
         

--- a/src/test/java/teammates/test/cases/ui/browsertests/InstructorSearchPageUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/InstructorSearchPageUiTest.java
@@ -48,7 +48,7 @@ public class InstructorSearchPageUiTest extends BaseUiTestCase {
         
     }
     
-    private void testContent() {
+    private void testContent() throws Exception {
         
         ______TS("content: default search page");
         
@@ -60,7 +60,7 @@ public class InstructorSearchPageUiTest extends BaseUiTestCase {
         
     }
     
-    private void testSearch() {
+    private void testSearch() throws Exception {
         
         ______TS("search for nothing");
         

--- a/src/test/java/teammates/test/cases/ui/browsertests/InstructorStudentListPageUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/InstructorStudentListPageUiTest.java
@@ -68,7 +68,7 @@ public class InstructorStudentListPageUiTest extends BaseUiTestCase {
         testShowPhoto();
     }
 
-    private void testSearch() {
+    private void testSearch() throws Exception {
 
         InstructorAttributes instructorWith2Courses = testData.instructors.get("instructorOfCourse2");
         String instructorId = instructorWith2Courses.googleId;

--- a/src/test/java/teammates/test/cases/ui/browsertests/StudentCommentsPageUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/StudentCommentsPageUiTest.java
@@ -29,7 +29,7 @@ public class StudentCommentsPageUiTest extends BaseUiTestCase {
         testContent();
     }
 
-    private void testContent() {
+    private void testContent() throws Exception {
         
         ______TS("content: typical case");
         

--- a/src/test/java/teammates/test/cases/ui/browsertests/StudentCourseDetailsPageUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/StudentCourseDetailsPageUiTest.java
@@ -46,7 +46,7 @@ public class StudentCourseDetailsPageUiTest extends BaseUiTestCase {
     }
 
     private void verifyContent(String courseObjectId, String studentObjectId, String filePath,
-                               boolean isFullPageChecked) {
+                               boolean isFullPageChecked) throws Exception {
         AppUrl detailsPageUrl = createUrl(Const.ActionURIs.STUDENT_COURSE_DETAILS_PAGE)
                                 .withUserId(testData.students.get(studentObjectId).googleId)
                                 .withCourseId(testData.courses.get(courseObjectId).id);

--- a/src/test/java/teammates/test/cases/ui/browsertests/StudentCourseJoinConfirmationPageUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/StudentCourseJoinConfirmationPageUiTest.java
@@ -61,7 +61,7 @@ public class StudentCourseJoinConfirmationPageUiTest extends BaseUiTestCase {
     }
     
     
-    private void testJoinNewConfirmation() {
+    private void testJoinNewConfirmation() throws Exception {
         String expectedMsg;
         String homePageActionUrl = createUrl(Const.ActionURIs.STUDENT_HOME_PAGE).toAbsoluteString();
         String joinLink;

--- a/src/test/java/teammates/test/cases/ui/browsertests/StudentFeedbackQuestionSubmitPageUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/StudentFeedbackQuestionSubmitPageUiTest.java
@@ -104,7 +104,7 @@ public class StudentFeedbackQuestionSubmitPageUiTest extends BaseUiTestCase {
         submitPage.verifyHtmlMainContent("/studentFeedbackQuestionSubmitPageClosed.html");
     }
 
-    private void testSubmitAction() {
+    private void testSubmitAction() throws Exception {
         removeAndRestoreTestDataOnServer(testData);
         
         ______TS("create new responses");

--- a/src/test/java/teammates/test/cases/ui/browsertests/StudentFeedbackSubmitPageUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/StudentFeedbackSubmitPageUiTest.java
@@ -23,7 +23,6 @@ import teammates.common.datatransfer.FeedbackQuestionAttributes;
 import teammates.common.datatransfer.FeedbackResponseAttributes;
 import teammates.common.datatransfer.FeedbackSessionAttributes;
 import teammates.common.datatransfer.StudentAttributes;
-import teammates.common.exception.EnrollException;
 import teammates.common.util.AppUrl;
 import teammates.common.util.Const;
 import teammates.test.driver.BackDoor;
@@ -78,7 +77,7 @@ public class StudentFeedbackSubmitPageUiTest extends BaseUiTestCase {
         submitPage.clickAndCancel(browser.driver.findElement(By.id("studentCommentsNavLink")));
     }
 
-    private void testContent() {
+    private void testContent() throws Exception {
 
         ______TS("unreg student");
 
@@ -135,7 +134,7 @@ public class StudentFeedbackSubmitPageUiTest extends BaseUiTestCase {
         
     }
 
-    private void testSubmitAction() {
+    private void testSubmitAction() throws Exception {
 
         ______TS("create new responses");
 
@@ -553,7 +552,7 @@ public class StudentFeedbackSubmitPageUiTest extends BaseUiTestCase {
                                         "SFSubmitUiT.charlie.d@gmail.tmt").getResponseDetails().getAnswerString());
     }
 
-    private void testModifyData() throws EnrollException {
+    private void testModifyData() throws Exception {
         ______TS("modify data");
 
         // Next, we edit some student data to cover editing of students

--- a/src/test/java/teammates/test/cases/ui/browsertests/StudentHomePageUiTest.java
+++ b/src/test/java/teammates/test/cases/ui/browsertests/StudentHomePageUiTest.java
@@ -184,7 +184,7 @@ public class StudentHomePageUiTest extends BaseUiTestCase {
     }
     
     
-    private void testLinkAndContentAfterDelete(){
+    private void testLinkAndContentAfterDelete() throws Exception {
         
         AppUrl detailsPageUrl = createUrl(Const.ActionURIs.STUDENT_HOME_PAGE)
                              .withUserId(testData.students.get("SHomeUiT.charlie.d@SHomeUiT.CS2104").googleId);

--- a/src/test/java/teammates/test/driver/HtmlHelper.java
+++ b/src/test/java/teammates/test/driver/HtmlHelper.java
@@ -429,21 +429,24 @@ public class HtmlHelper {
      */
     public static String injectContextDependentValuesForTest(String content) {
         Date now = new Date();
-        String testAccounts = "<div>"
-                            + TP.TEST_ADMIN_ACCOUNT
-                            + StringHelper.truncateLongId(TP.TEST_ADMIN_ACCOUNT)
-                            + TP.TEST_INSTRUCTOR_ACCOUNT
-                            + StringHelper.truncateLongId(TP.TEST_INSTRUCTOR_ACCOUNT)
-                            + TP.TEST_STUDENT1_ACCOUNT
-                            + StringHelper.truncateLongId(TP.TEST_STUDENT1_ACCOUNT)
-                            + TP.TEST_STUDENT2_ACCOUNT
-                            + StringHelper.truncateLongId(TP.TEST_STUDENT2_ACCOUNT)
-                            + "</div>";
-        
-        return content.replace("<!-- TESTACCOUNTSPLACEHOLDER -->", testAccounts)
-                      .replace("<!-- VERSION -->", TP.TEAMMATES_VERSION)
-                      .replace("<!-- DATETODAY -->", TimeHelper.formatDate(now))
-                      .replace("<!-- DATETIMETODAY -->", TimeHelper.formatTime12H(now));
+        return content.replace("<!-- test.url -->", TP.TEAMMATES_URL)
+                      .replace("<!-- studentmotd.url -->", Config.STUDENT_MOTD_URL)
+                      .replace("<!-- version -->", TP.TEAMMATES_VERSION)
+                      .replace("<!-- test.student1 -->", TP.TEST_STUDENT1_ACCOUNT)
+                      .replace("<!-- test.student1.truncated -->",
+                               StringHelper.truncateLongId(TP.TEST_STUDENT1_ACCOUNT))
+                      .replace("<!-- test.student2 -->", TP.TEST_STUDENT2_ACCOUNT)
+                      .replace("<!-- test.student2.truncated -->",
+                               StringHelper.truncateLongId(TP.TEST_STUDENT2_ACCOUNT))
+                      .replace("<!-- test.instructor -->", TP.TEST_INSTRUCTOR_ACCOUNT)
+                      .replace("<!-- test.instructor.truncated -->",
+                               StringHelper.truncateLongId(TP.TEST_INSTRUCTOR_ACCOUNT))
+                      .replace("<!-- test.admin -->", TP.TEST_ADMIN_ACCOUNT)
+                      .replace("<!-- test.admin.truncated -->",
+                               StringHelper.truncateLongId(TP.TEST_ADMIN_ACCOUNT))
+                      .replace("<!-- now.date -->", TimeHelper.formatDate(now))
+                      .replace("<!-- now.datetime -->", TimeHelper.formatTime12H(now))
+                      .replace("<!-- now.datetime.comments -->", TimeHelper.formatDateTimeForComments(now));
     }
 
 }

--- a/src/test/java/teammates/test/driver/HtmlHelper.java
+++ b/src/test/java/teammates/test/driver/HtmlHelper.java
@@ -107,7 +107,7 @@ public class HtmlHelper {
      *               <code>&lt;head&gt;</code>, and <code>&lt;body&gt;</code>
      * @return converted HTML string
      */
-    public static String convertToStandardHtml(String rawHtml, boolean isPart) {
+    private static String convertToStandardHtml(String rawHtml, boolean isPart) {
         try {
             Node documentNode = getNodeFromString(rawHtml);
             String initialIndentation = INDENTATION_STEP; // TODO start from zero indentation

--- a/src/test/java/teammates/test/pageobjects/AppPage.java
+++ b/src/test/java/teammates/test/pageobjects/AppPage.java
@@ -5,6 +5,7 @@ import static org.testng.AssertJUnit.assertEquals;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileWriter;
+import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.net.URL;
 import java.util.List;
@@ -733,11 +734,11 @@ public abstract class AppPage {
      * folder is assumed to be {@link Const.TEST_PAGES_FOLDER}. 
      * @return The page (for chaining method calls).
      */
-    public AppPage verifyHtml(String filePath) {
+    public AppPage verifyHtml(String filePath) throws IOException {
         return verifyHtml(null, filePath, false);
     }
 
-    private AppPage verifyHtml(By by, String filePath, boolean isAfterAjaxLoad) {
+    private AppPage verifyHtml(By by, String filePath, boolean isAfterAjaxLoad) throws IOException {
         // TODO: improve this method by insert header and footer
         //       to the file specified by filePath
         if (filePath.startsWith("/")) {
@@ -761,13 +762,9 @@ public abstract class AppPage {
             }
             HtmlHelper.assertSameHtml(expected, actual, isPart);
             
-        } catch (Exception e) {
+        } catch (IOException|AssertionError e) {
             if (!testAndRunGodMode(filePath, actual, isPart)) {
-                throw new RuntimeException(e);
-            }
-        } catch (AssertionError ae) {
-            if (!testAndRunGodMode(filePath, actual, isPart)) {
-                throw ae;
+                throw e;
             }
         } 
         
@@ -811,7 +808,7 @@ public abstract class AppPage {
      * folder is assumed to be {@link Const.TEST_PAGES_FOLDER}. 
      * @return The page (for chaining method calls).
      */
-    public AppPage verifyHtmlPart(By by, String filePath) {
+    public AppPage verifyHtmlPart(By by, String filePath) throws IOException {
         return verifyHtml(by, filePath, false);
     }
     
@@ -824,7 +821,7 @@ public abstract class AppPage {
      * folder is assumed to be {@link Const.TEST_PAGES_FOLDER}. 
      * @return The page (for chaining method calls).
      */
-    public AppPage verifyHtmlMainContent(String filePath) {
+    public AppPage verifyHtmlMainContent(String filePath) throws IOException {
         return verifyHtmlPart(MAIN_CONTENT, filePath);
     }
     
@@ -839,7 +836,7 @@ public abstract class AppPage {
      * folder is assumed to be {@link Const.TEST_PAGES_FOLDER}. 
      * @return The page (for chaining method calls).
      */
-    public AppPage verifyHtmlAjaxMainContent(String filePath) throws Exception {
+    public AppPage verifyHtmlAjaxMainContent(String filePath) throws IOException {
         return verifyHtml(MAIN_CONTENT, filePath, true);
     }
 
@@ -853,7 +850,7 @@ public abstract class AppPage {
      * folder is assumed to be {@link Const.TEST_PAGES_FOLDER}. 
      * @return The page (for chaining method calls).
      */
-    public AppPage verifyHtmlAjax(String filePath) throws Exception {
+    public AppPage verifyHtmlAjax(String filePath) throws IOException {
         return verifyHtml(null, filePath, true);
     }
 

--- a/src/test/java/teammates/test/pageobjects/AppPage.java
+++ b/src/test/java/teammates/test/pageobjects/AppPage.java
@@ -782,9 +782,14 @@ public abstract class AppPage {
     }
 
     private boolean testAndRunGodMode(String filePath, String content, boolean isPart) {
-        if (content != null && !content.isEmpty() && 
-                System.getProperty("godmode") != null && 
-                System.getProperty("godmode").equals("true")) {
+        if (Boolean.parseBoolean(System.getProperty("godmode"))) {
+            return regenerateHtmlFile(filePath, content, isPart);
+        }
+        return false;
+    }
+    
+    private boolean regenerateHtmlFile(String filePath, String content, boolean isPart) {
+        if (content != null && !content.isEmpty()) {
             TestProperties.inst().verifyReadyForGodMode();
             try {
                 String processedPageSource = HtmlHelper.processPageSourceForExpectedHtmlRegeneration(content, isPart);

--- a/src/test/java/teammates/test/pageobjects/StudentProfilePicturePage.java
+++ b/src/test/java/teammates/test/pageobjects/StudentProfilePicturePage.java
@@ -32,7 +32,7 @@ public class StudentProfilePicturePage extends AppPage {
                      Sanitizer.sanitizeForHtml(browser.driver.getCurrentUrl()));
     }
 
-    public void verifyIsErrorPage(String expectedFilename) {
+    public void verifyIsErrorPage(String expectedFilename) throws Exception {
         if (TestProperties.inst().isDevServer()) {
             verifyHtmlPart(By.id("mainContent"), expectedFilename);
         } else {
@@ -40,11 +40,11 @@ public class StudentProfilePicturePage extends AppPage {
         }
     }
 
-    public void verifyIsUnauthorisedErrorPage(String expectedFilename) {
+    public void verifyIsUnauthorisedErrorPage(String expectedFilename) throws Exception {
         verifyHtmlPart(By.id("mainContent"), expectedFilename);
     }
 
-    public void verifyIsEntityNotFoundErrorPage(String expectedFilename) {
+    public void verifyIsEntityNotFoundErrorPage(String expectedFilename) throws Exception {
         verifyHtmlPart(By.id("mainContent"), expectedFilename);
     }
 

--- a/src/test/resources/pages/godmode.html
+++ b/src/test/resources/pages/godmode.html
@@ -1,46 +1,56 @@
-<html>
+<html xmlns="http://www.w3.org/1999/xhtml">
     <head>
-        <title>
-        </title>
+        <noscript>
+            This is going to be ignored.
+        </noscript>
     </head>
-    <div id="mainContent">
-        <input type="text" value="">
-        <a class="student-profile-pic-view-link btn-link" 
-           data-link="/page/studentProfilePic?studentemail=1CAAAF9A82CEF76B0BA249598DDF9CBC2031E84F1AF45D607A84A83D181C168E&amp;courseid=FA95864E467A11325349CB53B4C6D3C39398C035D135466658ABD102B08D4487">
-           View Photo</a>
-        <a class="navLinks" data-unreg="true" href="/page/studentCourseJoinAuthentication?key=055C66026349E1848C57998516281AE4CCA8E3AB27655ACCDCAB90685ACC8A7DE8FA8C1C628DD5B5EC0DE979BC7953807A7745670FE8176773D9A995F5CE17B0&">
-           Home
-        </a>
-        <input class="form-control"
-            type="text"
-            name="start"
-            id="start"
-            value="<!-- DATETODAY -->">
-        <p class="form-control-static"><!-- DATETIMETODAY --></p>
-        
-        <input type="hidden"
-            name=commentid
-            value="5685024871415808">
-        <input
-            type="hidden"
-            name="questionid"
-            value="ag10ZWFtbWF0ZXMtdGh5ch0LEhBGZWVkYmFja1F1ZXN0aW9uGICAgICA0NQLDA">
-        
-        <!-- these must not be changed: -->
-        <a class="btn btn-default btn-xs t_course_archive0"
-           href="/page/instructorCourseArchive?courseid=testuserm.gma-demo&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=testuser.instructor"
-           data-toggle="tooltip" data-placement="top" title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)">
-       </a>
-       <input name="end" 
-              value="21/05/2001">
-        
-        <!-- TESTACCOUNTSPLACEHOLDER -->
-        
-    </div>
-    <div class="footer">V<!-- VERSION --></div>
-    <div class="col-md-8" id="adminInstitute">
-    </div>
-    <div id="adminInstitute" class="col-md-8">
-        An Institute 123
-    </div>
+    <body>
+        <div id="mainContent">
+            <h2>Injected values</h2>
+            <ul>
+                <li>window.location.origin + '/<!-- studentmotd.url -->';</li>
+                <li>V<!-- version --></li>
+                <li><!-- test.student1 --></li>
+                <li><!-- test.student2 --></li>
+                <li><!-- test.instructor --></li>
+                <li><!-- test.admin --></li>
+            </ul>
+            <h2>Variations in injected values</h2>
+            <ul>
+                <li><!-- test.student1.truncated --></li>
+                <li><!-- test.student2.truncated --></li>
+                <li><!-- test.instructor.truncated --></li>
+                <li><!-- test.admin.truncated --></li>
+            </ul>
+            <h2>Unpredictable values</h2>
+            <ul>
+                <li>"<!-- test.url -->/_ah"</li>
+                <li>_ah/logout?continue=http://www.google.com"</li>
+                <li>/page/studentProfilePic?studentemail=1CAAAF9A82CEF76B0BA249598DDF9CBC2031E84F1AF45D607A84A83D181C168E&amp;courseid=FA95864E467A11325349CB53B4C6D3C39398C035D135466658ABD102B08D4487</li>
+                <li>/page/studentProfilePic?blob-key=ag_10ZWFtbWF0ZXMtdGh5ch0LEhBGZWVkYm-Fja1F1ZXN0aW9uGICAgICA0NQLDA</li>
+                <li><input type="hidden" value="encoded_gs_key:ag_10ZWFtbWF0ZXMtdGh5ch0LEhBGZWVkYm-Fja1F1ZXN0aW9uGICAgICA0NQLDA" name="blob-key" id="blobKey"></li>
+                <li>key=ag_10ZWFtbWF0ZXMtdGh5ch0LEhBGZWVkYm-Fja1F1ZXN0aW9uGICAgICA0NQLDA</li>
+                <li><input type="hidden" value="ag_10ZWFtbWF0ZXMtdGh5ch0LEhBGZWVkYm-Fja1F1ZXN0aW9uGICAgICA0NQLDA" name="key"></li>
+                <li>value="ag_10ZWFtbWF0ZXMtdGh5ch0LEhBGZWVkYm-Fja1F1ZXN0aW9uGICAgICA0NQLDA"</li>
+                <li>"ag_10ZWFtbWF0ZXMtdGh5ch0LEhBGZWVkYm-Fja1F1ZXN0aW9uGICAgICA0NQLDA%</li>
+                <li>"1234567812345678"</li>
+                <li>#1234567812345678</li>
+                <li>responseCommentRow-1234567812345678</li>
+                <li>commentBar-1234567812345678</li>
+                <li>plainCommentText-1234567812345678</li>
+                <li><!-- now.date --></li>
+                <li><!-- now.datetime --></li>
+                <li><!-- now.datetime.comments --></li>
+                <li>/js/lib/jquery.min.js</li>
+                <li>https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js</li>
+                <li>/js/lib/jquery-ui.min.js</li>
+                <li>https://ajax.googleapis.com/ajax/libs/jqueryui/1.10.4/jquery-ui.min.js</li>
+                <li><div class="col-md-8" id="adminInstitute">
+                </div></li>
+                <li><div id="adminInstitute" class="col-md-8">
+                    Test Institute 123
+                </div></li>
+            </ul>
+        </div>
+    </body>
 </html>

--- a/src/test/resources/pages/godmodeExpectedOutput.html
+++ b/src/test/resources/pages/godmodeExpectedOutput.html
@@ -1,44 +1,50 @@
 <html>
     <head>
-        <title>
-        </title>
     </head>
-    <div id="mainContent">
-        <input type="text" value="">
-        <a class="student-profile-pic-view-link btn-link" 
-           data-link="/page/studentProfilePic?studentemail=${student.email.enc}&amp;courseid=${course.id.enc}">
-           View Photo</a>
-        <a class="navLinks" data-unreg="true" href="/page/studentCourseJoinAuthentication?key=${regkey.enc}&">
-           Home
-        </a>
-        <input class="form-control"
-            type="text"
-            name="start"
-            id="start"
-            value="${today}">
-        <p class="form-control-static">${datetime.now}</p>
-        <input type="hidden"
-            name=commentid
-            value="${comment.id}">
-        <input
-            type="hidden"
-            name="questionid"
-            value="${question.id}">
-        
-        <!-- these must not be changed: -->
-        <a class="btn btn-default btn-xs t_course_archive0"
-           href="/page/instructorCourseArchive?courseid=testuserm.gma-demo&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=testuser.instructor"
-           data-toggle="tooltip" data-placement="top" title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)">
-       </a>
-       <input name="end" 
-              value="21/05/2001">
-        
-        <div>
-            ${test.admin}${test.admin}${test.instructor}${test.instructor}${test.student1}${test.student1}${test.student2}${test.student2}
+    <body>
+        <div id="mainContent">
+            <h2>Injected values</h2>
+            <ul>
+                <li>window.location.origin + '/${studentmotd.url}';</li>
+                <li>V${version}</li>
+                <li>${test.student1}</li>
+                <li>${test.student2}</li>
+                <li>${test.instructor}</li>
+                <li>${test.admin}</li>
+            </ul>
+            <h2>Variations in injected values</h2>
+            <ul>
+                <li>${test.student1}</li>
+                <li>${test.student2}</li>
+                <li>${test.instructor}</li>
+                <li>${test.admin}</li>
+            </ul>
+            <h2>Unpredictable values</h2>
+            <ul>
+                <li>"/_ah"</li>
+                <li>_ah/logout?continue=${continue.url}"</li>
+                <li>/page/studentProfilePic?studentemail=${student.email.enc}&amp;courseid=${course.id.enc}</li>
+                <li>/page/studentProfilePic?blob-key=${blobkey}</li>
+                <li><input id="blobKey" name="blob-key" type="hidden" value="${blobkey}"></li>
+                <li>key=${regkey.enc}</li>
+                <li><input name="key" type="hidden" value="${regkey.enc}"></li>
+                <li>value="${question.id}"</li>
+                <li>"${question.id}%</li>
+                <li>"${comment.id}"</li>
+                <li>#${comment.id}</li>
+                <li>responseCommentRow-${comment.id}</li>
+                <li>commentBar-${comment.id}</li>
+                <li>plainCommentText-${comment.id}</li>
+                <li>${today}</li>
+                <li>${datetime.now}</li>
+                <li>${datetime.now}</li>
+                <li>${lib.path}/jquery.min.js</li>
+                <li>${lib.path}/jquery.min.js</li>
+                <li>${lib.path}/jquery-ui.min.js</li>
+                <li>${lib.path}/jquery-ui.min.js</li>
+                <li>${admin.institute}</li>
+                <li>${admin.institute}</li>
+            </ul>
         </div>
-        
-    </div>
-    <div class="footer">V${version}</div>
-    ${admin.institute}
-    ${admin.institute}
+    </body>
 </html>

--- a/src/test/resources/pages/godmodeExpectedPartOutput.html
+++ b/src/test/resources/pages/godmodeExpectedPartOutput.html
@@ -1,35 +1,44 @@
 <div id="mainContent">
-    <input type="text" value="">
-    <a class="student-profile-pic-view-link btn-link" 
-       data-link="/page/studentProfilePic?studentemail=${student.email.enc}&amp;courseid=${course.id.enc}">
-       View Photo</a>
-    <a class="navLinks" data-unreg="true" href="/page/studentCourseJoinAuthentication?key=${regkey.enc}&">
-       Home
-    </a>
-    <input class="form-control"
-        type="text"
-        name="start"
-        id="start"
-        value="${today}">
-    <p class="form-control-static">${datetime.now}</p>
-    <input type="hidden"
-        name=commentid
-        value="${comment.id}">
-    <input
-        type="hidden"
-        name="questionid"
-        value="${question.id}">
-    
-    <!-- these must not be changed: -->
-    <a class="btn btn-default btn-xs t_course_archive0"
-       href="/page/instructorCourseArchive?courseid=testuserm.gma-demo&archive=true&next=%2Fpage%2FinstructorCoursesPage&user=testuser.instructor"
-       data-toggle="tooltip" data-placement="top" title="Archive the course so that it will not be shown in the home page any more (you can still access it from the 'Courses' tab)">
-   </a>
-   <input name="end" 
-          value="21/05/2001">
-    
-    <div>
-        ${test.admin}${test.admin}${test.instructor}${test.instructor}${test.student1}${test.student1}${test.student2}${test.student2}
-    </div>
-    
+    <h2>Injected values</h2>
+    <ul>
+        <li>window.location.origin + '/${studentmotd.url}';</li>
+        <li>V${version}</li>
+        <li>${test.student1}</li>
+        <li>${test.student2}</li>
+        <li>${test.instructor}</li>
+        <li>${test.admin}</li>
+    </ul>
+    <h2>Variations in injected values</h2>
+    <ul>
+        <li>${test.student1}</li>
+        <li>${test.student2}</li>
+        <li>${test.instructor}</li>
+        <li>${test.admin}</li>
+    </ul>
+    <h2>Unpredictable values</h2>
+    <ul>
+        <li>"/_ah"</li>
+        <li>_ah/logout?continue=${continue.url}"</li>
+        <li>/page/studentProfilePic?studentemail=${student.email.enc}&amp;courseid=${course.id.enc}</li>
+        <li>/page/studentProfilePic?blob-key=${blobkey}</li>
+        <li><input id="blobKey" name="blob-key" type="hidden" value="${blobkey}"></li>
+        <li>key=${regkey.enc}</li>
+        <li><input name="key" type="hidden" value="${regkey.enc}"></li>
+        <li>value="${question.id}"</li>
+        <li>"${question.id}%</li>
+        <li>"${comment.id}"</li>
+        <li>#${comment.id}</li>
+        <li>responseCommentRow-${comment.id}</li>
+        <li>commentBar-${comment.id}</li>
+        <li>plainCommentText-${comment.id}</li>
+        <li>${today}</li>
+        <li>${datetime.now}</li>
+        <li>${datetime.now}</li>
+        <li>${lib.path}/jquery.min.js</li>
+        <li>${lib.path}/jquery.min.js</li>
+        <li>${lib.path}/jquery-ui.min.js</li>
+        <li>${lib.path}/jquery-ui.min.js</li>
+        <li>${admin.institute}</li>
+        <li>${admin.institute}</li>
+    </ul>
 </div>


### PR DESCRIPTION
Fixes #4679 

Key changes:
1. Refactored `GodModeTest` for more clarity + suppressing repetitions + ...
2. Added a test for GodMode when the expected file doesn't exist (not tested before, although working).
3. Updated the GodMode test files to provide complete coverage of all replacements.
4. The widespread change in other UI tests is because `verifyHtml*` now throws an `IOException`. That change is so that `GodModeTest` can specifically catch it to test (2) up there, rather than catching a generic and potentially dangerous `Exception`. In fact, the change in all UI tests (other than `GodModeTest`, of course) and `StudentProfilePicturePage.java` is nothing more than addition of `throws Exception`.

Add: this change is also propagated to `HtmlHelperTest`, in particular the `testReplacement` added on #4635.