### PR TITLE
Move team before giver/recipient for feedback result responses #4672

### DIFF
--- a/src/main/java/teammates/ui/controller/InstructorFeedbackResultsPageData.java
+++ b/src/main/java/teammates/ui/controller/InstructorFeedbackResultsPageData.java
@@ -1094,89 +1094,88 @@ public class InstructorFeedbackResultsPageData extends PageData {
 
     private void buildTableColumnHeaderForQuestionView(List<ElementTag> columnTags, 
                                                        Map<String, Boolean> isSortable) {
-        ElementTag giverElement 
-            = new ElementTag("Giver", "id", "button_sortFromName", "class", "button-sort-none", "onclick", 
-                             "toggleSort(this,1)", "style", "width: 15%;");
         ElementTag giverTeamElement 
             = new ElementTag("Team", "id", "button_sortFromTeam", "class", "button-sort-none", "onclick", 
+                         "toggleSort(this,1)", "style", "width: 15%;");
+        ElementTag giverElement 
+            = new ElementTag("Giver", "id", "button_sortFromName", "class", "button-sort-none", "onclick", 
                              "toggleSort(this,2)", "style", "width: 15%;");
-        ElementTag recipientElement 
-            = new ElementTag("Recipient", "id", "button_sortToName", "class", "button-sort-none", "onclick", 
-                             "toggleSort(this,3)", "style", "width: 15%;");
         ElementTag recipientTeamElement 
             = new ElementTag("Team", "id", "button_sortToTeam", "class", "button-sort-ascending", "onclick", 
+                         "toggleSort(this,3)", "style", "width: 15%;");
+        ElementTag recipientElement 
+            = new ElementTag("Recipient", "id", "button_sortToName", "class", "button-sort-none", "onclick", 
                              "toggleSort(this,4)", "style", "width: 15%;");
         ElementTag responseElement 
             = new ElementTag("Feedback", "id", "button_sortFeedback", "class", "button-sort-none", "onclick", 
                              "toggleSort(this,5)");
         ElementTag actionElement = new ElementTag("Actions");
-        
-        columnTags.add(giverElement);
+
         columnTags.add(giverTeamElement);
-        columnTags.add(recipientElement);
+        columnTags.add(giverElement);
         columnTags.add(recipientTeamElement);
+        columnTags.add(recipientElement);
         columnTags.add(responseElement);
         columnTags.add(actionElement);
-        
+
         isSortable.put(giverElement.getContent(), true);
         isSortable.put(giverTeamElement.getContent(), true);
         isSortable.put(recipientElement.getContent(), true);
         isSortable.put(responseElement.getContent(), true);
         isSortable.put(actionElement.getContent(), false);
     }
-    
+
     private void buildTableColumnHeaderForGiverQuestionRecipientView(List<ElementTag> columnTags,
                                                                      Map<String, Boolean> isSortable) {
         ElementTag photoElement = new ElementTag("Photo");
-        ElementTag recipientElement 
-            = new ElementTag("Recipient", "id", "button_sortTo", "class", "button-sort-none", "onclick", 
-                             "toggleSort(this,2)", "style", "width: 15%;");
         ElementTag recipientTeamElement 
             = new ElementTag("Team", "id", "button_sortFromTeam", "class", "button-sort-ascending", "onclick", 
+                         "toggleSort(this,2)", "style", "width: 15%;");
+        ElementTag recipientElement 
+            = new ElementTag("Recipient", "id", "button_sortTo", "class", "button-sort-none", "onclick", 
                              "toggleSort(this,3)", "style", "width: 15%;");
         ElementTag responseElement 
             = new ElementTag("Feedback", "id", "button_sortFeedback", "class", "button-sort-none", "onclick", 
                              "toggleSort(this,4)");
 
         columnTags.add(photoElement);
-        columnTags.add(recipientElement);
         columnTags.add(recipientTeamElement);
+        columnTags.add(recipientElement);
         columnTags.add(responseElement);
-        
+
         isSortable.put(photoElement.getContent(), false);
         isSortable.put(recipientTeamElement.getContent(), true);
         isSortable.put(recipientElement.getContent(), true);
         isSortable.put(responseElement.getContent(), true);
-
     }
-    
+
     private void buildTableColumnHeaderForRecipientQuestionGiverView(List<ElementTag> columnTags,
                                                                      Map<String, Boolean> isSortable) {
         ElementTag photoElement = new ElementTag("Photo");
-        ElementTag giverElement 
-            = new ElementTag("Giver", "id", "button_sortFromName", "class", "button-sort-none", "onclick", 
-                             "toggleSort(this,2)", "style", "width: 15%;");
         ElementTag giverTeamElement 
             = new ElementTag("Team", "id", "button_sortFromTeam", "class", "button-sort-ascending", "onclick", 
+                         "toggleSort(this,2)", "style", "width: 15%;");
+        ElementTag giverElement 
+            = new ElementTag("Giver", "id", "button_sortFromName", "class", "button-sort-none", "onclick", 
                              "toggleSort(this,3)", "style", "width: 15%;");
         ElementTag responseElement 
             = new ElementTag("Feedback", "id", "button_sortFeedback", "class", "button-sort-none", "onclick", 
                              "toggleSort(this,4)");
         ElementTag actionElement = new ElementTag("Actions");
-        
+
         columnTags.add(photoElement);
-        columnTags.add(giverElement);
         columnTags.add(giverTeamElement);
+        columnTags.add(giverElement);
         columnTags.add(responseElement);
         columnTags.add(actionElement);
-        
+
         isSortable.put(photoElement.getContent(), false);
         isSortable.put(giverTeamElement.getContent(), true);
         isSortable.put(giverElement.getContent(), true);
         isSortable.put(responseElement.getContent(), true);
         isSortable.put(actionElement.getContent(), false);
     }
-    
+
     /**
      * Builds response rows for a given question. This not only builds response rows for existing responses, but includes 
      * the missing responses between pairs of givers and recipients.

--- a/src/main/webapp/WEB-INF/tags/instructor/results/responseRow.tag
+++ b/src/main/webapp/WEB-INF/tags/instructor/results/responseRow.tag
@@ -20,7 +20,6 @@
                     </div>
                 </c:when>
                 <c:otherwise>
-                    
                         <div class="align-center" data-link="">
                             <a class="student-profile-pic-view-link btn-link">
                                 No Photo
@@ -30,6 +29,7 @@
              </c:choose>
                 </td>
         </c:if>
+        <td class="middlealign<c:if test="${responseRow.rowGrey}"> color_neutral</c:if>">${responseRow.giverTeam}</td>
         <td class="middlealign<c:if test="${responseRow.rowGrey}"> color_neutral</c:if>">
         <c:choose>
             <c:when test="${not empty responseRow.giverProfilePictureLink && !responseRow.giverProfilePictureAColumn}">
@@ -43,7 +43,6 @@
             </c:otherwise>
         </c:choose>   
         </td>
-        <td class="middlealign<c:if test="${responseRow.rowGrey}"> color_neutral</c:if>">${responseRow.giverTeam}</td>
     </c:if>
     <c:if test="${responseRow.recipientDisplayed}">
         <c:if test="${responseRow.recipientProfilePictureAColumn}">
@@ -58,17 +57,16 @@
                         </div>
                     </c:when>
                     <c:otherwise>
-                        
                             <div class="align-center" data-link="">
                                 <a class="student-profile-pic-view-link btn-link">
                                     No Photo
                                 </a>
                             </div>
-                       
                     </c:otherwise>
                 </c:choose>
             </td>
         </c:if>
+        <td class="middlealign<c:if test="${responseRow.rowGrey}"> color_neutral</c:if>">${responseRow.recipientTeam}</td>
         <td class="middlealign<c:if test="${responseRow.rowGrey}"> color_neutral</c:if>">
         <c:choose>
             <c:when test="${not empty responseRow.recipientProfilePictureLink && !responseRow.recipientProfilePictureAColumn}">
@@ -82,7 +80,6 @@
             </c:otherwise>
         </c:choose>   
         </td>
-        <td class="middlealign<c:if test="${responseRow.rowGrey}"> color_neutral</c:if>">${responseRow.recipientTeam}</td>
     </c:if>
     <!--Note: When an element has class text-preserve-space, do not insert and HTML spaces-->
     <td class="text-preserve-space<c:if test="${responseRow.rowGrey}"> color_neutral</c:if>">${responseRow.displayableResponse}</td>
@@ -93,5 +90,4 @@
             </c:if>
         </td>
     </c:if>
-
 </tr>

--- a/src/test/java/teammates/test/pageobjects/InstructorFeedbackResultsPage.java
+++ b/src/test/java/teammates/test/pageobjects/InstructorFeedbackResultsPage.java
@@ -383,12 +383,12 @@ public class InstructorFeedbackResultsPage extends AppPage {
 
     public void hoverClickAndViewGiverPhotoOnTableCell(int questionBodyIndex, int tableRow,
                                                        String urlRegex) throws Exception {
-        hoverClickAndViewPhotoOnTableCell(questionBodyIndex, tableRow, 0, urlRegex);
+        hoverClickAndViewPhotoOnTableCell(questionBodyIndex, tableRow, 1, urlRegex);
     }
 
     public void hoverClickAndViewRecipientPhotoOnTableCell(int questionBodyIndex, int tableRow,
                                                            String urlRegex) throws Exception {
-        hoverClickAndViewPhotoOnTableCell(questionBodyIndex, tableRow, 2, urlRegex);
+        hoverClickAndViewPhotoOnTableCell(questionBodyIndex, tableRow, 3, urlRegex);
     }
 
     public void removeNavBar() {

--- a/src/test/resources/pages/instructorFeedbackResultsAjaxByGQR.html
+++ b/src/test/resources/pages/instructorFeedbackResultsAjaxByGQR.html
@@ -328,13 +328,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Recipient
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Recipient
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -358,10 +358,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Benny Charles
+                                                Team 1
                                              </td>
                                              <td class="middlealign">
-                                                Team 1
+                                                Benny Charles
                                              </td>
                                              <td class="text-preserve-space">
                                                 2 Response to Benny.
@@ -377,10 +377,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Drop out
+                                                Team 2
                                              </td>
                                              <td class="middlealign">
-                                                Team 2
+                                                Drop out
                                              </td>
                                              <td class="text-preserve-space">
                                                 Response to Dropout.
@@ -410,13 +410,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Recipient
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Recipient
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -440,10 +440,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Alice Betsy
+                                                Team 1
                                              </td>
                                              <td class="middlealign">
-                                                Team 1
+                                                Alice Betsy
                                              </td>
                                              <td class="text-preserve-space">
                                                 Alice self feedback.
@@ -570,13 +570,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Recipient
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Recipient
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -600,10 +600,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Alice Betsy
+                                                Team 1
                                              </td>
                                              <td class="middlealign">
-                                                Team 1
+                                                Alice Betsy
                                              </td>
                                              <td class="text-preserve-space">
                                                 PowerSearch
@@ -730,13 +730,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Recipient
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Recipient
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -760,10 +760,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Alice Betsy
+                                                Team 1
                                              </td>
                                              <td class="middlealign">
-                                                Team 1
+                                                Alice Betsy
                                              </td>
                                              <td class="text-preserve-space">
                                                 <ul class="selectedOptionsList">
@@ -852,13 +852,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Recipient
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Recipient
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -882,10 +882,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Alice Betsy
+                                                Team 1
                                              </td>
                                              <td class="middlealign">
-                                                Team 1
+                                                Alice Betsy
                                              </td>
                                              <td class="text-preserve-space">
                                                 Danny
@@ -967,13 +967,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Recipient
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Recipient
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -997,10 +997,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Alice Betsy
+                                                Team 1
                                              </td>
                                              <td class="middlealign">
-                                                Team 1
+                                                Alice Betsy
                                              </td>
                                              <td class="text-preserve-space">
                                                 Team 1
@@ -1061,13 +1061,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Recipient
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Recipient
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -1091,10 +1091,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Charlie Dávis
+                                                Team 2
                                              </td>
                                              <td class="middlealign">
-                                                Team 2
+                                                Charlie Dávis
                                              </td>
                                              <td class="text-preserve-space">
                                                 4 Response to Charlie.
@@ -1110,10 +1110,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Danny Engrid
+                                                Team 2
                                              </td>
                                              <td class="middlealign">
-                                                Team 2
+                                                Danny Engrid
                                              </td>
                                              <td class="text-preserve-space">
                                                 1 Response to Danny.
@@ -1166,13 +1166,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Recipient
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Recipient
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -1196,10 +1196,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Benny Charles
+                                                Team 1
                                              </td>
                                              <td class="middlealign">
-                                                Team 1
+                                                Benny Charles
                                              </td>
                                              <td class="text-preserve-space">
                                              </td>
@@ -1259,13 +1259,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Recipient
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Recipient
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -1289,10 +1289,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Emily
+                                                Team 3
                                              </td>
                                              <td class="middlealign">
-                                                Team 3
+                                                Emily
                                              </td>
                                              <td class="text-preserve-space">
                                                 3 Response to Emily.
@@ -1353,13 +1353,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Recipient
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Recipient
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -1383,10 +1383,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Alice Betsy
+                                                Team 1
                                              </td>
                                              <td class="middlealign">
-                                                Team 1
+                                                Alice Betsy
                                              </td>
                                              <td class="text-preserve-space">
                                                 Response to Alice from Dropout.
@@ -1402,10 +1402,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Benny Charles
+                                                Team 1
                                              </td>
                                              <td class="middlealign">
-                                                Team 1
+                                                Benny Charles
                                              </td>
                                              <td class="text-preserve-space">
                                                 Response to Benny from Dropout.
@@ -1421,10 +1421,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Danny Engrid
+                                                Team 2
                                              </td>
                                              <td class="middlealign">
-                                                Team 2
+                                                Danny Engrid
                                              </td>
                                              <td class="text-preserve-space">
                                                 Response to Danny from Dropout.
@@ -1551,13 +1551,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Recipient
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Recipient
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -1581,10 +1581,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Drop out
+                                                Team 2
                                              </td>
                                              <td class="middlealign">
-                                                Team 2
+                                                Drop out
                                              </td>
                                              <td class="text-preserve-space">
                                                 PowerSearch
@@ -1666,13 +1666,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Recipient
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Recipient
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -1696,10 +1696,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Drop out
+                                                Team 2
                                              </td>
                                              <td class="middlealign">
-                                                Team 2
+                                                Drop out
                                              </td>
                                              <td class="text-preserve-space">
                                                 Team 2
@@ -1750,13 +1750,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Recipient
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Recipient
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -1779,9 +1779,9 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Team 2
                                              </td>
                                              <td class="middlealign">
+                                                Team 2
                                              </td>
                                              <td class="text-preserve-space">
                                                 Response from team 1 (by alice) to team 2.

--- a/src/test/resources/pages/instructorFeedbackResultsAjaxByQuestion.html
+++ b/src/test/resources/pages/instructorFeedbackResultsAjaxByQuestion.html
@@ -281,23 +281,23 @@
                   <table class="table table-striped table-bordered dataTable margin-0">
                      <thead class="background-color-medium-gray text-color-gray font-weight-normal">
                         <tr>
-                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,1)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,1)" style="width: 15%;">
+                              Team
+                              <span class="icon-sort unsorted">
+                              </span>
+                           </th>
+                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
                               Giver
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,3)" style="width: 15%;">
                               Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,3)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,4)" style="width: 15%;">
                               Recipient
-                              <span class="icon-sort unsorted">
-                              </span>
-                           </th>
-                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,4)" style="width: 15%;">
-                              Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
@@ -316,6 +316,9 @@
                      <tbody>
                         <tr>
                            <td class="middlealign">
+                              Team 1
+                           </td>
+                           <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Alice Betsy
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
@@ -329,9 +332,6 @@
                                  Benny Charles
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign">
-                              Team 1
                            </td>
                            <td class="text-preserve-space">
                               2 Response to Benny.
@@ -348,22 +348,22 @@
                         </tr>
                         <tr>
                            <td class="middlealign">
+                              Team 1
+                           </td>
+                           <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Alice Betsy
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
                            <td class="middlealign">
-                              Team 1
+                              Team 2
                            </td>
                            <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Drop out
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign">
-                              Team 2
                            </td>
                            <td class="text-preserve-space">
                               Response to Dropout.
@@ -380,22 +380,22 @@
                         </tr>
                         <tr>
                            <td class="middlealign">
+                              Team 1
+                           </td>
+                           <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Benny Charles
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
                            <td class="middlealign">
-                              Team 1
+                              Team 2
                            </td>
                            <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Charlie Dávis
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign">
-                              Team 2
                            </td>
                            <td class="text-preserve-space">
                               4 Response to Charlie.
@@ -412,22 +412,22 @@
                         </tr>
                         <tr>
                            <td class="middlealign">
+                              Team 1
+                           </td>
+                           <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Benny Charles
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
                            <td class="middlealign">
-                              Team 1
+                              Team 2
                            </td>
                            <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Danny Engrid
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign">
-                              Team 2
                            </td>
                            <td class="text-preserve-space">
                               1 Response to Danny.
@@ -444,22 +444,22 @@
                         </tr>
                         <tr>
                            <td class="middlealign">
+                              Team 2
+                           </td>
+                           <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Charlie Dávis
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
                            <td class="middlealign">
-                              Team 2
+                              Team 3
                            </td>
                            <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Emily
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign">
-                              Team 3
                            </td>
                            <td class="text-preserve-space">
                               3 Response to Emily.
@@ -476,22 +476,22 @@
                         </tr>
                         <tr>
                            <td class="middlealign">
+                              Team 2
+                           </td>
+                           <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Drop out
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
                            <td class="middlealign">
-                              Team 2
+                              Team 1
                            </td>
                            <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Alice Betsy
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign">
-                              Team 1
                            </td>
                            <td class="text-preserve-space">
                               Response to Alice from Dropout.
@@ -508,22 +508,22 @@
                         </tr>
                         <tr>
                            <td class="middlealign">
+                              Team 2
+                           </td>
+                           <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Drop out
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
                            <td class="middlealign">
-                              Team 2
+                              Team 1
                            </td>
                            <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Benny Charles
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign">
-                              Team 1
                            </td>
                            <td class="text-preserve-space">
                               Response to Benny from Dropout.
@@ -540,6 +540,9 @@
                         </tr>
                         <tr>
                            <td class="middlealign">
+                              Team 2
+                           </td>
+                           <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Drop out
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
@@ -553,9 +556,6 @@
                                  Danny Engrid
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign">
-                              Team 2
                            </td>
                            <td class="text-preserve-space">
                               Response to Danny from Dropout.

--- a/src/test/resources/pages/instructorFeedbackResultsAjaxByQuestionViewForHelperTwo.html
+++ b/src/test/resources/pages/instructorFeedbackResultsAjaxByQuestionViewForHelperTwo.html
@@ -278,23 +278,23 @@
                   <table class="table table-striped table-bordered dataTable margin-0">
                      <thead class="background-color-medium-gray text-color-gray font-weight-normal">
                         <tr>
-                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,1)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,1)" style="width: 15%;">
+                              Team
+                              <span class="icon-sort unsorted">
+                              </span>
+                           </th>
+                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
                               Giver
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,3)" style="width: 15%;">
                               Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,3)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,4)" style="width: 15%;">
                               Recipient
-                              <span class="icon-sort unsorted">
-                              </span>
-                           </th>
-                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,4)" style="width: 15%;">
-                              Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
@@ -313,6 +313,9 @@
                      <tbody>
                         <tr>
                            <td class="middlealign">
+                              Team 1
+                           </td>
+                           <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
                                  Alice Betsy
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
@@ -326,9 +329,6 @@
                                  Benny Charles
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign">
-                              Team 1
                            </td>
                            <td class="text-preserve-space">
                               2 Response to Benny.
@@ -345,22 +345,22 @@
                         </tr>
                         <tr>
                            <td class="middlealign">
+                              Team 1
+                           </td>
+                           <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
                                  Alice Betsy
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
                            <td class="middlealign">
-                              Team 1
+                              Team 2
                            </td>
                            <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
                                  Drop out
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign">
-                              Team 2
                            </td>
                            <td class="text-preserve-space">
                               Response to Dropout.
@@ -377,22 +377,22 @@
                         </tr>
                         <tr>
                            <td class="middlealign">
+                              Team 1
+                           </td>
+                           <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
                                  Benny Charles
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
                            <td class="middlealign">
-                              Team 1
+                              Team 2
                            </td>
                            <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
                                  Charlie Dávis
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign">
-                              Team 2
                            </td>
                            <td class="text-preserve-space">
                               4 Response to Charlie.
@@ -409,22 +409,22 @@
                         </tr>
                         <tr>
                            <td class="middlealign">
+                              Team 1
+                           </td>
+                           <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
                                  Benny Charles
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
                            <td class="middlealign">
-                              Team 1
+                              Team 2
                            </td>
                            <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
                                  Danny Engrid
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign">
-                              Team 2
                            </td>
                            <td class="text-preserve-space">
                               1 Response to Danny.
@@ -441,22 +441,22 @@
                         </tr>
                         <tr>
                            <td class="middlealign">
+                              Team 2
+                           </td>
+                           <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
                                  Drop out
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
                            <td class="middlealign">
-                              Team 2
+                              Team 1
                            </td>
                            <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
                                  Alice Betsy
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign">
-                              Team 1
                            </td>
                            <td class="text-preserve-space">
                               Response to Alice from Dropout.
@@ -473,22 +473,22 @@
                         </tr>
                         <tr>
                            <td class="middlealign">
+                              Team 2
+                           </td>
+                           <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
                                  Drop out
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
                            <td class="middlealign">
-                              Team 2
+                              Team 1
                            </td>
                            <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
                                  Benny Charles
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign">
-                              Team 1
                            </td>
                            <td class="text-preserve-space">
                               Response to Benny from Dropout.
@@ -505,6 +505,9 @@
                         </tr>
                         <tr>
                            <td class="middlealign">
+                              Team 2
+                           </td>
+                           <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
                                  Drop out
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
@@ -518,9 +521,6 @@
                                  Danny Engrid
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign">
-                              Team 2
                            </td>
                            <td class="text-preserve-space">
                               Response to Danny from Dropout.

--- a/src/test/resources/pages/instructorFeedbackResultsAjaxByRQG.html
+++ b/src/test/resources/pages/instructorFeedbackResultsAjaxByRQG.html
@@ -322,13 +322,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Giver
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Giver
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -355,10 +355,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Drop out
+                                                Team 2
                                              </td>
                                              <td class="middlealign">
-                                                Team 2
+                                                Drop out
                                              </td>
                                              <td class="text-preserve-space">
                                                 Response to Alice from Dropout.
@@ -397,13 +397,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Giver
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Giver
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -430,10 +430,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Alice Betsy
+                                                Team 1
                                              </td>
                                              <td class="middlealign">
-                                                Team 1
+                                                Alice Betsy
                                              </td>
                                              <td class="text-preserve-space">
                                                 Alice self feedback.
@@ -569,13 +569,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Giver
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Giver
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -602,10 +602,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Alice Betsy
+                                                Team 1
                                              </td>
                                              <td class="middlealign">
-                                                Team 1
+                                                Alice Betsy
                                              </td>
                                              <td class="text-preserve-space">
                                                 PowerSearch
@@ -741,13 +741,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Giver
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Giver
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -774,10 +774,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Alice Betsy
+                                                Team 1
                                              </td>
                                              <td class="middlealign">
-                                                Team 1
+                                                Alice Betsy
                                              </td>
                                              <td class="text-preserve-space">
                                                 <ul class="selectedOptionsList">
@@ -875,13 +875,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Giver
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Giver
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -908,10 +908,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Alice Betsy
+                                                Team 1
                                              </td>
                                              <td class="middlealign">
-                                                Team 1
+                                                Alice Betsy
                                              </td>
                                              <td class="text-preserve-space">
                                                 Danny
@@ -1002,13 +1002,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Giver
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Giver
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -1035,10 +1035,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Alice Betsy
+                                                Team 1
                                              </td>
                                              <td class="middlealign">
-                                                Team 1
+                                                Alice Betsy
                                              </td>
                                              <td class="text-preserve-space">
                                                 Team 1
@@ -1102,13 +1102,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Giver
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Giver
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -1135,10 +1135,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Alice Betsy
+                                                Team 1
                                              </td>
                                              <td class="middlealign">
-                                                Team 1
+                                                Alice Betsy
                                              </td>
                                              <td class="text-preserve-space">
                                                 2 Response to Benny.
@@ -1163,10 +1163,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Drop out
+                                                Team 2
                                              </td>
                                              <td class="middlealign">
-                                                Team 2
+                                                Drop out
                                              </td>
                                              <td class="text-preserve-space">
                                                 Response to Benny from Dropout.
@@ -1228,13 +1228,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Giver
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Giver
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -1261,10 +1261,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Benny Charles
+                                                Team 1
                                              </td>
                                              <td class="middlealign">
-                                                Team 1
+                                                Benny Charles
                                              </td>
                                              <td class="text-preserve-space">
                                              </td>
@@ -1327,13 +1327,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Giver
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Giver
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -1360,10 +1360,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Benny Charles
+                                                Team 1
                                              </td>
                                              <td class="middlealign">
-                                                Team 1
+                                                Benny Charles
                                              </td>
                                              <td class="text-preserve-space">
                                                 4 Response to Charlie.
@@ -1427,13 +1427,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Giver
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Giver
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -1460,10 +1460,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Benny Charles
+                                                Team 1
                                              </td>
                                              <td class="middlealign">
-                                                Team 1
+                                                Benny Charles
                                              </td>
                                              <td class="text-preserve-space">
                                                 1 Response to Danny.
@@ -1488,10 +1488,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Drop out
+                                                Team 2
                                              </td>
                                              <td class="middlealign">
-                                                Team 2
+                                                Drop out
                                              </td>
                                              <td class="text-preserve-space">
                                                 Response to Danny from Dropout.
@@ -1555,13 +1555,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Giver
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Giver
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -1588,10 +1588,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Alice Betsy
+                                                Team 1
                                              </td>
                                              <td class="middlealign">
-                                                Team 1
+                                                Alice Betsy
                                              </td>
                                              <td class="text-preserve-space">
                                                 Response to Dropout.
@@ -1727,13 +1727,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Giver
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Giver
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -1760,10 +1760,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Drop out
+                                                Team 2
                                              </td>
                                              <td class="middlealign">
-                                                Team 2
+                                                Drop out
                                              </td>
                                              <td class="text-preserve-space">
                                                 PowerSearch
@@ -1854,13 +1854,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Giver
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Giver
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -1887,10 +1887,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Drop out
+                                                Team 2
                                              </td>
                                              <td class="middlealign">
-                                                Team 2
+                                                Drop out
                                              </td>
                                              <td class="text-preserve-space">
                                                 Team 2
@@ -1950,13 +1950,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Giver
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Giver
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -1982,9 +1982,9 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Team 1
                                              </td>
                                              <td class="middlealign">
+                                                Team 1
                                              </td>
                                              <td class="text-preserve-space">
                                                 Response from team 1 (by alice) to team 2.

--- a/src/test/resources/pages/instructorFeedbackResultsDuplicateQuestionNumberPanel1.html
+++ b/src/test/resources/pages/instructorFeedbackResultsDuplicateQuestionNumberPanel1.html
@@ -2,23 +2,23 @@
       <table class="table table-striped table-bordered dataTable margin-0">
          <thead class="background-color-medium-gray text-color-gray font-weight-normal">
             <tr>
-               <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,1)" style="width: 15%;">
+               <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,1)" style="width: 15%;">
+                  Team
+                  <span class="icon-sort unsorted">
+                  </span>
+               </th>
+               <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
                   Giver
                   <span class="icon-sort unsorted">
                   </span>
                </th>
-               <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+               <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,3)" style="width: 15%;">
                   Team
                   <span class="icon-sort unsorted">
                   </span>
                </th>
-               <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,3)" style="width: 15%;">
+               <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,4)" style="width: 15%;">
                   Recipient
-                  <span class="icon-sort unsorted">
-                  </span>
-               </th>
-               <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,4)" style="width: 15%;">
-                  Team
                   <span class="icon-sort unsorted">
                   </span>
                </th>
@@ -37,9 +37,9 @@
          <tbody>
             <tr>
                <td class="middlealign">
-                  Team 1
                </td>
                <td class="middlealign">
+                  Team 1
                </td>
                <td class="middlealign">
                   -
@@ -62,9 +62,9 @@
             </tr>
             <tr class="pending_response_row">
                <td class="middlealign color_neutral">
-                  Team 2
                </td>
                <td class="middlealign color_neutral">
+                  Team 2
                </td>
                <td class="middlealign color_neutral">
                   -
@@ -89,9 +89,9 @@
             </tr>
             <tr class="pending_response_row">
                <td class="middlealign color_neutral">
-                  Team 3
                </td>
                <td class="middlealign color_neutral">
+                  Team 3
                </td>
                <td class="middlealign color_neutral">
                   -

--- a/src/test/resources/pages/instructorFeedbackResultsDuplicateQuestionNumberPanel2.html
+++ b/src/test/resources/pages/instructorFeedbackResultsDuplicateQuestionNumberPanel2.html
@@ -2,23 +2,23 @@
       <table class="table table-striped table-bordered dataTable margin-0">
          <thead class="background-color-medium-gray text-color-gray font-weight-normal">
             <tr>
-               <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,1)" style="width: 15%;">
+               <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,1)" style="width: 15%;">
+                  Team
+                  <span class="icon-sort unsorted">
+                  </span>
+               </th>
+               <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
                   Giver
                   <span class="icon-sort unsorted">
                   </span>
                </th>
-               <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+               <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,3)" style="width: 15%;">
                   Team
                   <span class="icon-sort unsorted">
                   </span>
                </th>
-               <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,3)" style="width: 15%;">
+               <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,4)" style="width: 15%;">
                   Recipient
-                  <span class="icon-sort unsorted">
-                  </span>
-               </th>
-               <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,4)" style="width: 15%;">
-                  Team
                   <span class="icon-sort unsorted">
                   </span>
                </th>
@@ -37,15 +37,15 @@
          <tbody>
             <tr>
                <td class="middlealign">
+               </td>
+               <td class="middlealign">
                   Team 1
                </td>
                <td class="middlealign">
+                  Anonymous student 227201833's Team
                </td>
                <td class="middlealign">
                   Anonymous student 227201833
-               </td>
-               <td class="middlealign">
-                  Anonymous student 227201833's Team
                </td>
                <td class="text-preserve-space">
                   50
@@ -62,18 +62,18 @@
             </tr>
             <tr class="pending_response_row">
                <td class="middlealign color_neutral">
+               </td>
+               <td class="middlealign color_neutral">
                   Team 1
                </td>
                <td class="middlealign color_neutral">
+                  Team 1
                </td>
                <td class="middlealign color_neutral">
                   <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                      Alice Betsy
                      <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                   </div>
-               </td>
-               <td class="middlealign color_neutral">
-                  Team 1
                </td>
                <td class="text-preserve-space color_neutral">
                   <i>
@@ -92,18 +92,18 @@
             </tr>
             <tr class="pending_response_row">
                <td class="middlealign color_neutral">
+               </td>
+               <td class="middlealign color_neutral">
                   Team 1
                </td>
                <td class="middlealign color_neutral">
+                  Team 1
                </td>
                <td class="middlealign color_neutral">
                   <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                      Benny Charles
                      <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                   </div>
-               </td>
-               <td class="middlealign color_neutral">
-                  Team 1
                </td>
                <td class="text-preserve-space color_neutral">
                   <i>

--- a/src/test/resources/pages/instructorFeedbackResultsFilteredByNoSection.html
+++ b/src/test/resources/pages/instructorFeedbackResultsFilteredByNoSection.html
@@ -346,23 +346,23 @@
                   <table class="table table-striped table-bordered dataTable margin-0">
                      <thead class="background-color-medium-gray text-color-gray font-weight-normal">
                         <tr>
-                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,1)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,1)" style="width: 15%;">
+                              Team
+                              <span class="icon-sort unsorted">
+                              </span>
+                           </th>
+                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
                               Giver
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,3)" style="width: 15%;">
                               Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,3)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,4)" style="width: 15%;">
                               Recipient
-                              <span class="icon-sort unsorted">
-                              </span>
-                           </th>
-                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,4)" style="width: 15%;">
-                              Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
@@ -381,13 +381,13 @@
                      <tbody>
                         <tr>
                            <td class="middlealign">
+                              Instructors
+                           </td>
+                           <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Teammates Test
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign">
-                              Instructors
                            </td>
                            <td class="middlealign">
                               -

--- a/src/test/resources/pages/instructorFeedbackResultsFilteredBySectionA.html
+++ b/src/test/resources/pages/instructorFeedbackResultsFilteredBySectionA.html
@@ -276,23 +276,23 @@
                   <table class="table table-striped table-bordered dataTable margin-0">
                      <thead class="background-color-medium-gray text-color-gray font-weight-normal">
                         <tr>
-                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,1)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,1)" style="width: 15%;">
+                              Team
+                              <span class="icon-sort unsorted">
+                              </span>
+                           </th>
+                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
                               Giver
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,3)" style="width: 15%;">
                               Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,3)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,4)" style="width: 15%;">
                               Recipient
-                              <span class="icon-sort unsorted">
-                              </span>
-                           </th>
-                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,4)" style="width: 15%;">
-                              Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
@@ -311,6 +311,9 @@
                      <tbody>
                         <tr>
                            <td class="middlealign">
+                              Team 1
+                           </td>
+                           <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Alice Betsy
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
@@ -324,9 +327,6 @@
                                  Benny Charles
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign">
-                              Team 1
                            </td>
                            <td class="text-preserve-space">
                               2 Response to Benny.
@@ -343,22 +343,22 @@
                         </tr>
                         <tr>
                            <td class="middlealign">
+                              Team 1
+                           </td>
+                           <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Alice Betsy
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
                            <td class="middlealign">
-                              Team 1
+                              Team 2
                            </td>
                            <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Drop out
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign">
-                              Team 2
                            </td>
                            <td class="text-preserve-space">
                               Response to Dropout.
@@ -375,22 +375,22 @@
                         </tr>
                         <tr>
                            <td class="middlealign">
+                              Team 1
+                           </td>
+                           <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Benny Charles
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
                            <td class="middlealign">
-                              Team 1
+                              Team 2
                            </td>
                            <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Charlie Dávis
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign">
-                              Team 2
                            </td>
                            <td class="text-preserve-space">
                               4 Response to Charlie.
@@ -407,22 +407,22 @@
                         </tr>
                         <tr>
                            <td class="middlealign">
+                              Team 1
+                           </td>
+                           <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Benny Charles
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
                            <td class="middlealign">
-                              Team 1
+                              Team 2
                            </td>
                            <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Danny Engrid
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign">
-                              Team 2
                            </td>
                            <td class="text-preserve-space">
                               1 Response to Danny.
@@ -439,22 +439,22 @@
                         </tr>
                         <tr>
                            <td class="middlealign">
+                              Team 2
+                           </td>
+                           <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Drop out
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
                            <td class="middlealign">
-                              Team 2
+                              Team 1
                            </td>
                            <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Alice Betsy
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign">
-                              Team 1
                            </td>
                            <td class="text-preserve-space">
                               Response to Alice from Dropout.
@@ -471,22 +471,22 @@
                         </tr>
                         <tr>
                            <td class="middlealign">
+                              Team 2
+                           </td>
+                           <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Drop out
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
                            <td class="middlealign">
-                              Team 2
+                              Team 1
                            </td>
                            <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Benny Charles
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign">
-                              Team 1
                            </td>
                            <td class="text-preserve-space">
                               Response to Benny from Dropout.
@@ -503,6 +503,9 @@
                         </tr>
                         <tr>
                            <td class="middlealign">
+                              Team 2
+                           </td>
+                           <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Drop out
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
@@ -516,9 +519,6 @@
                                  Danny Engrid
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign">
-                              Team 2
                            </td>
                            <td class="text-preserve-space">
                               Response to Danny from Dropout.
@@ -572,23 +572,23 @@
                   <table class="table table-striped table-bordered dataTable margin-0">
                      <thead class="background-color-medium-gray text-color-gray font-weight-normal">
                         <tr>
-                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,1)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,1)" style="width: 15%;">
+                              Team
+                              <span class="icon-sort unsorted">
+                              </span>
+                           </th>
+                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
                               Giver
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,3)" style="width: 15%;">
                               Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,3)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,4)" style="width: 15%;">
                               Recipient
-                              <span class="icon-sort unsorted">
-                              </span>
-                           </th>
-                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,4)" style="width: 15%;">
-                              Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
@@ -607,12 +607,6 @@
                      <tbody>
                         <tr>
                            <td class="middlealign">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Alice Betsy
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign">
                               Team 1
                            </td>
                            <td class="middlealign">
@@ -623,6 +617,12 @@
                            </td>
                            <td class="middlealign">
                               Team 1
+                           </td>
+                           <td class="middlealign">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Alice Betsy
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space">
                               Alice self feedback.
@@ -639,12 +639,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Benny Charles
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 1
                            </td>
                            <td class="middlealign color_neutral">
@@ -655,6 +649,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 1
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Benny Charles
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -673,12 +673,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Charlie Dávis
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -689,6 +683,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Charlie Dávis
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -707,12 +707,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Danny Engrid
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -723,6 +717,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Danny Engrid
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -741,12 +741,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Drop out
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -757,6 +751,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Drop out
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -775,12 +775,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Extra guy
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -791,6 +785,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Extra guy
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -881,23 +881,23 @@
                   <table class="table table-striped table-bordered dataTable margin-0">
                      <thead class="background-color-medium-gray text-color-gray font-weight-normal">
                         <tr>
-                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,1)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,1)" style="width: 15%;">
+                              Team
+                              <span class="icon-sort unsorted">
+                              </span>
+                           </th>
+                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
                               Giver
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,3)" style="width: 15%;">
                               Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,3)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,4)" style="width: 15%;">
                               Recipient
-                              <span class="icon-sort unsorted">
-                              </span>
-                           </th>
-                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,4)" style="width: 15%;">
-                              Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
@@ -916,14 +916,14 @@
                      <tbody>
                         <tr>
                            <td class="middlealign">
+                           </td>
+                           <td class="middlealign">
                               Team 1
                            </td>
                            <td class="middlealign">
                            </td>
                            <td class="middlealign">
                               Team 2
-                           </td>
-                           <td class="middlealign">
                            </td>
                            <td class="text-preserve-space">
                               Response from team 1 (by alice) to team 2.
@@ -1144,23 +1144,23 @@
                   <table class="table table-striped table-bordered dataTable margin-0">
                      <thead class="background-color-medium-gray text-color-gray font-weight-normal">
                         <tr>
-                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,1)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,1)" style="width: 15%;">
+                              Team
+                              <span class="icon-sort unsorted">
+                              </span>
+                           </th>
+                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
                               Giver
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,3)" style="width: 15%;">
                               Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,3)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,4)" style="width: 15%;">
                               Recipient
-                              <span class="icon-sort unsorted">
-                              </span>
-                           </th>
-                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,4)" style="width: 15%;">
-                              Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
@@ -1179,12 +1179,6 @@
                      <tbody>
                         <tr>
                            <td class="middlealign">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Alice Betsy
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign">
                               Team 1
                            </td>
                            <td class="middlealign">
@@ -1195,6 +1189,12 @@
                            </td>
                            <td class="middlealign">
                               Team 1
+                           </td>
+                           <td class="middlealign">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Alice Betsy
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space">
                               PowerSearch
@@ -1211,12 +1211,6 @@
                         </tr>
                         <tr>
                            <td class="middlealign">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Drop out
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign">
                               Team 2
                            </td>
                            <td class="middlealign">
@@ -1227,6 +1221,12 @@
                            </td>
                            <td class="middlealign">
                               Team 2
+                           </td>
+                           <td class="middlealign">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Drop out
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space">
                               PowerSearch
@@ -1243,12 +1243,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Benny Charles
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 1
                            </td>
                            <td class="middlealign color_neutral">
@@ -1259,6 +1253,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 1
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Benny Charles
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -1277,12 +1277,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Charlie Dávis
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -1293,6 +1287,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Charlie Dávis
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -1311,12 +1311,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Danny Engrid
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -1327,6 +1321,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Danny Engrid
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -1345,12 +1345,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Extra guy
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -1361,6 +1355,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Extra guy
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -1513,23 +1513,23 @@
                   <table class="table table-striped table-bordered dataTable margin-0">
                      <thead class="background-color-medium-gray text-color-gray font-weight-normal">
                         <tr>
-                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,1)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,1)" style="width: 15%;">
+                              Team
+                              <span class="icon-sort unsorted">
+                              </span>
+                           </th>
+                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
                               Giver
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,3)" style="width: 15%;">
                               Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,3)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,4)" style="width: 15%;">
                               Recipient
-                              <span class="icon-sort unsorted">
-                              </span>
-                           </th>
-                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,4)" style="width: 15%;">
-                              Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
@@ -1548,12 +1548,6 @@
                      <tbody>
                         <tr>
                            <td class="middlealign">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Alice Betsy
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign">
                               Team 1
                            </td>
                            <td class="middlealign">
@@ -1564,6 +1558,12 @@
                            </td>
                            <td class="middlealign">
                               Team 1
+                           </td>
+                           <td class="middlealign">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Alice Betsy
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space">
                               <ul class="selectedOptionsList">
@@ -1587,12 +1587,6 @@
                         </tr>
                         <tr>
                            <td class="middlealign">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Benny Charles
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign">
                               Team 1
                            </td>
                            <td class="middlealign">
@@ -1603,6 +1597,12 @@
                            </td>
                            <td class="middlealign">
                               Team 1
+                           </td>
+                           <td class="middlealign">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Benny Charles
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space">
                            </td>
@@ -1618,12 +1618,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Charlie Dávis
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -1634,6 +1628,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Charlie Dávis
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -1652,12 +1652,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Danny Engrid
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -1668,6 +1662,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Danny Engrid
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -1686,12 +1686,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Drop out
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -1702,6 +1696,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Drop out
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -1720,12 +1720,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Extra guy
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -1736,6 +1730,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Extra guy
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -1843,23 +1843,23 @@
                   <table class="table table-striped table-bordered dataTable margin-0">
                      <thead class="background-color-medium-gray text-color-gray font-weight-normal">
                         <tr>
-                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,1)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,1)" style="width: 15%;">
+                              Team
+                              <span class="icon-sort unsorted">
+                              </span>
+                           </th>
+                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
                               Giver
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,3)" style="width: 15%;">
                               Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,3)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,4)" style="width: 15%;">
                               Recipient
-                              <span class="icon-sort unsorted">
-                              </span>
-                           </th>
-                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,4)" style="width: 15%;">
-                              Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
@@ -1878,12 +1878,6 @@
                      <tbody>
                         <tr>
                            <td class="middlealign">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Alice Betsy
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign">
                               Team 1
                            </td>
                            <td class="middlealign">
@@ -1894,6 +1888,12 @@
                            </td>
                            <td class="middlealign">
                               Team 1
+                           </td>
+                           <td class="middlealign">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Alice Betsy
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space">
                               Danny
@@ -1910,12 +1910,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Benny Charles
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 1
                            </td>
                            <td class="middlealign color_neutral">
@@ -1926,6 +1920,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 1
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Benny Charles
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -1944,12 +1944,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Charlie Dávis
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -1960,6 +1954,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Charlie Dávis
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -1978,12 +1978,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Danny Engrid
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -1994,6 +1988,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Danny Engrid
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -2012,12 +2012,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Drop out
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -2028,6 +2022,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Drop out
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -2046,12 +2046,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Extra guy
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -2062,6 +2056,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Extra guy
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -2180,23 +2180,23 @@
                   <table class="table table-striped table-bordered dataTable margin-0">
                      <thead class="background-color-medium-gray text-color-gray font-weight-normal">
                         <tr>
-                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,1)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,1)" style="width: 15%;">
+                              Team
+                              <span class="icon-sort unsorted">
+                              </span>
+                           </th>
+                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
                               Giver
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,3)" style="width: 15%;">
                               Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,3)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,4)" style="width: 15%;">
                               Recipient
-                              <span class="icon-sort unsorted">
-                              </span>
-                           </th>
-                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,4)" style="width: 15%;">
-                              Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
@@ -2215,12 +2215,6 @@
                      <tbody>
                         <tr>
                            <td class="middlealign">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Alice Betsy
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign">
                               Team 1
                            </td>
                            <td class="middlealign">
@@ -2231,6 +2225,12 @@
                            </td>
                            <td class="middlealign">
                               Team 1
+                           </td>
+                           <td class="middlealign">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Alice Betsy
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space">
                               Team 1
@@ -2247,12 +2247,6 @@
                         </tr>
                         <tr>
                            <td class="middlealign">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Drop out
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign">
                               Team 2
                            </td>
                            <td class="middlealign">
@@ -2263,6 +2257,12 @@
                            </td>
                            <td class="middlealign">
                               Team 2
+                           </td>
+                           <td class="middlealign">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Drop out
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space">
                               Team 2
@@ -2279,12 +2279,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Benny Charles
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 1
                            </td>
                            <td class="middlealign color_neutral">
@@ -2295,6 +2289,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 1
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Benny Charles
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -2313,12 +2313,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Charlie Dávis
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -2329,6 +2323,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Charlie Dávis
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -2347,12 +2347,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Danny Engrid
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -2363,6 +2357,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Danny Engrid
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -2381,12 +2381,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Extra guy
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -2397,6 +2391,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Extra guy
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>

--- a/src/test/resources/pages/instructorFeedbackResultsPageOpen.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageOpen.html
@@ -2909,7 +2909,7 @@
                         <a href="/index.html">
                            TEAMMATES
                         </a>
-                        V4.18]
+                        V${version}]
                      </span>
                   </div>
                   <div class="col-md-8">

--- a/src/test/resources/pages/instructorFeedbackResultsPageOpen.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageOpen.html
@@ -383,23 +383,23 @@
                         <table class="table table-striped table-bordered dataTable margin-0">
                            <thead class="background-color-medium-gray text-color-gray font-weight-normal">
                               <tr>
-                                 <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,1)" style="width: 15%;">
+                                 <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,1)" style="width: 15%;">
+                                    Team
+                                    <span class="icon-sort unsorted">
+                                    </span>
+                                 </th>
+                                 <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
                                     Giver
                                     <span class="icon-sort unsorted">
                                     </span>
                                  </th>
-                                 <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                 <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,3)" style="width: 15%;">
                                     Team
                                     <span class="icon-sort unsorted">
                                     </span>
                                  </th>
-                                 <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                 <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,4)" style="width: 15%;">
                                     Recipient
-                                    <span class="icon-sort unsorted">
-                                    </span>
-                                 </th>
-                                 <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,4)" style="width: 15%;">
-                                    Team
                                     <span class="icon-sort unsorted">
                                     </span>
                                  </th>
@@ -418,6 +418,9 @@
                            <tbody>
                               <tr>
                                  <td class="middlealign">
+                                    Team 1
+                                 </td>
+                                 <td class="middlealign">
                                     <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                        Alice Betsy
                                        <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
@@ -431,9 +434,6 @@
                                        Benny Charles
                                        <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                                     </div>
-                                 </td>
-                                 <td class="middlealign">
-                                    Team 1
                                  </td>
                                  <td class="text-preserve-space">
                                     2 Response to Benny.
@@ -450,22 +450,22 @@
                               </tr>
                               <tr>
                                  <td class="middlealign">
+                                    Team 1
+                                 </td>
+                                 <td class="middlealign">
                                     <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                        Alice Betsy
                                        <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                                     </div>
                                  </td>
                                  <td class="middlealign">
-                                    Team 1
+                                    Team 2
                                  </td>
                                  <td class="middlealign">
                                     <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                        Drop out
                                        <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                                     </div>
-                                 </td>
-                                 <td class="middlealign">
-                                    Team 2
                                  </td>
                                  <td class="text-preserve-space">
                                     Response to Dropout.
@@ -482,22 +482,22 @@
                               </tr>
                               <tr>
                                  <td class="middlealign">
+                                    Team 1
+                                 </td>
+                                 <td class="middlealign">
                                     <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                        Benny Charles
                                        <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                                     </div>
                                  </td>
                                  <td class="middlealign">
-                                    Team 1
+                                    Team 2
                                  </td>
                                  <td class="middlealign">
                                     <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                        Charlie Dávis
                                        <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                                     </div>
-                                 </td>
-                                 <td class="middlealign">
-                                    Team 2
                                  </td>
                                  <td class="text-preserve-space">
                                     4 Response to Charlie.
@@ -514,22 +514,22 @@
                               </tr>
                               <tr>
                                  <td class="middlealign">
+                                    Team 1
+                                 </td>
+                                 <td class="middlealign">
                                     <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                        Benny Charles
                                        <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                                     </div>
                                  </td>
                                  <td class="middlealign">
-                                    Team 1
+                                    Team 2
                                  </td>
                                  <td class="middlealign">
                                     <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                        Danny Engrid
                                        <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                                     </div>
-                                 </td>
-                                 <td class="middlealign">
-                                    Team 2
                                  </td>
                                  <td class="text-preserve-space">
                                     1 Response to Danny.
@@ -546,22 +546,22 @@
                               </tr>
                               <tr>
                                  <td class="middlealign">
+                                    Team 2
+                                 </td>
+                                 <td class="middlealign">
                                     <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                        Charlie Dávis
                                        <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                                     </div>
                                  </td>
                                  <td class="middlealign">
-                                    Team 2
+                                    Team 3
                                  </td>
                                  <td class="middlealign">
                                     <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                        Emily
                                        <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                                     </div>
-                                 </td>
-                                 <td class="middlealign">
-                                    Team 3
                                  </td>
                                  <td class="text-preserve-space">
                                     3 Response to Emily.
@@ -578,22 +578,22 @@
                               </tr>
                               <tr>
                                  <td class="middlealign">
+                                    Team 2
+                                 </td>
+                                 <td class="middlealign">
                                     <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                        Drop out
                                        <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                                     </div>
                                  </td>
                                  <td class="middlealign">
-                                    Team 2
+                                    Team 1
                                  </td>
                                  <td class="middlealign">
                                     <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                        Alice Betsy
                                        <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                                     </div>
-                                 </td>
-                                 <td class="middlealign">
-                                    Team 1
                                  </td>
                                  <td class="text-preserve-space">
                                     Response to Alice from Dropout.
@@ -610,22 +610,22 @@
                               </tr>
                               <tr>
                                  <td class="middlealign">
+                                    Team 2
+                                 </td>
+                                 <td class="middlealign">
                                     <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                        Drop out
                                        <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                                     </div>
                                  </td>
                                  <td class="middlealign">
-                                    Team 2
+                                    Team 1
                                  </td>
                                  <td class="middlealign">
                                     <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                        Benny Charles
                                        <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                                     </div>
-                                 </td>
-                                 <td class="middlealign">
-                                    Team 1
                                  </td>
                                  <td class="text-preserve-space">
                                     Response to Benny from Dropout.
@@ -642,6 +642,9 @@
                               </tr>
                               <tr>
                                  <td class="middlealign">
+                                    Team 2
+                                 </td>
+                                 <td class="middlealign">
                                     <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                        Drop out
                                        <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
@@ -655,9 +658,6 @@
                                        Danny Engrid
                                        <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                                     </div>
-                                 </td>
-                                 <td class="middlealign">
-                                    Team 2
                                  </td>
                                  <td class="text-preserve-space">
                                     Response to Danny from Dropout.
@@ -711,23 +711,23 @@
                         <table class="table table-striped table-bordered dataTable margin-0">
                            <thead class="background-color-medium-gray text-color-gray font-weight-normal">
                               <tr>
-                                 <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,1)" style="width: 15%;">
+                                 <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,1)" style="width: 15%;">
+                                    Team
+                                    <span class="icon-sort unsorted">
+                                    </span>
+                                 </th>
+                                 <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
                                     Giver
                                     <span class="icon-sort unsorted">
                                     </span>
                                  </th>
-                                 <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                 <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,3)" style="width: 15%;">
                                     Team
                                     <span class="icon-sort unsorted">
                                     </span>
                                  </th>
-                                 <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                 <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,4)" style="width: 15%;">
                                     Recipient
-                                    <span class="icon-sort unsorted">
-                                    </span>
-                                 </th>
-                                 <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,4)" style="width: 15%;">
-                                    Team
                                     <span class="icon-sort unsorted">
                                     </span>
                                  </th>
@@ -746,12 +746,6 @@
                            <tbody>
                               <tr>
                                  <td class="middlealign">
-                                    <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                       Alice Betsy
-                                       <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                                    </div>
-                                 </td>
-                                 <td class="middlealign">
                                     Team 1
                                  </td>
                                  <td class="middlealign">
@@ -762,6 +756,12 @@
                                  </td>
                                  <td class="middlealign">
                                     Team 1
+                                 </td>
+                                 <td class="middlealign">
+                                    <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                       Alice Betsy
+                                       <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                                    </div>
                                  </td>
                                  <td class="text-preserve-space">
                                     Alice self feedback.
@@ -778,12 +778,6 @@
                               </tr>
                               <tr class="pending_response_row">
                                  <td class="middlealign color_neutral">
-                                    <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                       Benny Charles
-                                       <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                                    </div>
-                                 </td>
-                                 <td class="middlealign color_neutral">
                                     Team 1
                                  </td>
                                  <td class="middlealign color_neutral">
@@ -794,6 +788,12 @@
                                  </td>
                                  <td class="middlealign color_neutral">
                                     Team 1
+                                 </td>
+                                 <td class="middlealign color_neutral">
+                                    <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                       Benny Charles
+                                       <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                                    </div>
                                  </td>
                                  <td class="text-preserve-space color_neutral">
                                     <i>
@@ -812,12 +812,6 @@
                               </tr>
                               <tr class="pending_response_row">
                                  <td class="middlealign color_neutral">
-                                    <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                       Charlie Dávis
-                                       <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                                    </div>
-                                 </td>
-                                 <td class="middlealign color_neutral">
                                     Team 2
                                  </td>
                                  <td class="middlealign color_neutral">
@@ -828,6 +822,12 @@
                                  </td>
                                  <td class="middlealign color_neutral">
                                     Team 2
+                                 </td>
+                                 <td class="middlealign color_neutral">
+                                    <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                       Charlie Dávis
+                                       <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                                    </div>
                                  </td>
                                  <td class="text-preserve-space color_neutral">
                                     <i>
@@ -846,12 +846,6 @@
                               </tr>
                               <tr class="pending_response_row">
                                  <td class="middlealign color_neutral">
-                                    <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                       Danny Engrid
-                                       <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                                    </div>
-                                 </td>
-                                 <td class="middlealign color_neutral">
                                     Team 2
                                  </td>
                                  <td class="middlealign color_neutral">
@@ -862,6 +856,12 @@
                                  </td>
                                  <td class="middlealign color_neutral">
                                     Team 2
+                                 </td>
+                                 <td class="middlealign color_neutral">
+                                    <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                       Danny Engrid
+                                       <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                                    </div>
                                  </td>
                                  <td class="text-preserve-space color_neutral">
                                     <i>
@@ -880,12 +880,6 @@
                               </tr>
                               <tr class="pending_response_row">
                                  <td class="middlealign color_neutral">
-                                    <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                       Drop out
-                                       <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                                    </div>
-                                 </td>
-                                 <td class="middlealign color_neutral">
                                     Team 2
                                  </td>
                                  <td class="middlealign color_neutral">
@@ -896,6 +890,12 @@
                                  </td>
                                  <td class="middlealign color_neutral">
                                     Team 2
+                                 </td>
+                                 <td class="middlealign color_neutral">
+                                    <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                       Drop out
+                                       <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                                    </div>
                                  </td>
                                  <td class="text-preserve-space color_neutral">
                                     <i>
@@ -914,12 +914,6 @@
                               </tr>
                               <tr class="pending_response_row">
                                  <td class="middlealign color_neutral">
-                                    <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                       Extra guy
-                                       <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                                    </div>
-                                 </td>
-                                 <td class="middlealign color_neutral">
                                     Team 2
                                  </td>
                                  <td class="middlealign color_neutral">
@@ -930,6 +924,12 @@
                                  </td>
                                  <td class="middlealign color_neutral">
                                     Team 2
+                                 </td>
+                                 <td class="middlealign color_neutral">
+                                    <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                       Extra guy
+                                       <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                                    </div>
                                  </td>
                                  <td class="text-preserve-space color_neutral">
                                     <i>
@@ -948,12 +948,6 @@
                               </tr>
                               <tr class="pending_response_row">
                                  <td class="middlealign color_neutral">
-                                    <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                       Emily
-                                       <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                                    </div>
-                                 </td>
-                                 <td class="middlealign color_neutral">
                                     Team 3
                                  </td>
                                  <td class="middlealign color_neutral">
@@ -964,6 +958,12 @@
                                  </td>
                                  <td class="middlealign color_neutral">
                                     Team 3
+                                 </td>
+                                 <td class="middlealign color_neutral">
+                                    <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                       Emily
+                                       <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                                    </div>
                                  </td>
                                  <td class="text-preserve-space color_neutral">
                                     <i>
@@ -1019,23 +1019,23 @@
                         <table class="table table-striped table-bordered dataTable margin-0">
                            <thead class="background-color-medium-gray text-color-gray font-weight-normal">
                               <tr>
-                                 <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,1)" style="width: 15%;">
+                                 <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,1)" style="width: 15%;">
+                                    Team
+                                    <span class="icon-sort unsorted">
+                                    </span>
+                                 </th>
+                                 <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
                                     Giver
                                     <span class="icon-sort unsorted">
                                     </span>
                                  </th>
-                                 <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                 <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,3)" style="width: 15%;">
                                     Team
                                     <span class="icon-sort unsorted">
                                     </span>
                                  </th>
-                                 <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                 <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,4)" style="width: 15%;">
                                     Recipient
-                                    <span class="icon-sort unsorted">
-                                    </span>
-                                 </th>
-                                 <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,4)" style="width: 15%;">
-                                    Team
                                     <span class="icon-sort unsorted">
                                     </span>
                                  </th>
@@ -1054,13 +1054,13 @@
                            <tbody>
                               <tr>
                                  <td class="middlealign">
+                                    Instructors
+                                 </td>
+                                 <td class="middlealign">
                                     <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                        Teammates Test
                                        <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                                     </div>
-                                 </td>
-                                 <td class="middlealign">
-                                    Instructors
                                  </td>
                                  <td class="middlealign">
                                     -
@@ -1113,23 +1113,23 @@
                         <table class="table table-striped table-bordered dataTable margin-0">
                            <thead class="background-color-medium-gray text-color-gray font-weight-normal">
                               <tr>
-                                 <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,1)" style="width: 15%;">
+                                 <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,1)" style="width: 15%;">
+                                    Team
+                                    <span class="icon-sort unsorted">
+                                    </span>
+                                 </th>
+                                 <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
                                     Giver
                                     <span class="icon-sort unsorted">
                                     </span>
                                  </th>
-                                 <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                 <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,3)" style="width: 15%;">
                                     Team
                                     <span class="icon-sort unsorted">
                                     </span>
                                  </th>
-                                 <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                 <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,4)" style="width: 15%;">
                                     Recipient
-                                    <span class="icon-sort unsorted">
-                                    </span>
-                                 </th>
-                                 <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,4)" style="width: 15%;">
-                                    Team
                                     <span class="icon-sort unsorted">
                                     </span>
                                  </th>
@@ -1148,14 +1148,14 @@
                            <tbody>
                               <tr>
                                  <td class="middlealign">
+                                 </td>
+                                 <td class="middlealign">
                                     Team 1
                                  </td>
                                  <td class="middlealign">
                                  </td>
                                  <td class="middlealign">
                                     Team 2
-                                 </td>
-                                 <td class="middlealign">
                                  </td>
                                  <td class="text-preserve-space">
                                     Response from team 1 (by alice) to team 2.
@@ -1376,23 +1376,23 @@
                         <table class="table table-striped table-bordered dataTable margin-0">
                            <thead class="background-color-medium-gray text-color-gray font-weight-normal">
                               <tr>
-                                 <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,1)" style="width: 15%;">
+                                 <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,1)" style="width: 15%;">
+                                    Team
+                                    <span class="icon-sort unsorted">
+                                    </span>
+                                 </th>
+                                 <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
                                     Giver
                                     <span class="icon-sort unsorted">
                                     </span>
                                  </th>
-                                 <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                 <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,3)" style="width: 15%;">
                                     Team
                                     <span class="icon-sort unsorted">
                                     </span>
                                  </th>
-                                 <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                 <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,4)" style="width: 15%;">
                                     Recipient
-                                    <span class="icon-sort unsorted">
-                                    </span>
-                                 </th>
-                                 <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,4)" style="width: 15%;">
-                                    Team
                                     <span class="icon-sort unsorted">
                                     </span>
                                  </th>
@@ -1411,12 +1411,6 @@
                            <tbody>
                               <tr>
                                  <td class="middlealign">
-                                    <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                       Alice Betsy
-                                       <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                                    </div>
-                                 </td>
-                                 <td class="middlealign">
                                     Team 1
                                  </td>
                                  <td class="middlealign">
@@ -1427,6 +1421,12 @@
                                  </td>
                                  <td class="middlealign">
                                     Team 1
+                                 </td>
+                                 <td class="middlealign">
+                                    <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                       Alice Betsy
+                                       <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                                    </div>
                                  </td>
                                  <td class="text-preserve-space">
                                     PowerSearch
@@ -1443,12 +1443,6 @@
                               </tr>
                               <tr>
                                  <td class="middlealign">
-                                    <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                       Drop out
-                                       <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                                    </div>
-                                 </td>
-                                 <td class="middlealign">
                                     Team 2
                                  </td>
                                  <td class="middlealign">
@@ -1459,6 +1453,12 @@
                                  </td>
                                  <td class="middlealign">
                                     Team 2
+                                 </td>
+                                 <td class="middlealign">
+                                    <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                       Drop out
+                                       <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                                    </div>
                                  </td>
                                  <td class="text-preserve-space">
                                     PowerSearch
@@ -1475,12 +1475,6 @@
                               </tr>
                               <tr class="pending_response_row">
                                  <td class="middlealign color_neutral">
-                                    <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                       Benny Charles
-                                       <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                                    </div>
-                                 </td>
-                                 <td class="middlealign color_neutral">
                                     Team 1
                                  </td>
                                  <td class="middlealign color_neutral">
@@ -1491,6 +1485,12 @@
                                  </td>
                                  <td class="middlealign color_neutral">
                                     Team 1
+                                 </td>
+                                 <td class="middlealign color_neutral">
+                                    <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                       Benny Charles
+                                       <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                                    </div>
                                  </td>
                                  <td class="text-preserve-space color_neutral">
                                     <i>
@@ -1509,12 +1509,6 @@
                               </tr>
                               <tr class="pending_response_row">
                                  <td class="middlealign color_neutral">
-                                    <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                       Charlie Dávis
-                                       <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                                    </div>
-                                 </td>
-                                 <td class="middlealign color_neutral">
                                     Team 2
                                  </td>
                                  <td class="middlealign color_neutral">
@@ -1525,6 +1519,12 @@
                                  </td>
                                  <td class="middlealign color_neutral">
                                     Team 2
+                                 </td>
+                                 <td class="middlealign color_neutral">
+                                    <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                       Charlie Dávis
+                                       <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                                    </div>
                                  </td>
                                  <td class="text-preserve-space color_neutral">
                                     <i>
@@ -1543,12 +1543,6 @@
                               </tr>
                               <tr class="pending_response_row">
                                  <td class="middlealign color_neutral">
-                                    <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                       Danny Engrid
-                                       <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                                    </div>
-                                 </td>
-                                 <td class="middlealign color_neutral">
                                     Team 2
                                  </td>
                                  <td class="middlealign color_neutral">
@@ -1559,6 +1553,12 @@
                                  </td>
                                  <td class="middlealign color_neutral">
                                     Team 2
+                                 </td>
+                                 <td class="middlealign color_neutral">
+                                    <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                       Danny Engrid
+                                       <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                                    </div>
                                  </td>
                                  <td class="text-preserve-space color_neutral">
                                     <i>
@@ -1577,12 +1577,6 @@
                               </tr>
                               <tr class="pending_response_row">
                                  <td class="middlealign color_neutral">
-                                    <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                       Extra guy
-                                       <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                                    </div>
-                                 </td>
-                                 <td class="middlealign color_neutral">
                                     Team 2
                                  </td>
                                  <td class="middlealign color_neutral">
@@ -1593,6 +1587,12 @@
                                  </td>
                                  <td class="middlealign color_neutral">
                                     Team 2
+                                 </td>
+                                 <td class="middlealign color_neutral">
+                                    <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                       Extra guy
+                                       <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                                    </div>
                                  </td>
                                  <td class="text-preserve-space color_neutral">
                                     <i>
@@ -1611,12 +1611,6 @@
                               </tr>
                               <tr class="pending_response_row">
                                  <td class="middlealign color_neutral">
-                                    <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                       Emily
-                                       <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                                    </div>
-                                 </td>
-                                 <td class="middlealign color_neutral">
                                     Team 3
                                  </td>
                                  <td class="middlealign color_neutral">
@@ -1627,6 +1621,12 @@
                                  </td>
                                  <td class="middlealign color_neutral">
                                     Team 3
+                                 </td>
+                                 <td class="middlealign color_neutral">
+                                    <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                       Emily
+                                       <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                                    </div>
                                  </td>
                                  <td class="text-preserve-space color_neutral">
                                     <i>
@@ -1779,23 +1779,23 @@
                         <table class="table table-striped table-bordered dataTable margin-0">
                            <thead class="background-color-medium-gray text-color-gray font-weight-normal">
                               <tr>
-                                 <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,1)" style="width: 15%;">
+                                 <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,1)" style="width: 15%;">
+                                    Team
+                                    <span class="icon-sort unsorted">
+                                    </span>
+                                 </th>
+                                 <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
                                     Giver
                                     <span class="icon-sort unsorted">
                                     </span>
                                  </th>
-                                 <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                 <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,3)" style="width: 15%;">
                                     Team
                                     <span class="icon-sort unsorted">
                                     </span>
                                  </th>
-                                 <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                 <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,4)" style="width: 15%;">
                                     Recipient
-                                    <span class="icon-sort unsorted">
-                                    </span>
-                                 </th>
-                                 <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,4)" style="width: 15%;">
-                                    Team
                                     <span class="icon-sort unsorted">
                                     </span>
                                  </th>
@@ -1814,12 +1814,6 @@
                            <tbody>
                               <tr>
                                  <td class="middlealign">
-                                    <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                       Alice Betsy
-                                       <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                                    </div>
-                                 </td>
-                                 <td class="middlealign">
                                     Team 1
                                  </td>
                                  <td class="middlealign">
@@ -1830,6 +1824,12 @@
                                  </td>
                                  <td class="middlealign">
                                     Team 1
+                                 </td>
+                                 <td class="middlealign">
+                                    <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                       Alice Betsy
+                                       <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                                    </div>
                                  </td>
                                  <td class="text-preserve-space">
                                     <ul class="selectedOptionsList">
@@ -1853,12 +1853,6 @@
                               </tr>
                               <tr>
                                  <td class="middlealign">
-                                    <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                       Benny Charles
-                                       <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                                    </div>
-                                 </td>
-                                 <td class="middlealign">
                                     Team 1
                                  </td>
                                  <td class="middlealign">
@@ -1869,6 +1863,12 @@
                                  </td>
                                  <td class="middlealign">
                                     Team 1
+                                 </td>
+                                 <td class="middlealign">
+                                    <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                       Benny Charles
+                                       <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                                    </div>
                                  </td>
                                  <td class="text-preserve-space">
                                  </td>
@@ -1884,12 +1884,6 @@
                               </tr>
                               <tr class="pending_response_row">
                                  <td class="middlealign color_neutral">
-                                    <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                       Charlie Dávis
-                                       <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                                    </div>
-                                 </td>
-                                 <td class="middlealign color_neutral">
                                     Team 2
                                  </td>
                                  <td class="middlealign color_neutral">
@@ -1900,6 +1894,12 @@
                                  </td>
                                  <td class="middlealign color_neutral">
                                     Team 2
+                                 </td>
+                                 <td class="middlealign color_neutral">
+                                    <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                       Charlie Dávis
+                                       <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                                    </div>
                                  </td>
                                  <td class="text-preserve-space color_neutral">
                                     <i>
@@ -1918,12 +1918,6 @@
                               </tr>
                               <tr class="pending_response_row">
                                  <td class="middlealign color_neutral">
-                                    <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                       Danny Engrid
-                                       <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                                    </div>
-                                 </td>
-                                 <td class="middlealign color_neutral">
                                     Team 2
                                  </td>
                                  <td class="middlealign color_neutral">
@@ -1934,6 +1928,12 @@
                                  </td>
                                  <td class="middlealign color_neutral">
                                     Team 2
+                                 </td>
+                                 <td class="middlealign color_neutral">
+                                    <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                       Danny Engrid
+                                       <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                                    </div>
                                  </td>
                                  <td class="text-preserve-space color_neutral">
                                     <i>
@@ -1952,12 +1952,6 @@
                               </tr>
                               <tr class="pending_response_row">
                                  <td class="middlealign color_neutral">
-                                    <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                       Drop out
-                                       <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                                    </div>
-                                 </td>
-                                 <td class="middlealign color_neutral">
                                     Team 2
                                  </td>
                                  <td class="middlealign color_neutral">
@@ -1968,6 +1962,12 @@
                                  </td>
                                  <td class="middlealign color_neutral">
                                     Team 2
+                                 </td>
+                                 <td class="middlealign color_neutral">
+                                    <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                       Drop out
+                                       <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                                    </div>
                                  </td>
                                  <td class="text-preserve-space color_neutral">
                                     <i>
@@ -1986,12 +1986,6 @@
                               </tr>
                               <tr class="pending_response_row">
                                  <td class="middlealign color_neutral">
-                                    <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                       Extra guy
-                                       <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                                    </div>
-                                 </td>
-                                 <td class="middlealign color_neutral">
                                     Team 2
                                  </td>
                                  <td class="middlealign color_neutral">
@@ -2002,6 +1996,12 @@
                                  </td>
                                  <td class="middlealign color_neutral">
                                     Team 2
+                                 </td>
+                                 <td class="middlealign color_neutral">
+                                    <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                       Extra guy
+                                       <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                                    </div>
                                  </td>
                                  <td class="text-preserve-space color_neutral">
                                     <i>
@@ -2020,12 +2020,6 @@
                               </tr>
                               <tr class="pending_response_row">
                                  <td class="middlealign color_neutral">
-                                    <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                       Emily
-                                       <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                                    </div>
-                                 </td>
-                                 <td class="middlealign color_neutral">
                                     Team 3
                                  </td>
                                  <td class="middlealign color_neutral">
@@ -2036,6 +2030,12 @@
                                  </td>
                                  <td class="middlealign color_neutral">
                                     Team 3
+                                 </td>
+                                 <td class="middlealign color_neutral">
+                                    <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                       Emily
+                                       <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                                    </div>
                                  </td>
                                  <td class="text-preserve-space color_neutral">
                                     <i>
@@ -2143,23 +2143,23 @@
                         <table class="table table-striped table-bordered dataTable margin-0">
                            <thead class="background-color-medium-gray text-color-gray font-weight-normal">
                               <tr>
-                                 <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,1)" style="width: 15%;">
+                                 <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,1)" style="width: 15%;">
+                                    Team
+                                    <span class="icon-sort unsorted">
+                                    </span>
+                                 </th>
+                                 <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
                                     Giver
                                     <span class="icon-sort unsorted">
                                     </span>
                                  </th>
-                                 <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                 <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,3)" style="width: 15%;">
                                     Team
                                     <span class="icon-sort unsorted">
                                     </span>
                                  </th>
-                                 <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                 <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,4)" style="width: 15%;">
                                     Recipient
-                                    <span class="icon-sort unsorted">
-                                    </span>
-                                 </th>
-                                 <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,4)" style="width: 15%;">
-                                    Team
                                     <span class="icon-sort unsorted">
                                     </span>
                                  </th>
@@ -2178,12 +2178,6 @@
                            <tbody>
                               <tr>
                                  <td class="middlealign">
-                                    <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                       Alice Betsy
-                                       <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                                    </div>
-                                 </td>
-                                 <td class="middlealign">
                                     Team 1
                                  </td>
                                  <td class="middlealign">
@@ -2194,6 +2188,12 @@
                                  </td>
                                  <td class="middlealign">
                                     Team 1
+                                 </td>
+                                 <td class="middlealign">
+                                    <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                       Alice Betsy
+                                       <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                                    </div>
                                  </td>
                                  <td class="text-preserve-space">
                                     Danny
@@ -2210,12 +2210,6 @@
                               </tr>
                               <tr class="pending_response_row">
                                  <td class="middlealign color_neutral">
-                                    <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                       Benny Charles
-                                       <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                                    </div>
-                                 </td>
-                                 <td class="middlealign color_neutral">
                                     Team 1
                                  </td>
                                  <td class="middlealign color_neutral">
@@ -2226,6 +2220,12 @@
                                  </td>
                                  <td class="middlealign color_neutral">
                                     Team 1
+                                 </td>
+                                 <td class="middlealign color_neutral">
+                                    <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                       Benny Charles
+                                       <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                                    </div>
                                  </td>
                                  <td class="text-preserve-space color_neutral">
                                     <i>
@@ -2244,12 +2244,6 @@
                               </tr>
                               <tr class="pending_response_row">
                                  <td class="middlealign color_neutral">
-                                    <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                       Charlie Dávis
-                                       <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                                    </div>
-                                 </td>
-                                 <td class="middlealign color_neutral">
                                     Team 2
                                  </td>
                                  <td class="middlealign color_neutral">
@@ -2260,6 +2254,12 @@
                                  </td>
                                  <td class="middlealign color_neutral">
                                     Team 2
+                                 </td>
+                                 <td class="middlealign color_neutral">
+                                    <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                       Charlie Dávis
+                                       <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                                    </div>
                                  </td>
                                  <td class="text-preserve-space color_neutral">
                                     <i>
@@ -2278,12 +2278,6 @@
                               </tr>
                               <tr class="pending_response_row">
                                  <td class="middlealign color_neutral">
-                                    <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                       Danny Engrid
-                                       <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                                    </div>
-                                 </td>
-                                 <td class="middlealign color_neutral">
                                     Team 2
                                  </td>
                                  <td class="middlealign color_neutral">
@@ -2294,6 +2288,12 @@
                                  </td>
                                  <td class="middlealign color_neutral">
                                     Team 2
+                                 </td>
+                                 <td class="middlealign color_neutral">
+                                    <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                       Danny Engrid
+                                       <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                                    </div>
                                  </td>
                                  <td class="text-preserve-space color_neutral">
                                     <i>
@@ -2312,12 +2312,6 @@
                               </tr>
                               <tr class="pending_response_row">
                                  <td class="middlealign color_neutral">
-                                    <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                       Drop out
-                                       <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                                    </div>
-                                 </td>
-                                 <td class="middlealign color_neutral">
                                     Team 2
                                  </td>
                                  <td class="middlealign color_neutral">
@@ -2328,6 +2322,12 @@
                                  </td>
                                  <td class="middlealign color_neutral">
                                     Team 2
+                                 </td>
+                                 <td class="middlealign color_neutral">
+                                    <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                       Drop out
+                                       <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                                    </div>
                                  </td>
                                  <td class="text-preserve-space color_neutral">
                                     <i>
@@ -2346,12 +2346,6 @@
                               </tr>
                               <tr class="pending_response_row">
                                  <td class="middlealign color_neutral">
-                                    <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                       Extra guy
-                                       <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                                    </div>
-                                 </td>
-                                 <td class="middlealign color_neutral">
                                     Team 2
                                  </td>
                                  <td class="middlealign color_neutral">
@@ -2362,6 +2356,12 @@
                                  </td>
                                  <td class="middlealign color_neutral">
                                     Team 2
+                                 </td>
+                                 <td class="middlealign color_neutral">
+                                    <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                       Extra guy
+                                       <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                                    </div>
                                  </td>
                                  <td class="text-preserve-space color_neutral">
                                     <i>
@@ -2380,12 +2380,6 @@
                               </tr>
                               <tr class="pending_response_row">
                                  <td class="middlealign color_neutral">
-                                    <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                       Emily
-                                       <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                                    </div>
-                                 </td>
-                                 <td class="middlealign color_neutral">
                                     Team 3
                                  </td>
                                  <td class="middlealign color_neutral">
@@ -2396,6 +2390,12 @@
                                  </td>
                                  <td class="middlealign color_neutral">
                                     Team 3
+                                 </td>
+                                 <td class="middlealign color_neutral">
+                                    <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                       Emily
+                                       <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                                    </div>
                                  </td>
                                  <td class="text-preserve-space color_neutral">
                                     <i>
@@ -2514,23 +2514,23 @@
                         <table class="table table-striped table-bordered dataTable margin-0">
                            <thead class="background-color-medium-gray text-color-gray font-weight-normal">
                               <tr>
-                                 <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,1)" style="width: 15%;">
+                                 <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,1)" style="width: 15%;">
+                                    Team
+                                    <span class="icon-sort unsorted">
+                                    </span>
+                                 </th>
+                                 <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
                                     Giver
                                     <span class="icon-sort unsorted">
                                     </span>
                                  </th>
-                                 <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                 <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,3)" style="width: 15%;">
                                     Team
                                     <span class="icon-sort unsorted">
                                     </span>
                                  </th>
-                                 <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                 <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,4)" style="width: 15%;">
                                     Recipient
-                                    <span class="icon-sort unsorted">
-                                    </span>
-                                 </th>
-                                 <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,4)" style="width: 15%;">
-                                    Team
                                     <span class="icon-sort unsorted">
                                     </span>
                                  </th>
@@ -2549,12 +2549,6 @@
                            <tbody>
                               <tr>
                                  <td class="middlealign">
-                                    <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                       Alice Betsy
-                                       <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                                    </div>
-                                 </td>
-                                 <td class="middlealign">
                                     Team 1
                                  </td>
                                  <td class="middlealign">
@@ -2565,6 +2559,12 @@
                                  </td>
                                  <td class="middlealign">
                                     Team 1
+                                 </td>
+                                 <td class="middlealign">
+                                    <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                       Alice Betsy
+                                       <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                                    </div>
                                  </td>
                                  <td class="text-preserve-space">
                                     Team 1
@@ -2581,12 +2581,6 @@
                               </tr>
                               <tr>
                                  <td class="middlealign">
-                                    <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                       Drop out
-                                       <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                                    </div>
-                                 </td>
-                                 <td class="middlealign">
                                     Team 2
                                  </td>
                                  <td class="middlealign">
@@ -2597,6 +2591,12 @@
                                  </td>
                                  <td class="middlealign">
                                     Team 2
+                                 </td>
+                                 <td class="middlealign">
+                                    <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                       Drop out
+                                       <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                                    </div>
                                  </td>
                                  <td class="text-preserve-space">
                                     Team 2
@@ -2613,12 +2613,6 @@
                               </tr>
                               <tr class="pending_response_row">
                                  <td class="middlealign color_neutral">
-                                    <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                       Benny Charles
-                                       <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                                    </div>
-                                 </td>
-                                 <td class="middlealign color_neutral">
                                     Team 1
                                  </td>
                                  <td class="middlealign color_neutral">
@@ -2629,6 +2623,12 @@
                                  </td>
                                  <td class="middlealign color_neutral">
                                     Team 1
+                                 </td>
+                                 <td class="middlealign color_neutral">
+                                    <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                       Benny Charles
+                                       <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                                    </div>
                                  </td>
                                  <td class="text-preserve-space color_neutral">
                                     <i>
@@ -2647,12 +2647,6 @@
                               </tr>
                               <tr class="pending_response_row">
                                  <td class="middlealign color_neutral">
-                                    <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                       Charlie Dávis
-                                       <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                                    </div>
-                                 </td>
-                                 <td class="middlealign color_neutral">
                                     Team 2
                                  </td>
                                  <td class="middlealign color_neutral">
@@ -2663,6 +2657,12 @@
                                  </td>
                                  <td class="middlealign color_neutral">
                                     Team 2
+                                 </td>
+                                 <td class="middlealign color_neutral">
+                                    <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                       Charlie Dávis
+                                       <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                                    </div>
                                  </td>
                                  <td class="text-preserve-space color_neutral">
                                     <i>
@@ -2681,12 +2681,6 @@
                               </tr>
                               <tr class="pending_response_row">
                                  <td class="middlealign color_neutral">
-                                    <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                       Danny Engrid
-                                       <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                                    </div>
-                                 </td>
-                                 <td class="middlealign color_neutral">
                                     Team 2
                                  </td>
                                  <td class="middlealign color_neutral">
@@ -2697,6 +2691,12 @@
                                  </td>
                                  <td class="middlealign color_neutral">
                                     Team 2
+                                 </td>
+                                 <td class="middlealign color_neutral">
+                                    <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                       Danny Engrid
+                                       <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                                    </div>
                                  </td>
                                  <td class="text-preserve-space color_neutral">
                                     <i>
@@ -2715,12 +2715,6 @@
                               </tr>
                               <tr class="pending_response_row">
                                  <td class="middlealign color_neutral">
-                                    <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                       Extra guy
-                                       <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                                    </div>
-                                 </td>
-                                 <td class="middlealign color_neutral">
                                     Team 2
                                  </td>
                                  <td class="middlealign color_neutral">
@@ -2731,6 +2725,12 @@
                                  </td>
                                  <td class="middlealign color_neutral">
                                     Team 2
+                                 </td>
+                                 <td class="middlealign color_neutral">
+                                    <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                       Extra guy
+                                       <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                                    </div>
                                  </td>
                                  <td class="text-preserve-space color_neutral">
                                     <i>
@@ -2749,12 +2749,6 @@
                               </tr>
                               <tr class="pending_response_row">
                                  <td class="middlealign color_neutral">
-                                    <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                       Emily
-                                       <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                                    </div>
-                                 </td>
-                                 <td class="middlealign color_neutral">
                                     Team 3
                                  </td>
                                  <td class="middlealign color_neutral">
@@ -2765,6 +2759,12 @@
                                  </td>
                                  <td class="middlealign color_neutral">
                                     Team 3
+                                 </td>
+                                 <td class="middlealign color_neutral">
+                                    <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                       Emily
+                                       <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                                    </div>
                                  </td>
                                  <td class="text-preserve-space color_neutral">
                                     <i>
@@ -2909,7 +2909,7 @@
                         <a href="/index.html">
                            TEAMMATES
                         </a>
-                        V${version}]
+                        V4.18]
                      </span>
                   </div>
                   <div class="col-md-8">

--- a/src/test/resources/pages/instructorFeedbackResultsPageOpenViewForHelperTwo.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageOpenViewForHelperTwo.html
@@ -273,23 +273,23 @@
                   <table class="table table-striped table-bordered dataTable margin-0">
                      <thead class="background-color-medium-gray text-color-gray font-weight-normal">
                         <tr>
-                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,1)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,1)" style="width: 15%;">
+                              Team
+                              <span class="icon-sort unsorted">
+                              </span>
+                           </th>
+                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
                               Giver
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,3)" style="width: 15%;">
                               Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,3)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,4)" style="width: 15%;">
                               Recipient
-                              <span class="icon-sort unsorted">
-                              </span>
-                           </th>
-                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,4)" style="width: 15%;">
-                              Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
@@ -308,6 +308,9 @@
                      <tbody>
                         <tr>
                            <td class="middlealign">
+                              Team 1
+                           </td>
+                           <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
                                  Alice Betsy
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
@@ -321,9 +324,6 @@
                                  Benny Charles
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign">
-                              Team 1
                            </td>
                            <td class="text-preserve-space">
                               2 Response to Benny.
@@ -340,22 +340,22 @@
                         </tr>
                         <tr>
                            <td class="middlealign">
+                              Team 1
+                           </td>
+                           <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
                                  Alice Betsy
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
                            <td class="middlealign">
-                              Team 1
+                              Team 2
                            </td>
                            <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
                                  Drop out
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign">
-                              Team 2
                            </td>
                            <td class="text-preserve-space">
                               Response to Dropout.
@@ -372,22 +372,22 @@
                         </tr>
                         <tr>
                            <td class="middlealign">
+                              Team 1
+                           </td>
+                           <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
                                  Benny Charles
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
                            <td class="middlealign">
-                              Team 1
+                              Team 2
                            </td>
                            <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
                                  Charlie Dávis
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign">
-                              Team 2
                            </td>
                            <td class="text-preserve-space">
                               4 Response to Charlie.
@@ -404,22 +404,22 @@
                         </tr>
                         <tr>
                            <td class="middlealign">
+                              Team 1
+                           </td>
+                           <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
                                  Benny Charles
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
                            <td class="middlealign">
-                              Team 1
+                              Team 2
                            </td>
                            <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
                                  Danny Engrid
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign">
-                              Team 2
                            </td>
                            <td class="text-preserve-space">
                               1 Response to Danny.
@@ -436,22 +436,22 @@
                         </tr>
                         <tr>
                            <td class="middlealign">
+                              Team 2
+                           </td>
+                           <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
                                  Drop out
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
                            <td class="middlealign">
-                              Team 2
+                              Team 1
                            </td>
                            <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
                                  Alice Betsy
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign">
-                              Team 1
                            </td>
                            <td class="text-preserve-space">
                               Response to Alice from Dropout.
@@ -468,22 +468,22 @@
                         </tr>
                         <tr>
                            <td class="middlealign">
+                              Team 2
+                           </td>
+                           <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
                                  Drop out
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
                            <td class="middlealign">
-                              Team 2
+                              Team 1
                            </td>
                            <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
                                  Benny Charles
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign">
-                              Team 1
                            </td>
                            <td class="text-preserve-space">
                               Response to Benny from Dropout.
@@ -500,6 +500,9 @@
                         </tr>
                         <tr>
                            <td class="middlealign">
+                              Team 2
+                           </td>
+                           <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
                                  Drop out
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
@@ -513,9 +516,6 @@
                                  Danny Engrid
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign">
-                              Team 2
                            </td>
                            <td class="text-preserve-space">
                               Response to Danny from Dropout.
@@ -569,23 +569,23 @@
                   <table class="table table-striped table-bordered dataTable margin-0">
                      <thead class="background-color-medium-gray text-color-gray font-weight-normal">
                         <tr>
-                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,1)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,1)" style="width: 15%;">
+                              Team
+                              <span class="icon-sort unsorted">
+                              </span>
+                           </th>
+                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
                               Giver
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,3)" style="width: 15%;">
                               Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,3)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,4)" style="width: 15%;">
                               Recipient
-                              <span class="icon-sort unsorted">
-                              </span>
-                           </th>
-                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,4)" style="width: 15%;">
-                              Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
@@ -604,12 +604,6 @@
                      <tbody>
                         <tr>
                            <td class="middlealign">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
-                                 Alice Betsy
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign">
                               Team 1
                            </td>
                            <td class="middlealign">
@@ -620,6 +614,12 @@
                            </td>
                            <td class="middlealign">
                               Team 1
+                           </td>
+                           <td class="middlealign">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
+                                 Alice Betsy
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space">
                               Alice self feedback.
@@ -636,12 +636,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
-                                 Benny Charles
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 1
                            </td>
                            <td class="middlealign color_neutral">
@@ -652,6 +646,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 1
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
+                                 Benny Charles
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -670,12 +670,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
-                                 Charlie Dávis
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -686,6 +680,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
+                                 Charlie Dávis
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -704,12 +704,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
-                                 Danny Engrid
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -720,6 +714,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
+                                 Danny Engrid
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -738,12 +738,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
-                                 Drop out
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -754,6 +748,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
+                                 Drop out
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -772,12 +772,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
-                                 Extra guy
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -788,6 +782,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
+                                 Extra guy
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -806,12 +806,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
-                                 Emily
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 3
                            </td>
                            <td class="middlealign color_neutral">
@@ -822,6 +816,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 3
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
+                                 Emily
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -912,23 +912,23 @@
                   <table class="table table-striped table-bordered dataTable margin-0">
                      <thead class="background-color-medium-gray text-color-gray font-weight-normal">
                         <tr>
-                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,1)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,1)" style="width: 15%;">
+                              Team
+                              <span class="icon-sort unsorted">
+                              </span>
+                           </th>
+                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
                               Giver
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,3)" style="width: 15%;">
                               Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,3)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,4)" style="width: 15%;">
                               Recipient
-                              <span class="icon-sort unsorted">
-                              </span>
-                           </th>
-                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,4)" style="width: 15%;">
-                              Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
@@ -947,14 +947,14 @@
                      <tbody>
                         <tr>
                            <td class="middlealign">
+                           </td>
+                           <td class="middlealign">
                               Team 1
                            </td>
                            <td class="middlealign">
                            </td>
                            <td class="middlealign">
                               Team 2
-                           </td>
-                           <td class="middlealign">
                            </td>
                            <td class="text-preserve-space">
                               Response from team 1 (by alice) to team 2.
@@ -1175,23 +1175,23 @@
                   <table class="table table-striped table-bordered dataTable margin-0">
                      <thead class="background-color-medium-gray text-color-gray font-weight-normal">
                         <tr>
-                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,1)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,1)" style="width: 15%;">
+                              Team
+                              <span class="icon-sort unsorted">
+                              </span>
+                           </th>
+                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
                               Giver
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,3)" style="width: 15%;">
                               Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,3)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,4)" style="width: 15%;">
                               Recipient
-                              <span class="icon-sort unsorted">
-                              </span>
-                           </th>
-                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,4)" style="width: 15%;">
-                              Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
@@ -1210,12 +1210,6 @@
                      <tbody>
                         <tr>
                            <td class="middlealign">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
-                                 Alice Betsy
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign">
                               Team 1
                            </td>
                            <td class="middlealign">
@@ -1226,6 +1220,12 @@
                            </td>
                            <td class="middlealign">
                               Team 1
+                           </td>
+                           <td class="middlealign">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
+                                 Alice Betsy
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space">
                               PowerSearch
@@ -1242,12 +1242,6 @@
                         </tr>
                         <tr>
                            <td class="middlealign">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
-                                 Drop out
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign">
                               Team 2
                            </td>
                            <td class="middlealign">
@@ -1258,6 +1252,12 @@
                            </td>
                            <td class="middlealign">
                               Team 2
+                           </td>
+                           <td class="middlealign">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
+                                 Drop out
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space">
                               PowerSearch
@@ -1274,12 +1274,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
-                                 Benny Charles
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 1
                            </td>
                            <td class="middlealign color_neutral">
@@ -1290,6 +1284,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 1
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
+                                 Benny Charles
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -1308,12 +1308,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
-                                 Charlie Dávis
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -1324,6 +1318,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
+                                 Charlie Dávis
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -1342,12 +1342,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
-                                 Danny Engrid
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -1358,6 +1352,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
+                                 Danny Engrid
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -1376,12 +1376,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
-                                 Extra guy
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -1392,6 +1386,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
+                                 Extra guy
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -1410,12 +1410,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
-                                 Emily
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 3
                            </td>
                            <td class="middlealign color_neutral">
@@ -1426,6 +1420,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 3
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
+                                 Emily
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -1578,23 +1578,23 @@
                   <table class="table table-striped table-bordered dataTable margin-0">
                      <thead class="background-color-medium-gray text-color-gray font-weight-normal">
                         <tr>
-                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,1)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,1)" style="width: 15%;">
+                              Team
+                              <span class="icon-sort unsorted">
+                              </span>
+                           </th>
+                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
                               Giver
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,3)" style="width: 15%;">
                               Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,3)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,4)" style="width: 15%;">
                               Recipient
-                              <span class="icon-sort unsorted">
-                              </span>
-                           </th>
-                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,4)" style="width: 15%;">
-                              Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
@@ -1613,12 +1613,6 @@
                      <tbody>
                         <tr>
                            <td class="middlealign">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
-                                 Alice Betsy
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign">
                               Team 1
                            </td>
                            <td class="middlealign">
@@ -1629,6 +1623,12 @@
                            </td>
                            <td class="middlealign">
                               Team 1
+                           </td>
+                           <td class="middlealign">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
+                                 Alice Betsy
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space">
                               <ul class="selectedOptionsList">
@@ -1652,12 +1652,6 @@
                         </tr>
                         <tr>
                            <td class="middlealign">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
-                                 Benny Charles
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign">
                               Team 1
                            </td>
                            <td class="middlealign">
@@ -1668,6 +1662,12 @@
                            </td>
                            <td class="middlealign">
                               Team 1
+                           </td>
+                           <td class="middlealign">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
+                                 Benny Charles
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space">
                            </td>
@@ -1683,12 +1683,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
-                                 Charlie Dávis
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -1699,6 +1693,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
+                                 Charlie Dávis
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -1717,12 +1717,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
-                                 Danny Engrid
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -1733,6 +1727,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
+                                 Danny Engrid
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -1751,12 +1751,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
-                                 Drop out
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -1767,6 +1761,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
+                                 Drop out
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -1785,12 +1785,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
-                                 Extra guy
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -1801,6 +1795,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
+                                 Extra guy
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -1819,12 +1819,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
-                                 Emily
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 3
                            </td>
                            <td class="middlealign color_neutral">
@@ -1835,6 +1829,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 3
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
+                                 Emily
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -1942,23 +1942,23 @@
                   <table class="table table-striped table-bordered dataTable margin-0">
                      <thead class="background-color-medium-gray text-color-gray font-weight-normal">
                         <tr>
-                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,1)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,1)" style="width: 15%;">
+                              Team
+                              <span class="icon-sort unsorted">
+                              </span>
+                           </th>
+                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
                               Giver
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,3)" style="width: 15%;">
                               Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,3)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,4)" style="width: 15%;">
                               Recipient
-                              <span class="icon-sort unsorted">
-                              </span>
-                           </th>
-                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,4)" style="width: 15%;">
-                              Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
@@ -1977,12 +1977,6 @@
                      <tbody>
                         <tr>
                            <td class="middlealign">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
-                                 Alice Betsy
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign">
                               Team 1
                            </td>
                            <td class="middlealign">
@@ -1993,6 +1987,12 @@
                            </td>
                            <td class="middlealign">
                               Team 1
+                           </td>
+                           <td class="middlealign">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
+                                 Alice Betsy
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space">
                               Danny
@@ -2009,12 +2009,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
-                                 Benny Charles
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 1
                            </td>
                            <td class="middlealign color_neutral">
@@ -2025,6 +2019,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 1
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
+                                 Benny Charles
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -2043,12 +2043,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
-                                 Charlie Dávis
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -2059,6 +2053,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
+                                 Charlie Dávis
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -2077,12 +2077,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
-                                 Danny Engrid
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -2093,6 +2087,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
+                                 Danny Engrid
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -2111,12 +2111,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
-                                 Drop out
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -2127,6 +2121,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
+                                 Drop out
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -2145,12 +2145,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
-                                 Extra guy
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -2161,6 +2155,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
+                                 Extra guy
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -2179,12 +2179,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
-                                 Emily
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 3
                            </td>
                            <td class="middlealign color_neutral">
@@ -2195,6 +2189,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 3
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
+                                 Emily
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -2313,23 +2313,23 @@
                   <table class="table table-striped table-bordered dataTable margin-0">
                      <thead class="background-color-medium-gray text-color-gray font-weight-normal">
                         <tr>
-                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,1)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,1)" style="width: 15%;">
+                              Team
+                              <span class="icon-sort unsorted">
+                              </span>
+                           </th>
+                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
                               Giver
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,3)" style="width: 15%;">
                               Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,3)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,4)" style="width: 15%;">
                               Recipient
-                              <span class="icon-sort unsorted">
-                              </span>
-                           </th>
-                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,4)" style="width: 15%;">
-                              Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
@@ -2348,12 +2348,6 @@
                      <tbody>
                         <tr>
                            <td class="middlealign">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
-                                 Alice Betsy
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign">
                               Team 1
                            </td>
                            <td class="middlealign">
@@ -2364,6 +2358,12 @@
                            </td>
                            <td class="middlealign">
                               Team 1
+                           </td>
+                           <td class="middlealign">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
+                                 Alice Betsy
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space">
                               Team 1
@@ -2380,12 +2380,6 @@
                         </tr>
                         <tr>
                            <td class="middlealign">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
-                                 Drop out
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign">
                               Team 2
                            </td>
                            <td class="middlealign">
@@ -2396,6 +2390,12 @@
                            </td>
                            <td class="middlealign">
                               Team 2
+                           </td>
+                           <td class="middlealign">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
+                                 Drop out
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space">
                               Team 2
@@ -2412,12 +2412,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
-                                 Benny Charles
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 1
                            </td>
                            <td class="middlealign color_neutral">
@@ -2428,6 +2422,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 1
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
+                                 Benny Charles
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -2446,12 +2446,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
-                                 Charlie Dávis
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -2462,6 +2456,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
+                                 Charlie Dávis
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -2480,12 +2480,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
-                                 Danny Engrid
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -2496,6 +2490,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
+                                 Danny Engrid
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -2514,12 +2514,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
-                                 Extra guy
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -2530,6 +2524,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
+                                 Extra guy
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -2548,12 +2548,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
-                                 Emily
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 3
                            </td>
                            <td class="middlealign color_neutral">
@@ -2564,6 +2558,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 3
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.helper2" data-original-title="" title="">
+                                 Emily
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>

--- a/src/test/resources/pages/instructorFeedbackResultsPageRankGQRView.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageRankGQRView.html
@@ -394,13 +394,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Recipient
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Recipient
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -423,9 +423,9 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Team 1
                                              </td>
                                              <td class="middlealign">
+                                                Team 1
                                              </td>
                                              <td class="text-preserve-space">
                                                 <ul>
@@ -587,13 +587,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Recipient
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Recipient
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -617,10 +617,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Alice Betsy
+                                                Team 1
                                              </td>
                                              <td class="middlealign">
-                                                Team 1
+                                                Alice Betsy
                                              </td>
                                              <td class="text-preserve-space">
                                                 <ul>
@@ -643,10 +643,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Emily F.
+                                                Team 3
                                              </td>
                                              <td class="middlealign">
-                                                Team 3
+                                                Emily F.
                                              </td>
                                              <td class="text-preserve-space">
                                                 <ul>
@@ -762,13 +762,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Recipient
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Recipient
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -792,10 +792,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Alice Betsy
+                                                Team 1
                                              </td>
                                              <td class="middlealign">
-                                                Team 1
+                                                Alice Betsy
                                              </td>
                                              <td class="text-preserve-space">
                                                 1
@@ -811,10 +811,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Danny Engrid
+                                                Team 2
                                              </td>
                                              <td class="middlealign">
-                                                Team 2
+                                                Danny Engrid
                                              </td>
                                              <td class="text-preserve-space">
                                                 2

--- a/src/test/resources/pages/instructorFeedbackResultsPageRankQuestionView.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageRankQuestionView.html
@@ -365,23 +365,23 @@
                   <table class="table table-striped table-bordered dataTable margin-0">
                      <thead class="background-color-medium-gray text-color-gray font-weight-normal">
                         <tr>
-                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,1)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,1)" style="width: 15%;">
+                              Team
+                              <span class="icon-sort unsorted">
+                              </span>
+                           </th>
+                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
                               Giver
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,3)" style="width: 15%;">
                               Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,3)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,4)" style="width: 15%;">
                               Recipient
-                              <span class="icon-sort unsorted">
-                              </span>
-                           </th>
-                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,4)" style="width: 15%;">
-                              Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
@@ -400,18 +400,18 @@
                      <tbody>
                         <tr>
                            <td class="middlealign">
+                              Instructors
+                           </td>
+                           <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=FRankUiT.instructor" data-original-title="" title="">
                                  Teammates Test
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
                            <td class="middlealign">
-                              Instructors
                            </td>
                            <td class="middlealign">
                               Team 1
-                           </td>
-                           <td class="middlealign">
                            </td>
                            <td class="text-preserve-space">
                               <ul>
@@ -590,23 +590,23 @@
                   <table class="table table-striped table-bordered dataTable margin-0">
                      <thead class="background-color-medium-gray text-color-gray font-weight-normal">
                         <tr>
-                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,1)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,1)" style="width: 15%;">
+                              Team
+                              <span class="icon-sort unsorted">
+                              </span>
+                           </th>
+                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
                               Giver
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,3)" style="width: 15%;">
                               Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,3)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,4)" style="width: 15%;">
                               Recipient
-                              <span class="icon-sort unsorted">
-                              </span>
-                           </th>
-                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,4)" style="width: 15%;">
-                              Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
@@ -625,22 +625,22 @@
                      <tbody>
                         <tr>
                            <td class="middlealign">
+                              Instructors
+                           </td>
+                           <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=FRankUiT.instructor" data-original-title="" title="">
                                  Teammates Test
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
                            <td class="middlealign">
-                              Instructors
+                              Team 1
                            </td>
                            <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=FRankUiT.instructor" data-original-title="" title="">
                                  Alice Betsy
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign">
-                              Team 1
                            </td>
                            <td class="text-preserve-space">
                               <ul>
@@ -657,22 +657,22 @@
                         </tr>
                         <tr>
                            <td class="middlealign">
+                              Instructors
+                           </td>
+                           <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=FRankUiT.instructor" data-original-title="" title="">
                                  Teammates Test
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
                            <td class="middlealign">
-                              Instructors
+                              Team 3
                            </td>
                            <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=FRankUiT.instructor" data-original-title="" title="">
                                  Emily F.
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign">
-                              Team 3
                            </td>
                            <td class="text-preserve-space">
                               <ul>
@@ -805,23 +805,23 @@
                   <table class="table table-striped table-bordered dataTable margin-0">
                      <thead class="background-color-medium-gray text-color-gray font-weight-normal">
                         <tr>
-                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,1)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,1)" style="width: 15%;">
+                              Team
+                              <span class="icon-sort unsorted">
+                              </span>
+                           </th>
+                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
                               Giver
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,3)" style="width: 15%;">
                               Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,3)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,4)" style="width: 15%;">
                               Recipient
-                              <span class="icon-sort unsorted">
-                              </span>
-                           </th>
-                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,4)" style="width: 15%;">
-                              Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
@@ -840,22 +840,22 @@
                      <tbody>
                         <tr>
                            <td class="middlealign">
+                              Instructors
+                           </td>
+                           <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=FRankUiT.instructor" data-original-title="" title="">
                                  Teammates Test
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
                            <td class="middlealign">
-                              Instructors
+                              Team 1
                            </td>
                            <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=FRankUiT.instructor" data-original-title="" title="">
                                  Alice Betsy
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign">
-                              Team 1
                            </td>
                            <td class="text-preserve-space">
                               1
@@ -865,22 +865,22 @@
                         </tr>
                         <tr>
                            <td class="middlealign">
+                              Instructors
+                           </td>
+                           <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=FRankUiT.instructor" data-original-title="" title="">
                                  Teammates Test
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
                            <td class="middlealign">
-                              Instructors
+                              Team 2
                            </td>
                            <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=FRankUiT.instructor" data-original-title="" title="">
                                  Danny Engrid
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign">
-                              Team 2
                            </td>
                            <td class="text-preserve-space">
                               2

--- a/src/test/resources/pages/instructorFeedbackResultsPageRankRQGView.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageRankRQGView.html
@@ -416,13 +416,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Giver
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Giver
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -449,10 +449,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Teammates Test
+                                                Instructors
                                              </td>
                                              <td class="middlealign">
-                                                Instructors
+                                                Teammates Test
                                              </td>
                                              <td class="text-preserve-space">
                                                 <ul>
@@ -556,13 +556,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Giver
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Giver
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -589,10 +589,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Teammates Test
+                                                Instructors
                                              </td>
                                              <td class="middlealign">
-                                                Instructors
+                                                Teammates Test
                                              </td>
                                              <td class="text-preserve-space">
                                                 1
@@ -714,13 +714,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Giver
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Giver
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -747,10 +747,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Teammates Test
+                                                Instructors
                                              </td>
                                              <td class="middlealign">
-                                                Instructors
+                                                Teammates Test
                                              </td>
                                              <td class="text-preserve-space">
                                                 2
@@ -892,13 +892,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Giver
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Giver
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -925,10 +925,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Teammates Test
+                                                Instructors
                                              </td>
                                              <td class="middlealign">
-                                                Instructors
+                                                Teammates Test
                                              </td>
                                              <td class="text-preserve-space">
                                                 <ul>
@@ -1187,13 +1187,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Giver
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Giver
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -1220,10 +1220,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Teammates Test
+                                                Instructors
                                              </td>
                                              <td class="middlealign">
-                                                Instructors
+                                                Teammates Test
                                              </td>
                                              <td class="text-preserve-space">
                                                 <ul>

--- a/src/test/resources/pages/instructorFeedbackResultsPageRubricGQRView.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageRubricGQRView.html
@@ -362,13 +362,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Recipient
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Recipient
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -392,10 +392,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Benny Charles
+                                                Team 1
                                              </td>
                                              <td class="middlealign">
-                                                Team 1
+                                                Benny Charles
                                              </td>
                                              <td class="text-preserve-space">
                                                 a) Yes
@@ -424,10 +424,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign color_neutral">
-                                                Alice Betsy
+                                                Team 1
                                              </td>
                                              <td class="middlealign color_neutral">
-                                                Team 1
+                                                Alice Betsy
                                              </td>
                                              <td class="text-preserve-space color_neutral">
                                                 <i>

--- a/src/test/resources/pages/instructorFeedbackResultsPageRubricQuestionView.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageRubricQuestionView.html
@@ -327,23 +327,23 @@
                   <table class="table table-striped table-bordered dataTable margin-0">
                      <thead class="background-color-medium-gray text-color-gray font-weight-normal">
                         <tr>
-                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,1)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,1)" style="width: 15%;">
+                              Team
+                              <span class="icon-sort unsorted">
+                              </span>
+                           </th>
+                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
                               Giver
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,3)" style="width: 15%;">
                               Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,3)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,4)" style="width: 15%;">
                               Recipient
-                              <span class="icon-sort unsorted">
-                              </span>
-                           </th>
-                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,4)" style="width: 15%;">
-                              Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
@@ -362,6 +362,9 @@
                      <tbody>
                         <tr>
                            <td class="middlealign">
+                              Team 1
+                           </td>
+                           <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=FRubricQnUiT.instructor" data-original-title="" title="">
                                  Alice Betsy
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
@@ -375,9 +378,6 @@
                                  Benny Charles
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign">
-                              Team 1
                            </td>
                            <td class="text-preserve-space">
                               a) Yes
@@ -407,12 +407,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=FRubricQnUiT.instructor" data-original-title="" title="">
-                                 Alice Betsy
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 1
                            </td>
                            <td class="middlealign color_neutral">
@@ -423,6 +417,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 1
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=FRubricQnUiT.instructor" data-original-title="" title="">
+                                 Alice Betsy
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -441,6 +441,9 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
+                              Team 1
+                           </td>
+                           <td class="middlealign color_neutral">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=FRubricQnUiT.instructor" data-original-title="" title="">
                                  Benny Charles
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
@@ -454,9 +457,6 @@
                                  Alice Betsy
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign color_neutral">
-                              Team 1
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -475,12 +475,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=FRubricQnUiT.instructor" data-original-title="" title="">
-                                 Benny Charles
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 1
                            </td>
                            <td class="middlealign color_neutral">
@@ -491,6 +485,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 1
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=FRubricQnUiT.instructor" data-original-title="" title="">
+                                 Benny Charles
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>

--- a/src/test/resources/pages/instructorFeedbackResultsPageRubricRQGView.html
+++ b/src/test/resources/pages/instructorFeedbackResultsPageRubricRQGView.html
@@ -356,13 +356,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Giver
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Giver
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -389,10 +389,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Alice Betsy
+                                                Team 1
                                              </td>
                                              <td class="middlealign">
-                                                Team 1
+                                                Alice Betsy
                                              </td>
                                              <td class="text-preserve-space">
                                                 a) Yes
@@ -430,10 +430,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign color_neutral">
-                                                Benny Charles
+                                                Team 1
                                              </td>
                                              <td class="middlealign color_neutral">
-                                                Team 1
+                                                Benny Charles
                                              </td>
                                              <td class="text-preserve-space color_neutral">
                                                 <i>

--- a/src/test/resources/pages/instructorFeedbackResultsSortGiverQuestionRecipient.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortGiverQuestionRecipient.html
@@ -343,13 +343,13 @@
                                                       <th>
                                                          Photo
                                                       </th>
-                                                      <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                         Recipient
+                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                         Team
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
-                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                         Team
+                                                      <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                         Recipient
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
@@ -923,13 +923,13 @@
                                                       <th>
                                                          Photo
                                                       </th>
-                                                      <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                         Recipient
+                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                         Team
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
-                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                         Team
+                                                      <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                         Recipient
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
@@ -953,10 +953,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign">
-                                                         Benny Charles
+                                                         Team 1
                                                       </td>
                                                       <td class="middlealign">
-                                                         Team 1
+                                                         Benny Charles
                                                       </td>
                                                       <td class="text-preserve-space">
                                                          2 Response to Benny.
@@ -972,10 +972,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign">
-                                                         Drop out
+                                                         Team 2
                                                       </td>
                                                       <td class="middlealign">
-                                                         Team 2
+                                                         Drop out
                                                       </td>
                                                       <td class="text-preserve-space">
                                                          Response to Dropout.
@@ -1005,13 +1005,13 @@
                                                       <th>
                                                          Photo
                                                       </th>
-                                                      <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                         Recipient
+                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                         Team
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
-                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                         Team
+                                                      <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                         Recipient
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
@@ -1035,10 +1035,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign">
-                                                         Alice Betsy
+                                                         Team 1
                                                       </td>
                                                       <td class="middlealign">
-                                                         Team 1
+                                                         Alice Betsy
                                                       </td>
                                                       <td class="text-preserve-space">
                                                          Alice self feedback.
@@ -1165,13 +1165,13 @@
                                                       <th>
                                                          Photo
                                                       </th>
-                                                      <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                         Recipient
+                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                         Team
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
-                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                         Team
+                                                      <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                         Recipient
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
@@ -1195,10 +1195,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign">
-                                                         Alice Betsy
+                                                         Team 1
                                                       </td>
                                                       <td class="middlealign">
-                                                         Team 1
+                                                         Alice Betsy
                                                       </td>
                                                       <td class="text-preserve-space">
                                                          PowerSearch
@@ -1325,13 +1325,13 @@
                                                       <th>
                                                          Photo
                                                       </th>
-                                                      <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                         Recipient
+                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                         Team
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
-                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                         Team
+                                                      <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                         Recipient
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
@@ -1355,10 +1355,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign">
-                                                         Alice Betsy
+                                                         Team 1
                                                       </td>
                                                       <td class="middlealign">
-                                                         Team 1
+                                                         Alice Betsy
                                                       </td>
                                                       <td class="text-preserve-space">
                                                          <ul class="selectedOptionsList">
@@ -1447,13 +1447,13 @@
                                                       <th>
                                                          Photo
                                                       </th>
-                                                      <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                         Recipient
+                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                         Team
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
-                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                         Team
+                                                      <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                         Recipient
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
@@ -1477,10 +1477,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign">
-                                                         Alice Betsy
+                                                         Team 1
                                                       </td>
                                                       <td class="middlealign">
-                                                         Team 1
+                                                         Alice Betsy
                                                       </td>
                                                       <td class="text-preserve-space">
                                                          Danny
@@ -1562,13 +1562,13 @@
                                                       <th>
                                                          Photo
                                                       </th>
-                                                      <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                         Recipient
+                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                         Team
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
-                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                         Team
+                                                      <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                         Recipient
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
@@ -1592,10 +1592,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign">
-                                                         Alice Betsy
+                                                         Team 1
                                                       </td>
                                                       <td class="middlealign">
-                                                         Team 1
+                                                         Alice Betsy
                                                       </td>
                                                       <td class="text-preserve-space">
                                                          Team 1
@@ -1656,13 +1656,13 @@
                                                       <th>
                                                          Photo
                                                       </th>
-                                                      <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                         Recipient
+                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                         Team
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
-                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                         Team
+                                                      <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                         Recipient
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
@@ -1686,10 +1686,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign">
-                                                         Charlie Dávis
+                                                         Team 2
                                                       </td>
                                                       <td class="middlealign">
-                                                         Team 2
+                                                         Charlie Dávis
                                                       </td>
                                                       <td class="text-preserve-space">
                                                          4 Response to Charlie.
@@ -1705,10 +1705,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign">
-                                                         Danny Engrid
+                                                         Team 2
                                                       </td>
                                                       <td class="middlealign">
-                                                         Team 2
+                                                         Danny Engrid
                                                       </td>
                                                       <td class="text-preserve-space">
                                                          1 Response to Danny.
@@ -1761,13 +1761,13 @@
                                                       <th>
                                                          Photo
                                                       </th>
-                                                      <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                         Recipient
+                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                         Team
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
-                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                         Team
+                                                      <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                         Recipient
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
@@ -1791,10 +1791,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign">
-                                                         Benny Charles
+                                                         Team 1
                                                       </td>
                                                       <td class="middlealign">
-                                                         Team 1
+                                                         Benny Charles
                                                       </td>
                                                       <td class="text-preserve-space">
                                                       </td>
@@ -1844,13 +1844,13 @@
                                                       <th>
                                                          Photo
                                                       </th>
-                                                      <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                         Recipient
+                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                         Team
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
-                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                         Team
+                                                      <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                         Recipient
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
@@ -1873,9 +1873,9 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign">
-                                                         Team 2
                                                       </td>
                                                       <td class="middlealign">
+                                                         Team 2
                                                       </td>
                                                       <td class="text-preserve-space">
                                                          Response from team 1 (by alice) to team 2.
@@ -2157,13 +2157,13 @@
                                                       <th>
                                                          Photo
                                                       </th>
-                                                      <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                         Recipient
+                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                         Team
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
-                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                         Team
+                                                      <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                         Recipient
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
@@ -2187,10 +2187,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign">
-                                                         Emily
+                                                         Team 3
                                                       </td>
                                                       <td class="middlealign">
-                                                         Team 3
+                                                         Emily
                                                       </td>
                                                       <td class="text-preserve-space">
                                                          3 Response to Emily.
@@ -2251,13 +2251,13 @@
                                                       <th>
                                                          Photo
                                                       </th>
-                                                      <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                         Recipient
+                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                         Team
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
-                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                         Team
+                                                      <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                         Recipient
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
@@ -2281,10 +2281,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign">
-                                                         Alice Betsy
+                                                         Team 1
                                                       </td>
                                                       <td class="middlealign">
-                                                         Team 1
+                                                         Alice Betsy
                                                       </td>
                                                       <td class="text-preserve-space">
                                                          Response to Alice from Dropout.
@@ -2300,10 +2300,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign">
-                                                         Benny Charles
+                                                         Team 1
                                                       </td>
                                                       <td class="middlealign">
-                                                         Team 1
+                                                         Benny Charles
                                                       </td>
                                                       <td class="text-preserve-space">
                                                          Response to Benny from Dropout.
@@ -2319,10 +2319,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign">
-                                                         Danny Engrid
+                                                         Team 2
                                                       </td>
                                                       <td class="middlealign">
-                                                         Team 2
+                                                         Danny Engrid
                                                       </td>
                                                       <td class="text-preserve-space">
                                                          Response to Danny from Dropout.
@@ -2449,13 +2449,13 @@
                                                       <th>
                                                          Photo
                                                       </th>
-                                                      <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                         Recipient
+                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                         Team
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
-                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                         Team
+                                                      <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                         Recipient
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
@@ -2479,10 +2479,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign">
-                                                         Drop out
+                                                         Team 2
                                                       </td>
                                                       <td class="middlealign">
-                                                         Team 2
+                                                         Drop out
                                                       </td>
                                                       <td class="text-preserve-space">
                                                          PowerSearch
@@ -2564,13 +2564,13 @@
                                                       <th>
                                                          Photo
                                                       </th>
-                                                      <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                         Recipient
+                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                         Team
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
-                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                         Team
+                                                      <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                         Recipient
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
@@ -2594,10 +2594,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign">
-                                                         Drop out
+                                                         Team 2
                                                       </td>
                                                       <td class="middlealign">
-                                                         Team 2
+                                                         Drop out
                                                       </td>
                                                       <td class="text-preserve-space">
                                                          Team 2

--- a/src/test/resources/pages/instructorFeedbackResultsSortGiverQuestionRecipientTeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortGiverQuestionRecipientTeam.html
@@ -305,13 +305,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Recipient
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Recipient
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -479,13 +479,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Recipient
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Recipient
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -509,10 +509,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Benny Charles
+                                                Team 1
                                              </td>
                                              <td class="middlealign">
-                                                Team 1
+                                                Benny Charles
                                              </td>
                                              <td class="text-preserve-space">
                                                 2 Response to Benny.
@@ -528,10 +528,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Drop out
+                                                Team 2
                                              </td>
                                              <td class="middlealign">
-                                                Team 2
+                                                Drop out
                                              </td>
                                              <td class="text-preserve-space">
                                                 Response to Dropout.
@@ -561,13 +561,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Recipient
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Recipient
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -591,10 +591,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Alice Betsy
+                                                Team 1
                                              </td>
                                              <td class="middlealign">
-                                                Team 1
+                                                Alice Betsy
                                              </td>
                                              <td class="text-preserve-space">
                                                 Alice self feedback.
@@ -721,13 +721,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Recipient
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Recipient
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -751,10 +751,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Alice Betsy
+                                                Team 1
                                              </td>
                                              <td class="middlealign">
-                                                Team 1
+                                                Alice Betsy
                                              </td>
                                              <td class="text-preserve-space">
                                                 PowerSearch
@@ -881,13 +881,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Recipient
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Recipient
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -911,10 +911,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Alice Betsy
+                                                Team 1
                                              </td>
                                              <td class="middlealign">
-                                                Team 1
+                                                Alice Betsy
                                              </td>
                                              <td class="text-preserve-space">
                                                 <ul class="selectedOptionsList">
@@ -1003,13 +1003,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Recipient
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Recipient
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -1033,10 +1033,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Alice Betsy
+                                                Team 1
                                              </td>
                                              <td class="middlealign">
-                                                Team 1
+                                                Alice Betsy
                                              </td>
                                              <td class="text-preserve-space">
                                                 Danny
@@ -1118,13 +1118,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Recipient
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Recipient
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -1148,10 +1148,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Alice Betsy
+                                                Team 1
                                              </td>
                                              <td class="middlealign">
-                                                Team 1
+                                                Alice Betsy
                                              </td>
                                              <td class="text-preserve-space">
                                                 Team 1
@@ -1212,13 +1212,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Recipient
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Recipient
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -1242,10 +1242,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Charlie Dávis
+                                                Team 2
                                              </td>
                                              <td class="middlealign">
-                                                Team 2
+                                                Charlie Dávis
                                              </td>
                                              <td class="text-preserve-space">
                                                 4 Response to Charlie.
@@ -1261,10 +1261,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Danny Engrid
+                                                Team 2
                                              </td>
                                              <td class="middlealign">
-                                                Team 2
+                                                Danny Engrid
                                              </td>
                                              <td class="text-preserve-space">
                                                 1 Response to Danny.
@@ -1317,13 +1317,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Recipient
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Recipient
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -1347,10 +1347,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Benny Charles
+                                                Team 1
                                              </td>
                                              <td class="middlealign">
-                                                Team 1
+                                                Benny Charles
                                              </td>
                                              <td class="text-preserve-space">
                                              </td>
@@ -1410,13 +1410,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Recipient
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Recipient
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -1440,10 +1440,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Emily
+                                                Team 3
                                              </td>
                                              <td class="middlealign">
-                                                Team 3
+                                                Emily
                                              </td>
                                              <td class="text-preserve-space">
                                                 3 Response to Emily.
@@ -1504,13 +1504,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Recipient
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Recipient
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -1534,10 +1534,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Alice Betsy
+                                                Team 1
                                              </td>
                                              <td class="middlealign">
-                                                Team 1
+                                                Alice Betsy
                                              </td>
                                              <td class="text-preserve-space">
                                                 Response to Alice from Dropout.
@@ -1553,10 +1553,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Benny Charles
+                                                Team 1
                                              </td>
                                              <td class="middlealign">
-                                                Team 1
+                                                Benny Charles
                                              </td>
                                              <td class="text-preserve-space">
                                                 Response to Benny from Dropout.
@@ -1572,10 +1572,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Danny Engrid
+                                                Team 2
                                              </td>
                                              <td class="middlealign">
-                                                Team 2
+                                                Danny Engrid
                                              </td>
                                              <td class="text-preserve-space">
                                                 Response to Danny from Dropout.
@@ -1702,13 +1702,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Recipient
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Recipient
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -1732,10 +1732,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Drop out
+                                                Team 2
                                              </td>
                                              <td class="middlealign">
-                                                Team 2
+                                                Drop out
                                              </td>
                                              <td class="text-preserve-space">
                                                 PowerSearch
@@ -1817,13 +1817,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Recipient
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Recipient
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -1847,10 +1847,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Drop out
+                                                Team 2
                                              </td>
                                              <td class="middlealign">
-                                                Team 2
+                                                Drop out
                                              </td>
                                              <td class="text-preserve-space">
                                                 Team 2
@@ -1901,13 +1901,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Recipient
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Recipient
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -1930,9 +1930,9 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Team 2
                                              </td>
                                              <td class="middlealign">
+                                                Team 2
                                              </td>
                                              <td class="text-preserve-space">
                                                 Response from team 1 (by alice) to team 2.

--- a/src/test/resources/pages/instructorFeedbackResultsSortQuestion.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortQuestion.html
@@ -276,23 +276,23 @@
                   <table class="table table-striped table-bordered dataTable margin-0">
                      <thead class="background-color-medium-gray text-color-gray font-weight-normal">
                         <tr>
-                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,1)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,1)" style="width: 15%;">
+                              Team
+                              <span class="icon-sort unsorted">
+                              </span>
+                           </th>
+                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
                               Giver
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,3)" style="width: 15%;">
                               Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,3)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,4)" style="width: 15%;">
                               Recipient
-                              <span class="icon-sort unsorted">
-                              </span>
-                           </th>
-                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,4)" style="width: 15%;">
-                              Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
@@ -311,6 +311,9 @@
                      <tbody>
                         <tr>
                            <td class="middlealign">
+                              Team 1
+                           </td>
+                           <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Alice Betsy
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
@@ -324,9 +327,6 @@
                                  Benny Charles
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign">
-                              Team 1
                            </td>
                            <td class="text-preserve-space">
                               2 Response to Benny.
@@ -343,22 +343,22 @@
                         </tr>
                         <tr>
                            <td class="middlealign">
+                              Team 1
+                           </td>
+                           <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Alice Betsy
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
                            <td class="middlealign">
-                              Team 1
+                              Team 2
                            </td>
                            <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Drop out
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign">
-                              Team 2
                            </td>
                            <td class="text-preserve-space">
                               Response to Dropout.
@@ -375,22 +375,22 @@
                         </tr>
                         <tr>
                            <td class="middlealign">
+                              Team 1
+                           </td>
+                           <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Benny Charles
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
                            <td class="middlealign">
-                              Team 1
+                              Team 2
                            </td>
                            <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Charlie Dávis
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign">
-                              Team 2
                            </td>
                            <td class="text-preserve-space">
                               4 Response to Charlie.
@@ -407,22 +407,22 @@
                         </tr>
                         <tr>
                            <td class="middlealign">
+                              Team 1
+                           </td>
+                           <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Benny Charles
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
                            <td class="middlealign">
-                              Team 1
+                              Team 2
                            </td>
                            <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Danny Engrid
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign">
-                              Team 2
                            </td>
                            <td class="text-preserve-space">
                               1 Response to Danny.
@@ -439,22 +439,22 @@
                         </tr>
                         <tr>
                            <td class="middlealign">
+                              Team 2
+                           </td>
+                           <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Charlie Dávis
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
                            <td class="middlealign">
-                              Team 2
+                              Team 3
                            </td>
                            <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Emily
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign">
-                              Team 3
                            </td>
                            <td class="text-preserve-space">
                               3 Response to Emily.
@@ -471,22 +471,22 @@
                         </tr>
                         <tr>
                            <td class="middlealign">
+                              Team 2
+                           </td>
+                           <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Drop out
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
                            <td class="middlealign">
-                              Team 2
+                              Team 1
                            </td>
                            <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Alice Betsy
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign">
-                              Team 1
                            </td>
                            <td class="text-preserve-space">
                               Response to Alice from Dropout.
@@ -503,22 +503,22 @@
                         </tr>
                         <tr>
                            <td class="middlealign">
+                              Team 2
+                           </td>
+                           <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Drop out
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
                            <td class="middlealign">
-                              Team 2
+                              Team 1
                            </td>
                            <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Benny Charles
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign">
-                              Team 1
                            </td>
                            <td class="text-preserve-space">
                               Response to Benny from Dropout.
@@ -535,6 +535,9 @@
                         </tr>
                         <tr>
                            <td class="middlealign">
+                              Team 2
+                           </td>
+                           <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Drop out
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
@@ -548,9 +551,6 @@
                                  Danny Engrid
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign">
-                              Team 2
                            </td>
                            <td class="text-preserve-space">
                               Response to Danny from Dropout.
@@ -604,23 +604,23 @@
                   <table class="table table-striped table-bordered dataTable margin-0">
                      <thead class="background-color-medium-gray text-color-gray font-weight-normal">
                         <tr>
-                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,1)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,1)" style="width: 15%;">
+                              Team
+                              <span class="icon-sort unsorted">
+                              </span>
+                           </th>
+                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
                               Giver
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,3)" style="width: 15%;">
                               Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,3)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,4)" style="width: 15%;">
                               Recipient
-                              <span class="icon-sort unsorted">
-                              </span>
-                           </th>
-                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,4)" style="width: 15%;">
-                              Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
@@ -639,12 +639,6 @@
                      <tbody>
                         <tr>
                            <td class="middlealign">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Alice Betsy
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign">
                               Team 1
                            </td>
                            <td class="middlealign">
@@ -655,6 +649,12 @@
                            </td>
                            <td class="middlealign">
                               Team 1
+                           </td>
+                           <td class="middlealign">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Alice Betsy
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space">
                               Alice self feedback.
@@ -671,12 +671,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Benny Charles
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 1
                            </td>
                            <td class="middlealign color_neutral">
@@ -687,6 +681,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 1
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Benny Charles
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -705,12 +705,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Charlie Dávis
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -721,6 +715,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Charlie Dávis
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -739,12 +739,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Danny Engrid
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -755,6 +749,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Danny Engrid
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -773,12 +773,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Drop out
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -789,6 +783,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Drop out
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -807,12 +807,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Extra guy
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -823,6 +817,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Extra guy
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -841,12 +841,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Emily
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 3
                            </td>
                            <td class="middlealign color_neutral">
@@ -857,6 +851,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 3
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Emily
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -912,23 +912,23 @@
                   <table class="table table-striped table-bordered dataTable margin-0">
                      <thead class="background-color-medium-gray text-color-gray font-weight-normal">
                         <tr>
-                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,1)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,1)" style="width: 15%;">
+                              Team
+                              <span class="icon-sort unsorted">
+                              </span>
+                           </th>
+                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
                               Giver
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,3)" style="width: 15%;">
                               Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,3)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,4)" style="width: 15%;">
                               Recipient
-                              <span class="icon-sort unsorted">
-                              </span>
-                           </th>
-                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,4)" style="width: 15%;">
-                              Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
@@ -947,13 +947,13 @@
                      <tbody>
                         <tr>
                            <td class="middlealign">
+                              Instructors
+                           </td>
+                           <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Teammates Test
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign">
-                              Instructors
                            </td>
                            <td class="middlealign">
                               -
@@ -1006,23 +1006,23 @@
                   <table class="table table-striped table-bordered dataTable margin-0">
                      <thead class="background-color-medium-gray text-color-gray font-weight-normal">
                         <tr>
-                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,1)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,1)" style="width: 15%;">
+                              Team
+                              <span class="icon-sort unsorted">
+                              </span>
+                           </th>
+                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
                               Giver
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,3)" style="width: 15%;">
                               Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,3)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,4)" style="width: 15%;">
                               Recipient
-                              <span class="icon-sort unsorted">
-                              </span>
-                           </th>
-                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,4)" style="width: 15%;">
-                              Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
@@ -1041,14 +1041,14 @@
                      <tbody>
                         <tr>
                            <td class="middlealign">
+                           </td>
+                           <td class="middlealign">
                               Team 1
                            </td>
                            <td class="middlealign">
                            </td>
                            <td class="middlealign">
                               Team 2
-                           </td>
-                           <td class="middlealign">
                            </td>
                            <td class="text-preserve-space">
                               Response from team 1 (by alice) to team 2.
@@ -1269,23 +1269,23 @@
                   <table class="table table-striped table-bordered dataTable margin-0">
                      <thead class="background-color-medium-gray text-color-gray font-weight-normal">
                         <tr>
-                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,1)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,1)" style="width: 15%;">
+                              Team
+                              <span class="icon-sort unsorted">
+                              </span>
+                           </th>
+                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
                               Giver
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,3)" style="width: 15%;">
                               Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,3)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,4)" style="width: 15%;">
                               Recipient
-                              <span class="icon-sort unsorted">
-                              </span>
-                           </th>
-                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,4)" style="width: 15%;">
-                              Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
@@ -1304,12 +1304,6 @@
                      <tbody>
                         <tr>
                            <td class="middlealign">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Alice Betsy
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign">
                               Team 1
                            </td>
                            <td class="middlealign">
@@ -1320,6 +1314,12 @@
                            </td>
                            <td class="middlealign">
                               Team 1
+                           </td>
+                           <td class="middlealign">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Alice Betsy
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space">
                               PowerSearch
@@ -1336,12 +1336,6 @@
                         </tr>
                         <tr>
                            <td class="middlealign">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Drop out
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign">
                               Team 2
                            </td>
                            <td class="middlealign">
@@ -1352,6 +1346,12 @@
                            </td>
                            <td class="middlealign">
                               Team 2
+                           </td>
+                           <td class="middlealign">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Drop out
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space">
                               PowerSearch
@@ -1368,12 +1368,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Benny Charles
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 1
                            </td>
                            <td class="middlealign color_neutral">
@@ -1384,6 +1378,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 1
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Benny Charles
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -1402,12 +1402,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Charlie Dávis
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -1418,6 +1412,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Charlie Dávis
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -1436,12 +1436,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Danny Engrid
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -1452,6 +1446,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Danny Engrid
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -1470,12 +1470,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Extra guy
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -1486,6 +1480,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Extra guy
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -1504,12 +1504,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Emily
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 3
                            </td>
                            <td class="middlealign color_neutral">
@@ -1520,6 +1514,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 3
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Emily
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -1672,23 +1672,23 @@
                   <table class="table table-striped table-bordered dataTable margin-0">
                      <thead class="background-color-medium-gray text-color-gray font-weight-normal">
                         <tr>
-                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,1)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,1)" style="width: 15%;">
+                              Team
+                              <span class="icon-sort unsorted">
+                              </span>
+                           </th>
+                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
                               Giver
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,3)" style="width: 15%;">
                               Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,3)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,4)" style="width: 15%;">
                               Recipient
-                              <span class="icon-sort unsorted">
-                              </span>
-                           </th>
-                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,4)" style="width: 15%;">
-                              Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
@@ -1707,12 +1707,6 @@
                      <tbody>
                         <tr>
                            <td class="middlealign">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Alice Betsy
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign">
                               Team 1
                            </td>
                            <td class="middlealign">
@@ -1723,6 +1717,12 @@
                            </td>
                            <td class="middlealign">
                               Team 1
+                           </td>
+                           <td class="middlealign">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Alice Betsy
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space">
                               <ul class="selectedOptionsList">
@@ -1746,12 +1746,6 @@
                         </tr>
                         <tr>
                            <td class="middlealign">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Benny Charles
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign">
                               Team 1
                            </td>
                            <td class="middlealign">
@@ -1762,6 +1756,12 @@
                            </td>
                            <td class="middlealign">
                               Team 1
+                           </td>
+                           <td class="middlealign">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Benny Charles
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space">
                            </td>
@@ -1777,12 +1777,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Charlie Dávis
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -1793,6 +1787,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Charlie Dávis
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -1811,12 +1811,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Danny Engrid
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -1827,6 +1821,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Danny Engrid
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -1845,12 +1845,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Drop out
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -1861,6 +1855,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Drop out
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -1879,12 +1879,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Extra guy
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -1895,6 +1889,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Extra guy
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -1913,12 +1913,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Emily
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 3
                            </td>
                            <td class="middlealign color_neutral">
@@ -1929,6 +1923,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 3
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Emily
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -2036,23 +2036,23 @@
                   <table class="table table-striped table-bordered dataTable margin-0">
                      <thead class="background-color-medium-gray text-color-gray font-weight-normal">
                         <tr>
-                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,1)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,1)" style="width: 15%;">
+                              Team
+                              <span class="icon-sort unsorted">
+                              </span>
+                           </th>
+                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
                               Giver
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,3)" style="width: 15%;">
                               Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,3)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,4)" style="width: 15%;">
                               Recipient
-                              <span class="icon-sort unsorted">
-                              </span>
-                           </th>
-                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,4)" style="width: 15%;">
-                              Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
@@ -2071,12 +2071,6 @@
                      <tbody>
                         <tr>
                            <td class="middlealign">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Alice Betsy
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign">
                               Team 1
                            </td>
                            <td class="middlealign">
@@ -2087,6 +2081,12 @@
                            </td>
                            <td class="middlealign">
                               Team 1
+                           </td>
+                           <td class="middlealign">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Alice Betsy
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space">
                               Danny
@@ -2103,12 +2103,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Benny Charles
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 1
                            </td>
                            <td class="middlealign color_neutral">
@@ -2119,6 +2113,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 1
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Benny Charles
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -2137,12 +2137,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Charlie Dávis
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -2153,6 +2147,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Charlie Dávis
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -2171,12 +2171,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Danny Engrid
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -2187,6 +2181,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Danny Engrid
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -2205,12 +2205,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Drop out
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -2221,6 +2215,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Drop out
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -2239,12 +2239,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Extra guy
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -2255,6 +2249,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Extra guy
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -2273,12 +2273,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Emily
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 3
                            </td>
                            <td class="middlealign color_neutral">
@@ -2289,6 +2283,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 3
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Emily
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -2407,23 +2407,23 @@
                   <table class="table table-striped table-bordered dataTable margin-0">
                      <thead class="background-color-medium-gray text-color-gray font-weight-normal">
                         <tr>
-                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,1)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,1)" style="width: 15%;">
+                              Team
+                              <span class="icon-sort unsorted">
+                              </span>
+                           </th>
+                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
                               Giver
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,3)" style="width: 15%;">
                               Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,3)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,4)" style="width: 15%;">
                               Recipient
-                              <span class="icon-sort unsorted">
-                              </span>
-                           </th>
-                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,4)" style="width: 15%;">
-                              Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
@@ -2442,12 +2442,6 @@
                      <tbody>
                         <tr>
                            <td class="middlealign">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Alice Betsy
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign">
                               Team 1
                            </td>
                            <td class="middlealign">
@@ -2458,6 +2452,12 @@
                            </td>
                            <td class="middlealign">
                               Team 1
+                           </td>
+                           <td class="middlealign">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Alice Betsy
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space">
                               Team 1
@@ -2474,12 +2474,6 @@
                         </tr>
                         <tr>
                            <td class="middlealign">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Drop out
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign">
                               Team 2
                            </td>
                            <td class="middlealign">
@@ -2490,6 +2484,12 @@
                            </td>
                            <td class="middlealign">
                               Team 2
+                           </td>
+                           <td class="middlealign">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Drop out
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space">
                               Team 2
@@ -2506,12 +2506,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Benny Charles
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 1
                            </td>
                            <td class="middlealign color_neutral">
@@ -2522,6 +2516,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 1
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Benny Charles
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -2540,12 +2540,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Charlie Dávis
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -2556,6 +2550,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Charlie Dávis
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -2574,12 +2574,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Danny Engrid
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -2590,6 +2584,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Danny Engrid
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -2608,12 +2608,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Extra guy
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -2624,6 +2618,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Extra guy
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -2642,12 +2642,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Emily
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 3
                            </td>
                            <td class="middlealign color_neutral">
@@ -2658,6 +2652,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 3
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Emily
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>

--- a/src/test/resources/pages/instructorFeedbackResultsSortQuestionSearch.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortQuestionSearch.html
@@ -276,23 +276,23 @@
                   <table class="table table-striped table-bordered dataTable margin-0">
                      <thead class="background-color-medium-gray text-color-gray font-weight-normal">
                         <tr>
-                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,1)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,1)" style="width: 15%;">
+                              Team
+                              <span class="icon-sort unsorted">
+                              </span>
+                           </th>
+                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
                               Giver
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,3)" style="width: 15%;">
                               Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,3)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,4)" style="width: 15%;">
                               Recipient
-                              <span class="icon-sort unsorted">
-                              </span>
-                           </th>
-                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,4)" style="width: 15%;">
-                              Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
@@ -311,6 +311,9 @@
                      <tbody>
                         <tr>
                            <td class="middlealign">
+                              Team 1
+                           </td>
+                           <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Alice Betsy
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
@@ -324,9 +327,6 @@
                                  Benny Charles
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign">
-                              Team 1
                            </td>
                            <td class="text-preserve-space">
                               2 Response to Benny.
@@ -343,22 +343,22 @@
                         </tr>
                         <tr>
                            <td class="middlealign">
+                              Team 1
+                           </td>
+                           <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Alice Betsy
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
                            <td class="middlealign">
-                              Team 1
+                              Team 2
                            </td>
                            <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Drop out
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign">
-                              Team 2
                            </td>
                            <td class="text-preserve-space">
                               Response to Dropout.
@@ -375,22 +375,22 @@
                         </tr>
                         <tr>
                            <td class="middlealign">
+                              Team 1
+                           </td>
+                           <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Benny Charles
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
                            <td class="middlealign">
-                              Team 1
+                              Team 2
                            </td>
                            <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Charlie Dávis
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign">
-                              Team 2
                            </td>
                            <td class="text-preserve-space">
                               4 Response to Charlie.
@@ -407,22 +407,22 @@
                         </tr>
                         <tr>
                            <td class="middlealign">
+                              Team 1
+                           </td>
+                           <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Benny Charles
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
                            <td class="middlealign">
-                              Team 1
+                              Team 2
                            </td>
                            <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Danny Engrid
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign">
-                              Team 2
                            </td>
                            <td class="text-preserve-space">
                               1 Response to Danny.
@@ -439,22 +439,22 @@
                         </tr>
                         <tr>
                            <td class="middlealign">
+                              Team 2
+                           </td>
+                           <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Charlie Dávis
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
                            <td class="middlealign">
-                              Team 2
+                              Team 3
                            </td>
                            <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Emily
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign">
-                              Team 3
                            </td>
                            <td class="text-preserve-space">
                               3 Response to Emily.
@@ -471,22 +471,22 @@
                         </tr>
                         <tr>
                            <td class="middlealign">
+                              Team 2
+                           </td>
+                           <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Drop out
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
                            <td class="middlealign">
-                              Team 2
+                              Team 1
                            </td>
                            <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Alice Betsy
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign">
-                              Team 1
                            </td>
                            <td class="text-preserve-space">
                               Response to Alice from Dropout.
@@ -503,22 +503,22 @@
                         </tr>
                         <tr>
                            <td class="middlealign">
+                              Team 2
+                           </td>
+                           <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Drop out
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
                            <td class="middlealign">
-                              Team 2
+                              Team 1
                            </td>
                            <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Benny Charles
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign">
-                              Team 1
                            </td>
                            <td class="text-preserve-space">
                               Response to Benny from Dropout.
@@ -535,6 +535,9 @@
                         </tr>
                         <tr>
                            <td class="middlealign">
+                              Team 2
+                           </td>
+                           <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Drop out
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
@@ -548,9 +551,6 @@
                                  Danny Engrid
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign">
-                              Team 2
                            </td>
                            <td class="text-preserve-space">
                               Response to Danny from Dropout.
@@ -604,23 +604,23 @@
                   <table class="table table-striped table-bordered dataTable margin-0">
                      <thead class="background-color-medium-gray text-color-gray font-weight-normal">
                         <tr>
-                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,1)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,1)" style="width: 15%;">
+                              Team
+                              <span class="icon-sort unsorted">
+                              </span>
+                           </th>
+                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
                               Giver
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,3)" style="width: 15%;">
                               Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,3)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,4)" style="width: 15%;">
                               Recipient
-                              <span class="icon-sort unsorted">
-                              </span>
-                           </th>
-                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,4)" style="width: 15%;">
-                              Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
@@ -639,12 +639,6 @@
                      <tbody>
                         <tr>
                            <td class="middlealign">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Alice Betsy
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign">
                               Team 1
                            </td>
                            <td class="middlealign">
@@ -655,6 +649,12 @@
                            </td>
                            <td class="middlealign">
                               Team 1
+                           </td>
+                           <td class="middlealign">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Alice Betsy
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space">
                               Alice self feedback.
@@ -671,12 +671,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Benny Charles
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 1
                            </td>
                            <td class="middlealign color_neutral">
@@ -687,6 +681,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 1
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Benny Charles
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -705,12 +705,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Charlie Dávis
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -721,6 +715,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Charlie Dávis
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -739,12 +739,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Danny Engrid
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -755,6 +749,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Danny Engrid
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -773,12 +773,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Drop out
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -789,6 +783,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Drop out
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -807,12 +807,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Extra guy
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -823,6 +817,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Extra guy
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -841,12 +841,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Emily
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 3
                            </td>
                            <td class="middlealign color_neutral">
@@ -857,6 +851,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 3
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Emily
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -912,23 +912,23 @@
                   <table class="table table-striped table-bordered dataTable margin-0">
                      <thead class="background-color-medium-gray text-color-gray font-weight-normal">
                         <tr>
-                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,1)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,1)" style="width: 15%;">
+                              Team
+                              <span class="icon-sort unsorted">
+                              </span>
+                           </th>
+                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
                               Giver
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,3)" style="width: 15%;">
                               Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,3)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,4)" style="width: 15%;">
                               Recipient
-                              <span class="icon-sort unsorted">
-                              </span>
-                           </th>
-                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,4)" style="width: 15%;">
-                              Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
@@ -947,13 +947,13 @@
                      <tbody>
                         <tr>
                            <td class="middlealign">
+                              Instructors
+                           </td>
+                           <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Teammates Test
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign">
-                              Instructors
                            </td>
                            <td class="middlealign">
                               -
@@ -1006,23 +1006,23 @@
                   <table class="table table-striped table-bordered dataTable margin-0">
                      <thead class="background-color-medium-gray text-color-gray font-weight-normal">
                         <tr>
-                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,1)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,1)" style="width: 15%;">
+                              Team
+                              <span class="icon-sort unsorted">
+                              </span>
+                           </th>
+                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
                               Giver
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,3)" style="width: 15%;">
                               Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,3)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,4)" style="width: 15%;">
                               Recipient
-                              <span class="icon-sort unsorted">
-                              </span>
-                           </th>
-                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,4)" style="width: 15%;">
-                              Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
@@ -1041,14 +1041,14 @@
                      <tbody>
                         <tr>
                            <td class="middlealign">
+                           </td>
+                           <td class="middlealign">
                               Team 1
                            </td>
                            <td class="middlealign">
                            </td>
                            <td class="middlealign">
                               Team 2
-                           </td>
-                           <td class="middlealign">
                            </td>
                            <td class="text-preserve-space">
                               Response from team 1 (by alice) to team 2.
@@ -1269,23 +1269,23 @@
                   <table class="table table-striped table-bordered dataTable margin-0">
                      <thead class="background-color-medium-gray text-color-gray font-weight-normal">
                         <tr>
-                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,1)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,1)" style="width: 15%;">
+                              Team
+                              <span class="icon-sort unsorted">
+                              </span>
+                           </th>
+                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
                               Giver
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,3)" style="width: 15%;">
                               Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,3)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,4)" style="width: 15%;">
                               Recipient
-                              <span class="icon-sort unsorted">
-                              </span>
-                           </th>
-                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,4)" style="width: 15%;">
-                              Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
@@ -1304,12 +1304,6 @@
                      <tbody>
                         <tr>
                            <td class="middlealign">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Alice Betsy
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign">
                               Team 1
                            </td>
                            <td class="middlealign">
@@ -1320,6 +1314,12 @@
                            </td>
                            <td class="middlealign">
                               Team 1
+                           </td>
+                           <td class="middlealign">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Alice Betsy
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space">
                               PowerSearch
@@ -1336,12 +1336,6 @@
                         </tr>
                         <tr>
                            <td class="middlealign">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Drop out
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign">
                               Team 2
                            </td>
                            <td class="middlealign">
@@ -1352,6 +1346,12 @@
                            </td>
                            <td class="middlealign">
                               Team 2
+                           </td>
+                           <td class="middlealign">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Drop out
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space">
                               PowerSearch
@@ -1368,12 +1368,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Benny Charles
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 1
                            </td>
                            <td class="middlealign color_neutral">
@@ -1384,6 +1378,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 1
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Benny Charles
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -1402,12 +1402,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Charlie Dávis
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -1418,6 +1412,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Charlie Dávis
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -1436,12 +1436,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Danny Engrid
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -1452,6 +1446,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Danny Engrid
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -1470,12 +1470,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Extra guy
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -1486,6 +1480,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Extra guy
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -1504,12 +1504,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Emily
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 3
                            </td>
                            <td class="middlealign color_neutral">
@@ -1520,6 +1514,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 3
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Emily
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -1672,23 +1672,23 @@
                   <table class="table table-striped table-bordered dataTable margin-0">
                      <thead class="background-color-medium-gray text-color-gray font-weight-normal">
                         <tr>
-                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,1)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,1)" style="width: 15%;">
+                              Team
+                              <span class="icon-sort unsorted">
+                              </span>
+                           </th>
+                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
                               Giver
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,3)" style="width: 15%;">
                               Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,3)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,4)" style="width: 15%;">
                               Recipient
-                              <span class="icon-sort unsorted">
-                              </span>
-                           </th>
-                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,4)" style="width: 15%;">
-                              Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
@@ -1707,12 +1707,6 @@
                      <tbody>
                         <tr>
                            <td class="middlealign">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Alice Betsy
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign">
                               Team 1
                            </td>
                            <td class="middlealign">
@@ -1723,6 +1717,12 @@
                            </td>
                            <td class="middlealign">
                               Team 1
+                           </td>
+                           <td class="middlealign">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Alice Betsy
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space">
                               <ul class="selectedOptionsList">
@@ -1746,12 +1746,6 @@
                         </tr>
                         <tr>
                            <td class="middlealign">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Benny Charles
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign">
                               Team 1
                            </td>
                            <td class="middlealign">
@@ -1762,6 +1756,12 @@
                            </td>
                            <td class="middlealign">
                               Team 1
+                           </td>
+                           <td class="middlealign">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Benny Charles
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space">
                            </td>
@@ -1777,12 +1777,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Charlie Dávis
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -1793,6 +1787,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Charlie Dávis
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -1811,12 +1811,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Danny Engrid
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -1827,6 +1821,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Danny Engrid
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -1845,12 +1845,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Drop out
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -1861,6 +1855,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Drop out
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -1879,12 +1879,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Extra guy
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -1895,6 +1889,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Extra guy
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -1913,12 +1913,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Emily
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 3
                            </td>
                            <td class="middlealign color_neutral">
@@ -1929,6 +1923,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 3
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Emily
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -2036,23 +2036,23 @@
                   <table class="table table-striped table-bordered dataTable margin-0">
                      <thead class="background-color-medium-gray text-color-gray font-weight-normal">
                         <tr>
-                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,1)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,1)" style="width: 15%;">
+                              Team
+                              <span class="icon-sort unsorted">
+                              </span>
+                           </th>
+                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
                               Giver
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,3)" style="width: 15%;">
                               Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,3)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,4)" style="width: 15%;">
                               Recipient
-                              <span class="icon-sort unsorted">
-                              </span>
-                           </th>
-                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,4)" style="width: 15%;">
-                              Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
@@ -2071,12 +2071,6 @@
                      <tbody>
                         <tr>
                            <td class="middlealign">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Alice Betsy
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign">
                               Team 1
                            </td>
                            <td class="middlealign">
@@ -2087,6 +2081,12 @@
                            </td>
                            <td class="middlealign">
                               Team 1
+                           </td>
+                           <td class="middlealign">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Alice Betsy
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space">
                               Danny
@@ -2103,12 +2103,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Benny Charles
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 1
                            </td>
                            <td class="middlealign color_neutral">
@@ -2119,6 +2113,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 1
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Benny Charles
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -2137,12 +2137,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Charlie Dávis
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -2153,6 +2147,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Charlie Dávis
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -2171,12 +2171,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Danny Engrid
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -2187,6 +2181,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Danny Engrid
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -2205,12 +2205,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Drop out
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -2221,6 +2215,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Drop out
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -2239,12 +2239,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Extra guy
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -2255,6 +2249,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Extra guy
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -2273,12 +2273,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Emily
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 3
                            </td>
                            <td class="middlealign color_neutral">
@@ -2289,6 +2283,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 3
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Emily
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -2407,23 +2407,23 @@
                   <table class="table table-striped table-bordered dataTable margin-0">
                      <thead class="background-color-medium-gray text-color-gray font-weight-normal">
                         <tr>
-                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,1)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,1)" style="width: 15%;">
+                              Team
+                              <span class="icon-sort unsorted">
+                              </span>
+                           </th>
+                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
                               Giver
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,3)" style="width: 15%;">
                               Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,3)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,4)" style="width: 15%;">
                               Recipient
-                              <span class="icon-sort unsorted">
-                              </span>
-                           </th>
-                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,4)" style="width: 15%;">
-                              Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
@@ -2442,12 +2442,6 @@
                      <tbody>
                         <tr>
                            <td class="middlealign">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Alice Betsy
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign">
                               Team 1
                            </td>
                            <td class="middlealign">
@@ -2458,6 +2452,12 @@
                            </td>
                            <td class="middlealign">
                               Team 1
+                           </td>
+                           <td class="middlealign">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Alice Betsy
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space">
                               Team 1
@@ -2474,12 +2474,6 @@
                         </tr>
                         <tr>
                            <td class="middlealign">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Drop out
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign">
                               Team 2
                            </td>
                            <td class="middlealign">
@@ -2490,6 +2484,12 @@
                            </td>
                            <td class="middlealign">
                               Team 2
+                           </td>
+                           <td class="middlealign">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Drop out
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space">
                               Team 2
@@ -2506,12 +2506,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Benny Charles
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 1
                            </td>
                            <td class="middlealign color_neutral">
@@ -2522,6 +2516,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 1
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Benny Charles
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -2540,12 +2540,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Charlie Dávis
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -2556,6 +2550,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Charlie Dávis
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -2574,12 +2574,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Danny Engrid
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -2590,6 +2584,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Danny Engrid
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -2608,12 +2608,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Extra guy
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -2624,6 +2618,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Extra guy
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -2642,12 +2642,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Emily
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 3
                            </td>
                            <td class="middlealign color_neutral">
@@ -2658,6 +2652,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 3
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Emily
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>

--- a/src/test/resources/pages/instructorFeedbackResultsSortRecipientQuestionGiver.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortRecipientQuestionGiver.html
@@ -319,13 +319,13 @@
                                                       <th>
                                                          Photo
                                                       </th>
-                                                      <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                         Giver
+                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                         Team
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
-                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                         Team
+                                                      <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                         Giver
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
@@ -352,10 +352,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign">
-                                                         Teammates Test
+                                                         Instructors
                                                       </td>
                                                       <td class="middlealign">
-                                                         Instructors
+                                                         Teammates Test
                                                       </td>
                                                       <td class="text-preserve-space">
                                                          This is for nobody specific.
@@ -843,13 +843,13 @@
                                                       <th>
                                                          Photo
                                                       </th>
-                                                      <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                         Giver
+                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                         Team
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
-                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                         Team
+                                                      <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                         Giver
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
@@ -876,10 +876,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign">
-                                                         Drop out
+                                                         Team 2
                                                       </td>
                                                       <td class="middlealign">
-                                                         Team 2
+                                                         Drop out
                                                       </td>
                                                       <td class="text-preserve-space">
                                                          Response to Alice from Dropout.
@@ -918,13 +918,13 @@
                                                       <th>
                                                          Photo
                                                       </th>
-                                                      <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                         Giver
+                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                         Team
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
-                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                         Team
+                                                      <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                         Giver
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
@@ -951,10 +951,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign">
-                                                         Alice Betsy
+                                                         Team 1
                                                       </td>
                                                       <td class="middlealign">
-                                                         Team 1
+                                                         Alice Betsy
                                                       </td>
                                                       <td class="text-preserve-space">
                                                          Alice self feedback.
@@ -1090,13 +1090,13 @@
                                                       <th>
                                                          Photo
                                                       </th>
-                                                      <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                         Giver
+                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                         Team
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
-                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                         Team
+                                                      <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                         Giver
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
@@ -1123,10 +1123,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign">
-                                                         Alice Betsy
+                                                         Team 1
                                                       </td>
                                                       <td class="middlealign">
-                                                         Team 1
+                                                         Alice Betsy
                                                       </td>
                                                       <td class="text-preserve-space">
                                                          PowerSearch
@@ -1262,13 +1262,13 @@
                                                       <th>
                                                          Photo
                                                       </th>
-                                                      <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                         Giver
+                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                         Team
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
-                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                         Team
+                                                      <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                         Giver
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
@@ -1295,10 +1295,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign">
-                                                         Alice Betsy
+                                                         Team 1
                                                       </td>
                                                       <td class="middlealign">
-                                                         Team 1
+                                                         Alice Betsy
                                                       </td>
                                                       <td class="text-preserve-space">
                                                          <ul class="selectedOptionsList">
@@ -1396,13 +1396,13 @@
                                                       <th>
                                                          Photo
                                                       </th>
-                                                      <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                         Giver
+                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                         Team
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
-                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                         Team
+                                                      <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                         Giver
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
@@ -1429,10 +1429,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign">
-                                                         Alice Betsy
+                                                         Team 1
                                                       </td>
                                                       <td class="middlealign">
-                                                         Team 1
+                                                         Alice Betsy
                                                       </td>
                                                       <td class="text-preserve-space">
                                                          Danny
@@ -1523,13 +1523,13 @@
                                                       <th>
                                                          Photo
                                                       </th>
-                                                      <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                         Giver
+                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                         Team
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
-                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                         Team
+                                                      <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                         Giver
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
@@ -1556,10 +1556,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign">
-                                                         Alice Betsy
+                                                         Team 1
                                                       </td>
                                                       <td class="middlealign">
-                                                         Team 1
+                                                         Alice Betsy
                                                       </td>
                                                       <td class="text-preserve-space">
                                                          Team 1
@@ -1623,13 +1623,13 @@
                                                       <th>
                                                          Photo
                                                       </th>
-                                                      <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                         Giver
+                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                         Team
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
-                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                         Team
+                                                      <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                         Giver
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
@@ -1656,10 +1656,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign">
-                                                         Alice Betsy
+                                                         Team 1
                                                       </td>
                                                       <td class="middlealign">
-                                                         Team 1
+                                                         Alice Betsy
                                                       </td>
                                                       <td class="text-preserve-space">
                                                          2 Response to Benny.
@@ -1684,10 +1684,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign">
-                                                         Drop out
+                                                         Team 2
                                                       </td>
                                                       <td class="middlealign">
-                                                         Team 2
+                                                         Drop out
                                                       </td>
                                                       <td class="text-preserve-space">
                                                          Response to Benny from Dropout.
@@ -1749,13 +1749,13 @@
                                                       <th>
                                                          Photo
                                                       </th>
-                                                      <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                         Giver
+                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                         Team
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
-                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                         Team
+                                                      <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                         Giver
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
@@ -1782,10 +1782,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign">
-                                                         Benny Charles
+                                                         Team 1
                                                       </td>
                                                       <td class="middlealign">
-                                                         Team 1
+                                                         Benny Charles
                                                       </td>
                                                       <td class="text-preserve-space">
                                                       </td>
@@ -2069,13 +2069,13 @@
                                                       <th>
                                                          Photo
                                                       </th>
-                                                      <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                         Giver
+                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                         Team
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
-                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                         Team
+                                                      <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                         Giver
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
@@ -2102,10 +2102,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign">
-                                                         Benny Charles
+                                                         Team 1
                                                       </td>
                                                       <td class="middlealign">
-                                                         Team 1
+                                                         Benny Charles
                                                       </td>
                                                       <td class="text-preserve-space">
                                                          4 Response to Charlie.
@@ -2169,13 +2169,13 @@
                                                       <th>
                                                          Photo
                                                       </th>
-                                                      <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                         Giver
+                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                         Team
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
-                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                         Team
+                                                      <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                         Giver
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
@@ -2202,10 +2202,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign">
-                                                         Benny Charles
+                                                         Team 1
                                                       </td>
                                                       <td class="middlealign">
-                                                         Team 1
+                                                         Benny Charles
                                                       </td>
                                                       <td class="text-preserve-space">
                                                          1 Response to Danny.
@@ -2230,10 +2230,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign">
-                                                         Drop out
+                                                         Team 2
                                                       </td>
                                                       <td class="middlealign">
-                                                         Team 2
+                                                         Drop out
                                                       </td>
                                                       <td class="text-preserve-space">
                                                          Response to Danny from Dropout.
@@ -2297,13 +2297,13 @@
                                                       <th>
                                                          Photo
                                                       </th>
-                                                      <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                         Giver
+                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                         Team
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
-                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                         Team
+                                                      <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                         Giver
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
@@ -2330,10 +2330,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign">
-                                                         Alice Betsy
+                                                         Team 1
                                                       </td>
                                                       <td class="middlealign">
-                                                         Team 1
+                                                         Alice Betsy
                                                       </td>
                                                       <td class="text-preserve-space">
                                                          Response to Dropout.
@@ -2469,13 +2469,13 @@
                                                       <th>
                                                          Photo
                                                       </th>
-                                                      <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                         Giver
+                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                         Team
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
-                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                         Team
+                                                      <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                         Giver
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
@@ -2502,10 +2502,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign">
-                                                         Drop out
+                                                         Team 2
                                                       </td>
                                                       <td class="middlealign">
-                                                         Team 2
+                                                         Drop out
                                                       </td>
                                                       <td class="text-preserve-space">
                                                          PowerSearch
@@ -2596,13 +2596,13 @@
                                                       <th>
                                                          Photo
                                                       </th>
-                                                      <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                         Giver
+                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                         Team
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
-                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                         Team
+                                                      <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                         Giver
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
@@ -2629,10 +2629,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign">
-                                                         Drop out
+                                                         Team 2
                                                       </td>
                                                       <td class="middlealign">
-                                                         Team 2
+                                                         Drop out
                                                       </td>
                                                       <td class="text-preserve-space">
                                                          Team 2
@@ -2692,13 +2692,13 @@
                                                       <th>
                                                          Photo
                                                       </th>
-                                                      <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                         Giver
+                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                         Team
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
-                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                         Team
+                                                      <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                         Giver
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
@@ -2724,9 +2724,9 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign">
-                                                         Team 1
                                                       </td>
                                                       <td class="middlealign">
+                                                         Team 1
                                                       </td>
                                                       <td class="text-preserve-space">
                                                          Response from team 1 (by alice) to team 2.
@@ -2884,13 +2884,13 @@
                                                       <th>
                                                          Photo
                                                       </th>
-                                                      <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                         Giver
+                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                         Team
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
-                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                         Team
+                                                      <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                         Giver
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
@@ -2917,10 +2917,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign">
-                                                         Charlie Dávis
+                                                         Team 2
                                                       </td>
                                                       <td class="middlealign">
-                                                         Team 2
+                                                         Charlie Dávis
                                                       </td>
                                                       <td class="text-preserve-space">
                                                          3 Response to Emily.

--- a/src/test/resources/pages/instructorFeedbackResultsSortRecipientQuestionGiverTeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortRecipientQuestionGiverTeam.html
@@ -301,13 +301,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Giver
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Giver
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -334,10 +334,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Teammates Test
+                                                Instructors
                                              </td>
                                              <td class="middlealign">
-                                                Instructors
+                                                Teammates Test
                                              </td>
                                              <td class="text-preserve-space">
                                                 This is for nobody specific.
@@ -419,13 +419,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Giver
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Giver
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -452,10 +452,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Drop out
+                                                Team 2
                                              </td>
                                              <td class="middlealign">
-                                                Team 2
+                                                Drop out
                                              </td>
                                              <td class="text-preserve-space">
                                                 Response to Alice from Dropout.
@@ -494,13 +494,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Giver
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Giver
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -527,10 +527,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Alice Betsy
+                                                Team 1
                                              </td>
                                              <td class="middlealign">
-                                                Team 1
+                                                Alice Betsy
                                              </td>
                                              <td class="text-preserve-space">
                                                 Alice self feedback.
@@ -666,13 +666,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Giver
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Giver
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -699,10 +699,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Alice Betsy
+                                                Team 1
                                              </td>
                                              <td class="middlealign">
-                                                Team 1
+                                                Alice Betsy
                                              </td>
                                              <td class="text-preserve-space">
                                                 PowerSearch
@@ -838,13 +838,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Giver
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Giver
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -871,10 +871,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Alice Betsy
+                                                Team 1
                                              </td>
                                              <td class="middlealign">
-                                                Team 1
+                                                Alice Betsy
                                              </td>
                                              <td class="text-preserve-space">
                                                 <ul class="selectedOptionsList">
@@ -972,13 +972,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Giver
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Giver
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -1005,10 +1005,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Alice Betsy
+                                                Team 1
                                              </td>
                                              <td class="middlealign">
-                                                Team 1
+                                                Alice Betsy
                                              </td>
                                              <td class="text-preserve-space">
                                                 Danny
@@ -1099,13 +1099,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Giver
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Giver
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -1132,10 +1132,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Alice Betsy
+                                                Team 1
                                              </td>
                                              <td class="middlealign">
-                                                Team 1
+                                                Alice Betsy
                                              </td>
                                              <td class="text-preserve-space">
                                                 Team 1
@@ -1199,13 +1199,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Giver
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Giver
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -1232,10 +1232,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Alice Betsy
+                                                Team 1
                                              </td>
                                              <td class="middlealign">
-                                                Team 1
+                                                Alice Betsy
                                              </td>
                                              <td class="text-preserve-space">
                                                 2 Response to Benny.
@@ -1260,10 +1260,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Drop out
+                                                Team 2
                                              </td>
                                              <td class="middlealign">
-                                                Team 2
+                                                Drop out
                                              </td>
                                              <td class="text-preserve-space">
                                                 Response to Benny from Dropout.
@@ -1325,13 +1325,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Giver
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Giver
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -1358,10 +1358,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Benny Charles
+                                                Team 1
                                              </td>
                                              <td class="middlealign">
-                                                Team 1
+                                                Benny Charles
                                              </td>
                                              <td class="text-preserve-space">
                                              </td>
@@ -1424,13 +1424,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Giver
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Giver
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -1457,10 +1457,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Benny Charles
+                                                Team 1
                                              </td>
                                              <td class="middlealign">
-                                                Team 1
+                                                Benny Charles
                                              </td>
                                              <td class="text-preserve-space">
                                                 4 Response to Charlie.
@@ -1524,13 +1524,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Giver
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Giver
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -1557,10 +1557,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Benny Charles
+                                                Team 1
                                              </td>
                                              <td class="middlealign">
-                                                Team 1
+                                                Benny Charles
                                              </td>
                                              <td class="text-preserve-space">
                                                 1 Response to Danny.
@@ -1585,10 +1585,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Drop out
+                                                Team 2
                                              </td>
                                              <td class="middlealign">
-                                                Team 2
+                                                Drop out
                                              </td>
                                              <td class="text-preserve-space">
                                                 Response to Danny from Dropout.
@@ -1652,13 +1652,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Giver
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Giver
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -1685,10 +1685,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Alice Betsy
+                                                Team 1
                                              </td>
                                              <td class="middlealign">
-                                                Team 1
+                                                Alice Betsy
                                              </td>
                                              <td class="text-preserve-space">
                                                 Response to Dropout.
@@ -1824,13 +1824,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Giver
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Giver
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -1857,10 +1857,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Drop out
+                                                Team 2
                                              </td>
                                              <td class="middlealign">
-                                                Team 2
+                                                Drop out
                                              </td>
                                              <td class="text-preserve-space">
                                                 PowerSearch
@@ -1951,13 +1951,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Giver
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Giver
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -1984,10 +1984,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Drop out
+                                                Team 2
                                              </td>
                                              <td class="middlealign">
-                                                Team 2
+                                                Drop out
                                              </td>
                                              <td class="text-preserve-space">
                                                 Team 2
@@ -2047,13 +2047,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Giver
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Giver
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -2079,9 +2079,9 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Team 1
                                              </td>
                                              <td class="middlealign">
+                                                Team 1
                                              </td>
                                              <td class="text-preserve-space">
                                                 Response from team 1 (by alice) to team 2.
@@ -2198,13 +2198,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Giver
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Giver
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -2231,10 +2231,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Charlie Dávis
+                                                Team 2
                                              </td>
                                              <td class="middlealign">
-                                                Team 2
+                                                Charlie Dávis
                                              </td>
                                              <td class="text-preserve-space">
                                                 3 Response to Emily.

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionFilteredBySectionA.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionFilteredBySectionA.html
@@ -363,23 +363,23 @@
                   <table class="table table-striped table-bordered dataTable margin-0">
                      <thead class="background-color-medium-gray text-color-gray font-weight-normal">
                         <tr>
-                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,1)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,1)" style="width: 15%;">
+                              Team
+                              <span class="icon-sort unsorted">
+                              </span>
+                           </th>
+                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
                               Giver
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,3)" style="width: 15%;">
                               Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,3)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,4)" style="width: 15%;">
                               Recipient
-                              <span class="icon-sort unsorted">
-                              </span>
-                           </th>
-                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,4)" style="width: 15%;">
-                              Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
@@ -398,12 +398,6 @@
                      <tbody>
                         <tr>
                            <td class="middlealign">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Alice Betsy
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign">
                               Team 1
                            </td>
                            <td class="middlealign">
@@ -414,6 +408,12 @@
                            </td>
                            <td class="middlealign">
                               Team 1
+                           </td>
+                           <td class="middlealign">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Alice Betsy
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space">
                               <ul class="selectedOptionsList">
@@ -434,12 +434,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Benny Charles
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 1
                            </td>
                            <td class="middlealign color_neutral">
@@ -450,6 +444,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 1
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Benny Charles
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -468,12 +468,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Charlie Dávis
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -484,6 +478,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Charlie Dávis
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -502,12 +502,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Danny Engrid
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -518,6 +512,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Danny Engrid
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -536,12 +536,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Drop out
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -552,6 +546,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Drop out
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -570,12 +570,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Extra guy
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -586,6 +580,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Extra guy
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -704,23 +704,23 @@
                   <table class="table table-striped table-bordered dataTable margin-0">
                      <thead class="background-color-medium-gray text-color-gray font-weight-normal">
                         <tr>
-                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,1)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,1)" style="width: 15%;">
+                              Team
+                              <span class="icon-sort unsorted">
+                              </span>
+                           </th>
+                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
                               Giver
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,3)" style="width: 15%;">
                               Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,3)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,4)" style="width: 15%;">
                               Recipient
-                              <span class="icon-sort unsorted">
-                              </span>
-                           </th>
-                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,4)" style="width: 15%;">
-                              Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
@@ -739,12 +739,6 @@
                      <tbody>
                         <tr>
                            <td class="middlealign">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Alice Betsy
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign">
                               Team 1
                            </td>
                            <td class="middlealign">
@@ -755,6 +749,12 @@
                            </td>
                            <td class="middlealign">
                               Team 1
+                           </td>
+                           <td class="middlealign">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Alice Betsy
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space">
                               <ul class="selectedOptionsList">
@@ -778,12 +778,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Benny Charles
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 1
                            </td>
                            <td class="middlealign color_neutral">
@@ -794,6 +788,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 1
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Benny Charles
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -812,12 +812,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Charlie Dávis
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -828,6 +822,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Charlie Dávis
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -846,12 +846,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Danny Engrid
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -862,6 +856,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Danny Engrid
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -880,12 +880,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Drop out
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -896,6 +890,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Drop out
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -914,12 +914,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Extra guy
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -930,6 +924,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Extra guy
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -1065,23 +1065,23 @@
                   <table class="table table-striped table-bordered dataTable margin-0">
                      <thead class="background-color-medium-gray text-color-gray font-weight-normal">
                         <tr>
-                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,1)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,1)" style="width: 15%;">
+                              Team
+                              <span class="icon-sort unsorted">
+                              </span>
+                           </th>
+                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
                               Giver
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,3)" style="width: 15%;">
                               Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,3)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,4)" style="width: 15%;">
                               Recipient
-                              <span class="icon-sort unsorted">
-                              </span>
-                           </th>
-                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,4)" style="width: 15%;">
-                              Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
@@ -1100,12 +1100,6 @@
                      <tbody>
                         <tr>
                            <td class="middlealign">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Alice Betsy
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign">
                               Team 1
                            </td>
                            <td class="middlealign">
@@ -1116,6 +1110,12 @@
                            </td>
                            <td class="middlealign">
                               Team 1
+                           </td>
+                           <td class="middlealign">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Alice Betsy
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space">
                               3.5
@@ -1132,12 +1132,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Benny Charles
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 1
                            </td>
                            <td class="middlealign color_neutral">
@@ -1148,6 +1142,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 1
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Benny Charles
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -1166,12 +1166,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Charlie Dávis
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -1182,6 +1176,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Charlie Dávis
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -1200,12 +1200,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Danny Engrid
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -1216,6 +1210,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Danny Engrid
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -1234,12 +1234,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Drop out
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -1250,6 +1244,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Drop out
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -1268,12 +1268,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Extra guy
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -1284,6 +1278,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Extra guy
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -1415,23 +1415,23 @@
                   <table class="table table-striped table-bordered dataTable margin-0">
                      <thead class="background-color-medium-gray text-color-gray font-weight-normal">
                         <tr>
-                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,1)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,1)" style="width: 15%;">
+                              Team
+                              <span class="icon-sort unsorted">
+                              </span>
+                           </th>
+                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
                               Giver
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,3)" style="width: 15%;">
                               Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,3)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,4)" style="width: 15%;">
                               Recipient
-                              <span class="icon-sort unsorted">
-                              </span>
-                           </th>
-                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,4)" style="width: 15%;">
-                              Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
@@ -1450,12 +1450,6 @@
                      <tbody>
                         <tr>
                            <td class="middlealign">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Alice Betsy
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign">
                               Team 1
                            </td>
                            <td class="middlealign">
@@ -1466,6 +1460,12 @@
                            </td>
                            <td class="middlealign">
                               Team 1
+                           </td>
+                           <td class="middlealign">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Alice Betsy
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space">
                               <ul>
@@ -1489,12 +1489,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Benny Charles
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 1
                            </td>
                            <td class="middlealign color_neutral">
@@ -1505,6 +1499,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 1
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Benny Charles
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -1523,12 +1523,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Charlie Dávis
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -1539,6 +1533,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Charlie Dávis
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -1557,12 +1557,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Danny Engrid
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -1573,6 +1567,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Danny Engrid
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -1591,12 +1591,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Drop out
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -1607,6 +1601,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Drop out
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -1625,12 +1625,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Extra guy
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -1641,6 +1635,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Extra guy
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -1804,23 +1804,23 @@
                   <table class="table table-striped table-bordered dataTable margin-0">
                      <thead class="background-color-medium-gray text-color-gray font-weight-normal">
                         <tr>
-                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,1)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,1)" style="width: 15%;">
+                              Team
+                              <span class="icon-sort unsorted">
+                              </span>
+                           </th>
+                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
                               Giver
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,3)" style="width: 15%;">
                               Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,3)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,4)" style="width: 15%;">
                               Recipient
-                              <span class="icon-sort unsorted">
-                              </span>
-                           </th>
-                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,4)" style="width: 15%;">
-                              Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
@@ -1839,12 +1839,6 @@
                      <tbody>
                         <tr>
                            <td class="middlealign">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Alice Betsy
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign">
                               Team 1
                            </td>
                            <td class="middlealign">
@@ -1855,6 +1849,12 @@
                            </td>
                            <td class="middlealign">
                               Team 1
+                           </td>
+                           <td class="middlealign">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Alice Betsy
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space">
                               110
@@ -1871,6 +1871,9 @@
                         </tr>
                         <tr>
                            <td class="middlealign">
+                              Team 1
+                           </td>
+                           <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Alice Betsy
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
@@ -1884,9 +1887,6 @@
                                  Benny Charles
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign">
-                              Team 1
                            </td>
                            <td class="text-preserve-space">
                               90
@@ -1903,22 +1903,22 @@
                         </tr>
                         <tr>
                            <td class="middlealign">
+                              Team 1
+                           </td>
+                           <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Alice Betsy
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
                            <td class="middlealign">
-                              Team 1
+                              Team 2
                            </td>
                            <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Charlie Dávis
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign">
-                              Team 2
                            </td>
                            <td class="text-preserve-space">
                               50
@@ -1935,22 +1935,22 @@
                         </tr>
                         <tr>
                            <td class="middlealign">
+                              Team 1
+                           </td>
+                           <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Alice Betsy
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
                            <td class="middlealign">
-                              Team 1
+                              Team 2
                            </td>
                            <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Danny Engrid
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign">
-                              Team 2
                            </td>
                            <td class="text-preserve-space">
                               150
@@ -1967,6 +1967,9 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
+                              Team 1
+                           </td>
+                           <td class="middlealign color_neutral">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Benny Charles
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
@@ -1981,8 +1984,39 @@
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
+                           <td class="text-preserve-space color_neutral">
+                              <i>
+                                 No Response
+                              </i>
+                           </td>
+                           <td>
+                              <form action="/page/instructorEditStudentFeedbackPage?user=CFResultsUiT.instr" class="inline" method="post" target="_blank">
+                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
+                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
+                                 <input name="fsname" type="hidden" value="Second Session"/>
+                                 <input name="moderatedquestion" type="hidden" value="6"/>
+                                 <input name="moderatedstudent" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt"/>
+                              </form>
+                           </td>
+                        </tr>
+                        <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
                               Team 1
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Benny Charles
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
+                           </td>
+                           <td class="middlealign color_neutral">
+                              Team 1
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Benny Charles
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -2001,39 +2035,8 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Benny Charles
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
+                              Team 2
                            </td>
-                           <td class="middlealign color_neutral">
-                              Team 1
-                           </td>
-                           <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Benny Charles
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
-                              Team 1
-                           </td>
-                           <td class="text-preserve-space color_neutral">
-                              <i>
-                                 No Response
-                              </i>
-                           </td>
-                           <td>
-                              <form action="/page/instructorEditStudentFeedbackPage?user=CFResultsUiT.instr" class="inline" method="post" target="_blank">
-                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
-                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
-                                 <input name="fsname" type="hidden" value="Second Session"/>
-                                 <input name="moderatedquestion" type="hidden" value="6"/>
-                                 <input name="moderatedstudent" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt"/>
-                              </form>
-                           </td>
-                        </tr>
-                        <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Charlie Dávis
@@ -2048,9 +2051,6 @@
                                  Charlie Dávis
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign color_neutral">
-                              Team 2
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -2069,6 +2069,9 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
+                              Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Charlie Dávis
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
@@ -2082,9 +2085,6 @@
                                  Danny Engrid
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign color_neutral">
-                              Team 2
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -2103,6 +2103,9 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
+                              Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Charlie Dávis
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
@@ -2116,9 +2119,6 @@
                                  Drop out
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign color_neutral">
-                              Team 2
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -2137,6 +2137,9 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
+                              Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Charlie Dávis
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
@@ -2150,9 +2153,6 @@
                                  Extra guy
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign color_neutral">
-                              Team 2
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -2171,6 +2171,9 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
+                              Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Danny Engrid
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
@@ -2185,8 +2188,39 @@
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
+                           <td class="text-preserve-space color_neutral">
+                              <i>
+                                 No Response
+                              </i>
+                           </td>
+                           <td>
+                              <form action="/page/instructorEditStudentFeedbackPage?user=CFResultsUiT.instr" class="inline" method="post" target="_blank">
+                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
+                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
+                                 <input name="fsname" type="hidden" value="Second Session"/>
+                                 <input name="moderatedquestion" type="hidden" value="6"/>
+                                 <input name="moderatedstudent" type="hidden" value="CFResultsUiT.danny.e@gmail.tmt"/>
+                              </form>
+                           </td>
+                        </tr>
+                        <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Danny Engrid
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
+                           </td>
+                           <td class="middlealign color_neutral">
+                              Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Danny Engrid
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -2205,39 +2239,8 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Danny Engrid
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
-                           <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Danny Engrid
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
-                              Team 2
-                           </td>
-                           <td class="text-preserve-space color_neutral">
-                              <i>
-                                 No Response
-                              </i>
-                           </td>
-                           <td>
-                              <form action="/page/instructorEditStudentFeedbackPage?user=CFResultsUiT.instr" class="inline" method="post" target="_blank">
-                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
-                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
-                                 <input name="fsname" type="hidden" value="Second Session"/>
-                                 <input name="moderatedquestion" type="hidden" value="6"/>
-                                 <input name="moderatedstudent" type="hidden" value="CFResultsUiT.danny.e@gmail.tmt"/>
-                              </form>
-                           </td>
-                        </tr>
-                        <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Danny Engrid
@@ -2253,9 +2256,6 @@
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
-                           <td class="middlealign color_neutral">
-                              Team 2
-                           </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
                                  No Response
@@ -2272,6 +2272,9 @@
                            </td>
                         </tr>
                         <tr class="pending_response_row">
+                           <td class="middlealign color_neutral">
+                              Team 2
+                           </td>
                            <td class="middlealign color_neutral">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Danny Engrid
@@ -2287,9 +2290,6 @@
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
-                           <td class="middlealign color_neutral">
-                              Team 2
-                           </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
                                  No Response
@@ -2307,6 +2307,9 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
+                              Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Drop out
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
@@ -2320,9 +2323,6 @@
                                  Charlie Dávis
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign color_neutral">
-                              Team 2
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -2340,6 +2340,9 @@
                            </td>
                         </tr>
                         <tr class="pending_response_row">
+                           <td class="middlealign color_neutral">
+                              Team 2
+                           </td>
                            <td class="middlealign color_neutral">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Drop out
@@ -2355,8 +2358,39 @@
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
+                           <td class="text-preserve-space color_neutral">
+                              <i>
+                                 No Response
+                              </i>
+                           </td>
+                           <td>
+                              <form action="/page/instructorEditStudentFeedbackPage?user=CFResultsUiT.instr" class="inline" method="post" target="_blank">
+                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
+                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
+                                 <input name="fsname" type="hidden" value="Second Session"/>
+                                 <input name="moderatedquestion" type="hidden" value="6"/>
+                                 <input name="moderatedstudent" type="hidden" value="drop.out@gmail.tmt"/>
+                              </form>
+                           </td>
+                        </tr>
+                        <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Drop out
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
+                           </td>
+                           <td class="middlealign color_neutral">
+                              Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Drop out
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -2375,39 +2409,8 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Drop out
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
-                           <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Drop out
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
-                              Team 2
-                           </td>
-                           <td class="text-preserve-space color_neutral">
-                              <i>
-                                 No Response
-                              </i>
-                           </td>
-                           <td>
-                              <form action="/page/instructorEditStudentFeedbackPage?user=CFResultsUiT.instr" class="inline" method="post" target="_blank">
-                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
-                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
-                                 <input name="fsname" type="hidden" value="Second Session"/>
-                                 <input name="moderatedquestion" type="hidden" value="6"/>
-                                 <input name="moderatedstudent" type="hidden" value="drop.out@gmail.tmt"/>
-                              </form>
-                           </td>
-                        </tr>
-                        <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Drop out
@@ -2423,9 +2426,6 @@
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
-                           <td class="middlealign color_neutral">
-                              Team 2
-                           </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
                                  No Response
@@ -2442,6 +2442,9 @@
                            </td>
                         </tr>
                         <tr class="pending_response_row">
+                           <td class="middlealign color_neutral">
+                              Team 2
+                           </td>
                            <td class="middlealign color_neutral">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Extra guy
@@ -2456,9 +2459,6 @@
                                  Charlie Dávis
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign color_neutral">
-                              Team 2
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -2477,6 +2477,9 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
+                              Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Extra guy
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
@@ -2490,9 +2493,6 @@
                                  Danny Engrid
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign color_neutral">
-                              Team 2
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -2510,6 +2510,9 @@
                            </td>
                         </tr>
                         <tr class="pending_response_row">
+                           <td class="middlealign color_neutral">
+                              Team 2
+                           </td>
                            <td class="middlealign color_neutral">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Extra guy
@@ -2525,9 +2528,6 @@
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
-                           <td class="middlealign color_neutral">
-                              Team 2
-                           </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
                                  No Response
@@ -2545,12 +2545,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Extra guy
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -2561,6 +2555,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Extra guy
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -2885,23 +2885,23 @@
                   <table class="table table-striped table-bordered dataTable margin-0">
                      <thead class="background-color-medium-gray text-color-gray font-weight-normal">
                         <tr>
-                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,1)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,1)" style="width: 15%;">
+                              Team
+                              <span class="icon-sort unsorted">
+                              </span>
+                           </th>
+                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
                               Giver
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,3)" style="width: 15%;">
                               Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,3)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,4)" style="width: 15%;">
                               Recipient
-                              <span class="icon-sort unsorted">
-                              </span>
-                           </th>
-                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,4)" style="width: 15%;">
-                              Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
@@ -2920,12 +2920,6 @@
                      <tbody>
                         <tr>
                            <td class="middlealign">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Alice Betsy
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign">
                               Team 1
                            </td>
                            <td class="middlealign">
@@ -2936,6 +2930,12 @@
                            </td>
                            <td class="middlealign">
                               Team 1
+                           </td>
+                           <td class="middlealign">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Alice Betsy
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space">
                               <span class="color-positive">
@@ -2961,6 +2961,9 @@
                         </tr>
                         <tr>
                            <td class="middlealign">
+                              Team 1
+                           </td>
+                           <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Alice Betsy
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
@@ -2974,9 +2977,6 @@
                                  Benny Charles
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign">
-                              Team 1
                            </td>
                            <td class="text-preserve-space">
                               <span class="color_neutral">
@@ -2995,6 +2995,9 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
+                              Team 1
+                           </td>
+                           <td class="middlealign color_neutral">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Benny Charles
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
@@ -3008,9 +3011,6 @@
                                  Alice Betsy
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign color_neutral">
-                              Team 1
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -3029,12 +3029,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Benny Charles
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 1
                            </td>
                            <td class="middlealign color_neutral">
@@ -3045,6 +3039,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 1
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Benny Charles
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -3070,12 +3070,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Charlie Dávis
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -3086,6 +3080,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Charlie Dávis
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -3104,6 +3104,9 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
+                              Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Charlie Dávis
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
@@ -3117,9 +3120,6 @@
                                  Danny Engrid
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign color_neutral">
-                              Team 2
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -3138,6 +3138,9 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
+                              Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Charlie Dávis
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
@@ -3151,9 +3154,6 @@
                                  Drop out
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign color_neutral">
-                              Team 2
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -3172,6 +3172,9 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
+                              Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Charlie Dávis
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
@@ -3185,9 +3188,6 @@
                                  Extra guy
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign color_neutral">
-                              Team 2
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -3206,6 +3206,9 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
+                              Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Danny Engrid
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
@@ -3220,8 +3223,39 @@
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
+                           <td class="text-preserve-space color_neutral">
+                              <i>
+                                 No Response
+                              </i>
+                           </td>
+                           <td>
+                              <form action="/page/instructorEditStudentFeedbackPage?user=CFResultsUiT.instr" class="inline" method="post" target="_blank">
+                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
+                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
+                                 <input name="fsname" type="hidden" value="Second Session"/>
+                                 <input name="moderatedquestion" type="hidden" value="7"/>
+                                 <input name="moderatedstudent" type="hidden" value="CFResultsUiT.danny.e@gmail.tmt"/>
+                              </form>
+                           </td>
+                        </tr>
+                        <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Danny Engrid
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
+                           </td>
+                           <td class="middlealign color_neutral">
+                              Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Danny Engrid
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -3240,39 +3274,8 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Danny Engrid
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
-                           <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Danny Engrid
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
-                              Team 2
-                           </td>
-                           <td class="text-preserve-space color_neutral">
-                              <i>
-                                 No Response
-                              </i>
-                           </td>
-                           <td>
-                              <form action="/page/instructorEditStudentFeedbackPage?user=CFResultsUiT.instr" class="inline" method="post" target="_blank">
-                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
-                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
-                                 <input name="fsname" type="hidden" value="Second Session"/>
-                                 <input name="moderatedquestion" type="hidden" value="7"/>
-                                 <input name="moderatedstudent" type="hidden" value="CFResultsUiT.danny.e@gmail.tmt"/>
-                              </form>
-                           </td>
-                        </tr>
-                        <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Danny Engrid
@@ -3288,9 +3291,6 @@
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
-                           <td class="middlealign color_neutral">
-                              Team 2
-                           </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
                                  No Response
@@ -3307,6 +3307,9 @@
                            </td>
                         </tr>
                         <tr class="pending_response_row">
+                           <td class="middlealign color_neutral">
+                              Team 2
+                           </td>
                            <td class="middlealign color_neutral">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Danny Engrid
@@ -3322,9 +3325,6 @@
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
-                           <td class="middlealign color_neutral">
-                              Team 2
-                           </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
                                  No Response
@@ -3342,6 +3342,9 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
+                              Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Drop out
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
@@ -3355,9 +3358,6 @@
                                  Charlie Dávis
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign color_neutral">
-                              Team 2
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -3375,6 +3375,9 @@
                            </td>
                         </tr>
                         <tr class="pending_response_row">
+                           <td class="middlealign color_neutral">
+                              Team 2
+                           </td>
                            <td class="middlealign color_neutral">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Drop out
@@ -3390,8 +3393,39 @@
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
+                           <td class="text-preserve-space color_neutral">
+                              <i>
+                                 No Response
+                              </i>
+                           </td>
+                           <td>
+                              <form action="/page/instructorEditStudentFeedbackPage?user=CFResultsUiT.instr" class="inline" method="post" target="_blank">
+                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
+                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
+                                 <input name="fsname" type="hidden" value="Second Session"/>
+                                 <input name="moderatedquestion" type="hidden" value="7"/>
+                                 <input name="moderatedstudent" type="hidden" value="drop.out@gmail.tmt"/>
+                              </form>
+                           </td>
+                        </tr>
+                        <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Drop out
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
+                           </td>
+                           <td class="middlealign color_neutral">
+                              Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Drop out
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -3410,39 +3444,8 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Drop out
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
-                           <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Drop out
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
-                              Team 2
-                           </td>
-                           <td class="text-preserve-space color_neutral">
-                              <i>
-                                 No Response
-                              </i>
-                           </td>
-                           <td>
-                              <form action="/page/instructorEditStudentFeedbackPage?user=CFResultsUiT.instr" class="inline" method="post" target="_blank">
-                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
-                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
-                                 <input name="fsname" type="hidden" value="Second Session"/>
-                                 <input name="moderatedquestion" type="hidden" value="7"/>
-                                 <input name="moderatedstudent" type="hidden" value="drop.out@gmail.tmt"/>
-                              </form>
-                           </td>
-                        </tr>
-                        <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Drop out
@@ -3458,9 +3461,6 @@
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
-                           <td class="middlealign color_neutral">
-                              Team 2
-                           </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
                                  No Response
@@ -3477,6 +3477,9 @@
                            </td>
                         </tr>
                         <tr class="pending_response_row">
+                           <td class="middlealign color_neutral">
+                              Team 2
+                           </td>
                            <td class="middlealign color_neutral">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Extra guy
@@ -3491,9 +3494,6 @@
                                  Charlie Dávis
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign color_neutral">
-                              Team 2
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -3512,6 +3512,9 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
+                              Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Extra guy
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
@@ -3525,9 +3528,6 @@
                                  Danny Engrid
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign color_neutral">
-                              Team 2
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -3545,6 +3545,9 @@
                            </td>
                         </tr>
                         <tr class="pending_response_row">
+                           <td class="middlealign color_neutral">
+                              Team 2
+                           </td>
                            <td class="middlealign color_neutral">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Extra guy
@@ -3560,9 +3563,6 @@
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
-                           <td class="middlealign color_neutral">
-                              Team 2
-                           </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
                                  No Response
@@ -3580,12 +3580,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Extra guy
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -3596,6 +3590,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Extra guy
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -3662,23 +3662,23 @@
                   <table class="table table-striped table-bordered dataTable margin-0">
                      <thead class="background-color-medium-gray text-color-gray font-weight-normal">
                         <tr>
-                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,1)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,1)" style="width: 15%;">
+                              Team
+                              <span class="icon-sort unsorted">
+                              </span>
+                           </th>
+                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
                               Giver
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,3)" style="width: 15%;">
                               Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,3)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,4)" style="width: 15%;">
                               Recipient
-                              <span class="icon-sort unsorted">
-                              </span>
-                           </th>
-                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,4)" style="width: 15%;">
-                              Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
@@ -3697,19 +3697,19 @@
                      <tbody>
                         <tr>
                            <td class="middlealign">
+                              Team 1
+                           </td>
+                           <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Alice Betsy
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
                            <td class="middlealign">
-                              Team 1
+                              Anonymous student 227201833's Team
                            </td>
                            <td class="middlealign">
                               Anonymous student 227201833
-                           </td>
-                           <td class="middlealign">
-                              Anonymous student 227201833's Team
                            </td>
                            <td class="text-preserve-space">
                               3
@@ -3726,19 +3726,19 @@
                         </tr>
                         <tr>
                            <td class="middlealign">
+                              Team 1
+                           </td>
+                           <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Alice Betsy
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
                            <td class="middlealign">
-                              Team 1
+                              Anonymous student 410339386's Team
                            </td>
                            <td class="middlealign">
                               Anonymous student 410339386
-                           </td>
-                           <td class="middlealign">
-                              Anonymous student 410339386's Team
                            </td>
                            <td class="text-preserve-space">
                               4
@@ -3872,23 +3872,23 @@
                   <table class="table table-striped table-bordered dataTable margin-0">
                      <thead class="background-color-medium-gray text-color-gray font-weight-normal">
                         <tr>
-                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,1)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,1)" style="width: 15%;">
+                              Team
+                              <span class="icon-sort unsorted">
+                              </span>
+                           </th>
+                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
                               Giver
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,3)" style="width: 15%;">
                               Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,3)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,4)" style="width: 15%;">
                               Recipient
-                              <span class="icon-sort unsorted">
-                              </span>
-                           </th>
-                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,4)" style="width: 15%;">
-                              Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
@@ -3907,10 +3907,10 @@
                      <tbody>
                         <tr>
                            <td class="middlealign">
-                              Anonymous student 410339386
+                              Anonymous student 410339386's Team
                            </td>
                            <td class="middlealign">
-                              Anonymous student 410339386's Team
+                              Anonymous student 410339386
                            </td>
                            <td class="middlealign">
                               -
@@ -4232,23 +4232,23 @@
                   <table class="table table-striped table-bordered dataTable margin-0">
                      <thead class="background-color-medium-gray text-color-gray font-weight-normal">
                         <tr>
-                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,1)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,1)" style="width: 15%;">
+                              Team
+                              <span class="icon-sort unsorted">
+                              </span>
+                           </th>
+                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
                               Giver
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,3)" style="width: 15%;">
                               Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,3)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,4)" style="width: 15%;">
                               Recipient
-                              <span class="icon-sort unsorted">
-                              </span>
-                           </th>
-                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,4)" style="width: 15%;">
-                              Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
@@ -4267,19 +4267,19 @@
                      <tbody>
                         <tr>
                            <td class="middlealign">
+                              Team 1
+                           </td>
+                           <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Alice Betsy
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
                            <td class="middlealign">
-                              Team 1
+                              Anonymous student 227201833's Team
                            </td>
                            <td class="middlealign">
                               Anonymous student 227201833
-                           </td>
-                           <td class="middlealign">
-                              Anonymous student 227201833's Team
                            </td>
                            <td class="text-preserve-space">
                               <span class="color_neutral">
@@ -4298,19 +4298,19 @@
                         </tr>
                         <tr>
                            <td class="middlealign">
+                              Team 1
+                           </td>
+                           <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Alice Betsy
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
                            <td class="middlealign">
-                              Team 1
+                              Anonymous student 410339386's Team
                            </td>
                            <td class="middlealign">
                               Anonymous student 410339386
-                           </td>
-                           <td class="middlealign">
-                              Anonymous student 410339386's Team
                            </td>
                            <td class="text-preserve-space">
                               <span class="color_neutral">
@@ -4366,23 +4366,23 @@
                   <table class="table table-striped table-bordered dataTable margin-0">
                      <thead class="background-color-medium-gray text-color-gray font-weight-normal">
                         <tr>
-                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,1)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,1)" style="width: 15%;">
+                              Team
+                              <span class="icon-sort unsorted">
+                              </span>
+                           </th>
+                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
                               Giver
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,3)" style="width: 15%;">
                               Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,3)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,4)" style="width: 15%;">
                               Recipient
-                              <span class="icon-sort unsorted">
-                              </span>
-                           </th>
-                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,4)" style="width: 15%;">
-                              Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
@@ -4401,14 +4401,14 @@
                      <tbody>
                         <tr>
                            <td class="middlealign">
-                              Team 1
-                           </td>
-                           <td class="middlealign">
                            </td>
                            <td class="middlealign">
                               Team 1
                            </td>
                            <td class="middlealign">
+                           </td>
+                           <td class="middlealign">
+                              Team 1
                            </td>
                            <td class="text-preserve-space">
                               Response from benny to Team 1 (own team)
@@ -4542,23 +4542,23 @@
                   <table class="table table-striped table-bordered dataTable margin-0">
                      <thead class="background-color-medium-gray text-color-gray font-weight-normal">
                         <tr>
-                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,1)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,1)" style="width: 15%;">
+                              Team
+                              <span class="icon-sort unsorted">
+                              </span>
+                           </th>
+                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
                               Giver
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,3)" style="width: 15%;">
                               Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,3)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,4)" style="width: 15%;">
                               Recipient
-                              <span class="icon-sort unsorted">
-                              </span>
-                           </th>
-                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,4)" style="width: 15%;">
-                              Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
@@ -4577,9 +4577,9 @@
                      <tbody>
                         <tr>
                            <td class="middlealign">
-                              Team 1
                            </td>
                            <td class="middlealign">
+                              Team 1
                            </td>
                            <td class="middlealign">
                               -

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionGiverQuestionRecipient.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionGiverQuestionRecipient.html
@@ -399,13 +399,13 @@
                                                       <th>
                                                          Photo
                                                       </th>
-                                                      <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                         Recipient
+                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                         Team
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
-                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                         Team
+                                                      <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                         Recipient
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
@@ -1147,13 +1147,13 @@
                                                       <th>
                                                          Photo
                                                       </th>
-                                                      <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                         Recipient
+                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                         Team
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
-                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                         Team
+                                                      <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                         Recipient
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
@@ -1177,10 +1177,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign">
-                                                         Alice Betsy
+                                                         Team 1
                                                       </td>
                                                       <td class="middlealign">
-                                                         Team 1
+                                                         Alice Betsy
                                                       </td>
                                                       <td class="text-preserve-space">
                                                          <ul class="selectedOptionsList">
@@ -1277,13 +1277,13 @@
                                                       <th>
                                                          Photo
                                                       </th>
-                                                      <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                         Recipient
+                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                         Team
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
-                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                         Team
+                                                      <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                         Recipient
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
@@ -1307,10 +1307,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign">
-                                                         Alice Betsy
+                                                         Team 1
                                                       </td>
                                                       <td class="middlealign">
-                                                         Team 1
+                                                         Alice Betsy
                                                       </td>
                                                       <td class="text-preserve-space">
                                                          <ul class="selectedOptionsList">
@@ -1427,13 +1427,13 @@
                                                       <th>
                                                          Photo
                                                       </th>
-                                                      <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                         Recipient
+                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                         Team
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
-                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                         Team
+                                                      <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                         Recipient
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
@@ -1457,10 +1457,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign">
-                                                         Alice Betsy
+                                                         Team 1
                                                       </td>
                                                       <td class="middlealign">
-                                                         Team 1
+                                                         Alice Betsy
                                                       </td>
                                                       <td class="text-preserve-space">
                                                          3.5
@@ -1566,13 +1566,13 @@
                                                       <th>
                                                          Photo
                                                       </th>
-                                                      <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                         Recipient
+                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                         Team
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
-                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                         Team
+                                                      <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                         Recipient
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
@@ -1596,10 +1596,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign">
-                                                         Alice Betsy
+                                                         Team 1
                                                       </td>
                                                       <td class="middlealign">
-                                                         Team 1
+                                                         Alice Betsy
                                                       </td>
                                                       <td class="text-preserve-space">
                                                          <ul>
@@ -1744,13 +1744,13 @@
                                                       <th>
                                                          Photo
                                                       </th>
-                                                      <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                         Recipient
+                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                         Team
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
-                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                         Team
+                                                      <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                         Recipient
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
@@ -1774,10 +1774,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign">
-                                                         Alice Betsy
+                                                         Team 1
                                                       </td>
                                                       <td class="middlealign">
-                                                         Team 1
+                                                         Alice Betsy
                                                       </td>
                                                       <td class="text-preserve-space">
                                                          110
@@ -1793,10 +1793,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign">
-                                                         Benny Charles
+                                                         Team 1
                                                       </td>
                                                       <td class="middlealign">
-                                                         Team 1
+                                                         Benny Charles
                                                       </td>
                                                       <td class="text-preserve-space">
                                                          90
@@ -1812,10 +1812,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign">
-                                                         Charlie Dávis
+                                                         Team 2
                                                       </td>
                                                       <td class="middlealign">
-                                                         Team 2
+                                                         Charlie Dávis
                                                       </td>
                                                       <td class="text-preserve-space">
                                                          50
@@ -1831,10 +1831,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign">
-                                                         Danny Engrid
+                                                         Team 2
                                                       </td>
                                                       <td class="middlealign">
-                                                         Team 2
+                                                         Danny Engrid
                                                       </td>
                                                       <td class="text-preserve-space">
                                                          150
@@ -1873,13 +1873,13 @@
                                                       <th>
                                                          Photo
                                                       </th>
-                                                      <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                         Recipient
+                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                         Team
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
-                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                         Team
+                                                      <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                         Recipient
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
@@ -1903,10 +1903,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign">
-                                                         Alice Betsy
+                                                         Team 1
                                                       </td>
                                                       <td class="middlealign">
-                                                         Team 1
+                                                         Alice Betsy
                                                       </td>
                                                       <td class="text-preserve-space">
                                                          <span class="color-positive">
@@ -1931,10 +1931,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign">
-                                                         Benny Charles
+                                                         Team 1
                                                       </td>
                                                       <td class="middlealign">
-                                                         Team 1
+                                                         Benny Charles
                                                       </td>
                                                       <td class="text-preserve-space">
                                                          <span class="color_neutral">
@@ -1977,13 +1977,13 @@
                                                       <th>
                                                          Photo
                                                       </th>
-                                                      <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                         Recipient
+                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                         Team
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
-                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                         Team
+                                                      <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                         Recipient
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
@@ -2006,10 +2006,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign">
-                                                         Anonymous student 227201833
+                                                         Anonymous student 227201833's Team
                                                       </td>
                                                       <td class="middlealign">
-                                                         Anonymous student 227201833's Team
+                                                         Anonymous student 227201833
                                                       </td>
                                                       <td class="text-preserve-space">
                                                          3
@@ -2024,10 +2024,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign">
-                                                         Anonymous student 410339386
+                                                         Anonymous student 410339386's Team
                                                       </td>
                                                       <td class="middlealign">
-                                                         Anonymous student 410339386's Team
+                                                         Anonymous student 410339386
                                                       </td>
                                                       <td class="text-preserve-space">
                                                          4
@@ -2066,13 +2066,13 @@
                                                       <th>
                                                          Photo
                                                       </th>
-                                                      <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                         Recipient
+                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                         Team
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
-                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                         Team
+                                                      <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                         Recipient
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
@@ -2095,10 +2095,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign">
-                                                         Anonymous student 227201833
+                                                         Anonymous student 227201833's Team
                                                       </td>
                                                       <td class="middlealign">
-                                                         Anonymous student 227201833's Team
+                                                         Anonymous student 227201833
                                                       </td>
                                                       <td class="text-preserve-space">
                                                          <span class="color_neutral">
@@ -2115,10 +2115,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign">
-                                                         Anonymous student 410339386
+                                                         Anonymous student 410339386's Team
                                                       </td>
                                                       <td class="middlealign">
-                                                         Anonymous student 410339386's Team
+                                                         Anonymous student 410339386
                                                       </td>
                                                       <td class="text-preserve-space">
                                                          <span class="color_neutral">
@@ -2171,13 +2171,13 @@
                                                       <th>
                                                          Photo
                                                       </th>
-                                                      <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                         Recipient
+                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                         Team
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
-                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                         Team
+                                                      <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                         Recipient
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
@@ -2200,9 +2200,9 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign">
-                                                         Team 1
                                                       </td>
                                                       <td class="middlealign">
+                                                         Team 1
                                                       </td>
                                                       <td class="text-preserve-space">
                                                          Response from benny to Team 1 (own team)
@@ -2312,13 +2312,13 @@
                                                       <th>
                                                          Photo
                                                       </th>
-                                                      <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                         Recipient
+                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                         Team
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
-                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                         Team
+                                                      <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                         Recipient
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionGiverQuestionRecipientTeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionGiverQuestionRecipientTeam.html
@@ -363,13 +363,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Recipient
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Recipient
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -393,10 +393,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Alice Betsy
+                                                Team 1
                                              </td>
                                              <td class="middlealign">
-                                                Team 1
+                                                Alice Betsy
                                              </td>
                                              <td class="text-preserve-space">
                                                 <ul class="selectedOptionsList">
@@ -493,13 +493,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Recipient
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Recipient
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -523,10 +523,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Alice Betsy
+                                                Team 1
                                              </td>
                                              <td class="middlealign">
-                                                Team 1
+                                                Alice Betsy
                                              </td>
                                              <td class="text-preserve-space">
                                                 <ul class="selectedOptionsList">
@@ -643,13 +643,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Recipient
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Recipient
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -673,10 +673,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Alice Betsy
+                                                Team 1
                                              </td>
                                              <td class="middlealign">
-                                                Team 1
+                                                Alice Betsy
                                              </td>
                                              <td class="text-preserve-space">
                                                 3.5
@@ -782,13 +782,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Recipient
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Recipient
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -812,10 +812,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Alice Betsy
+                                                Team 1
                                              </td>
                                              <td class="middlealign">
-                                                Team 1
+                                                Alice Betsy
                                              </td>
                                              <td class="text-preserve-space">
                                                 <ul>
@@ -960,13 +960,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Recipient
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Recipient
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -990,10 +990,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Alice Betsy
+                                                Team 1
                                              </td>
                                              <td class="middlealign">
-                                                Team 1
+                                                Alice Betsy
                                              </td>
                                              <td class="text-preserve-space">
                                                 110
@@ -1009,10 +1009,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Benny Charles
+                                                Team 1
                                              </td>
                                              <td class="middlealign">
-                                                Team 1
+                                                Benny Charles
                                              </td>
                                              <td class="text-preserve-space">
                                                 90
@@ -1028,10 +1028,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Charlie Dávis
+                                                Team 2
                                              </td>
                                              <td class="middlealign">
-                                                Team 2
+                                                Charlie Dávis
                                              </td>
                                              <td class="text-preserve-space">
                                                 50
@@ -1047,10 +1047,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Danny Engrid
+                                                Team 2
                                              </td>
                                              <td class="middlealign">
-                                                Team 2
+                                                Danny Engrid
                                              </td>
                                              <td class="text-preserve-space">
                                                 150
@@ -1089,13 +1089,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Recipient
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Recipient
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -1119,10 +1119,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Alice Betsy
+                                                Team 1
                                              </td>
                                              <td class="middlealign">
-                                                Team 1
+                                                Alice Betsy
                                              </td>
                                              <td class="text-preserve-space">
                                                 <span class="color-positive">
@@ -1147,10 +1147,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Benny Charles
+                                                Team 1
                                              </td>
                                              <td class="middlealign">
-                                                Team 1
+                                                Benny Charles
                                              </td>
                                              <td class="text-preserve-space">
                                                 <span class="color_neutral">
@@ -1193,13 +1193,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Recipient
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Recipient
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -1222,10 +1222,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Anonymous student 227201833
+                                                Anonymous student 227201833's Team
                                              </td>
                                              <td class="middlealign">
-                                                Anonymous student 227201833's Team
+                                                Anonymous student 227201833
                                              </td>
                                              <td class="text-preserve-space">
                                                 3
@@ -1240,10 +1240,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Anonymous student 410339386
+                                                Anonymous student 410339386's Team
                                              </td>
                                              <td class="middlealign">
-                                                Anonymous student 410339386's Team
+                                                Anonymous student 410339386
                                              </td>
                                              <td class="text-preserve-space">
                                                 4
@@ -1282,13 +1282,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Recipient
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Recipient
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -1311,10 +1311,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Anonymous student 227201833
+                                                Anonymous student 227201833's Team
                                              </td>
                                              <td class="middlealign">
-                                                Anonymous student 227201833's Team
+                                                Anonymous student 227201833
                                              </td>
                                              <td class="text-preserve-space">
                                                 <span class="color_neutral">
@@ -1331,10 +1331,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Anonymous student 410339386
+                                                Anonymous student 410339386's Team
                                              </td>
                                              <td class="middlealign">
-                                                Anonymous student 410339386's Team
+                                                Anonymous student 410339386
                                              </td>
                                              <td class="text-preserve-space">
                                                 <span class="color_neutral">
@@ -1467,13 +1467,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Recipient
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Recipient
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -1550,13 +1550,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Recipient
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Recipient
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -1579,9 +1579,9 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Team 1
                                              </td>
                                              <td class="middlealign">
+                                                Team 1
                                              </td>
                                              <td class="text-preserve-space">
                                                 Response from benny to Team 1 (own team)
@@ -1691,13 +1691,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Recipient
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortTo" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Recipient
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionQuestion.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionQuestion.html
@@ -363,23 +363,23 @@
                   <table class="table table-striped table-bordered dataTable margin-0">
                      <thead class="background-color-medium-gray text-color-gray font-weight-normal">
                         <tr>
-                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,1)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,1)" style="width: 15%;">
+                              Team
+                              <span class="icon-sort unsorted">
+                              </span>
+                           </th>
+                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
                               Giver
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,3)" style="width: 15%;">
                               Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,3)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,4)" style="width: 15%;">
                               Recipient
-                              <span class="icon-sort unsorted">
-                              </span>
-                           </th>
-                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,4)" style="width: 15%;">
-                              Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
@@ -398,12 +398,6 @@
                      <tbody>
                         <tr>
                            <td class="middlealign">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Alice Betsy
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign">
                               Team 1
                            </td>
                            <td class="middlealign">
@@ -414,6 +408,12 @@
                            </td>
                            <td class="middlealign">
                               Team 1
+                           </td>
+                           <td class="middlealign">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Alice Betsy
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space">
                               <ul class="selectedOptionsList">
@@ -434,12 +434,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Benny Charles
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 1
                            </td>
                            <td class="middlealign color_neutral">
@@ -450,6 +444,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 1
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Benny Charles
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -468,12 +468,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Charlie Dávis
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -484,6 +478,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Charlie Dávis
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -502,12 +502,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Danny Engrid
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -518,6 +512,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Danny Engrid
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -536,12 +536,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Drop out
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -552,6 +546,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Drop out
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -570,12 +570,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Extra guy
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -586,6 +580,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Extra guy
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -604,12 +604,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Emily
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 3
                            </td>
                            <td class="middlealign color_neutral">
@@ -620,6 +614,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 3
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Emily
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -738,23 +738,23 @@
                   <table class="table table-striped table-bordered dataTable margin-0">
                      <thead class="background-color-medium-gray text-color-gray font-weight-normal">
                         <tr>
-                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,1)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,1)" style="width: 15%;">
+                              Team
+                              <span class="icon-sort unsorted">
+                              </span>
+                           </th>
+                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
                               Giver
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,3)" style="width: 15%;">
                               Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,3)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,4)" style="width: 15%;">
                               Recipient
-                              <span class="icon-sort unsorted">
-                              </span>
-                           </th>
-                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,4)" style="width: 15%;">
-                              Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
@@ -773,12 +773,6 @@
                      <tbody>
                         <tr>
                            <td class="middlealign">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Alice Betsy
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign">
                               Team 1
                            </td>
                            <td class="middlealign">
@@ -789,6 +783,12 @@
                            </td>
                            <td class="middlealign">
                               Team 1
+                           </td>
+                           <td class="middlealign">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Alice Betsy
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space">
                               <ul class="selectedOptionsList">
@@ -812,12 +812,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Benny Charles
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 1
                            </td>
                            <td class="middlealign color_neutral">
@@ -828,6 +822,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 1
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Benny Charles
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -846,12 +846,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Charlie Dávis
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -862,6 +856,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Charlie Dávis
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -880,12 +880,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Danny Engrid
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -896,6 +890,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Danny Engrid
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -914,12 +914,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Drop out
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -930,6 +924,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Drop out
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -948,12 +948,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Extra guy
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -964,6 +958,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Extra guy
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -982,12 +982,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Emily
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 3
                            </td>
                            <td class="middlealign color_neutral">
@@ -998,6 +992,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 3
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Emily
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -1133,23 +1133,23 @@
                   <table class="table table-striped table-bordered dataTable margin-0">
                      <thead class="background-color-medium-gray text-color-gray font-weight-normal">
                         <tr>
-                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,1)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,1)" style="width: 15%;">
+                              Team
+                              <span class="icon-sort unsorted">
+                              </span>
+                           </th>
+                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
                               Giver
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,3)" style="width: 15%;">
                               Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,3)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,4)" style="width: 15%;">
                               Recipient
-                              <span class="icon-sort unsorted">
-                              </span>
-                           </th>
-                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,4)" style="width: 15%;">
-                              Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
@@ -1168,12 +1168,6 @@
                      <tbody>
                         <tr>
                            <td class="middlealign">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Alice Betsy
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign">
                               Team 1
                            </td>
                            <td class="middlealign">
@@ -1184,6 +1178,12 @@
                            </td>
                            <td class="middlealign">
                               Team 1
+                           </td>
+                           <td class="middlealign">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Alice Betsy
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space">
                               3.5
@@ -1200,12 +1200,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Benny Charles
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 1
                            </td>
                            <td class="middlealign color_neutral">
@@ -1216,6 +1210,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 1
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Benny Charles
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -1234,12 +1234,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Charlie Dávis
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -1250,6 +1244,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Charlie Dávis
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -1268,12 +1268,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Danny Engrid
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -1284,6 +1278,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Danny Engrid
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -1302,12 +1302,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Drop out
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -1318,6 +1312,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Drop out
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -1336,12 +1336,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Extra guy
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -1352,6 +1346,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Extra guy
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -1370,12 +1370,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Emily
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 3
                            </td>
                            <td class="middlealign color_neutral">
@@ -1386,6 +1380,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 3
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Emily
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -1517,23 +1517,23 @@
                   <table class="table table-striped table-bordered dataTable margin-0">
                      <thead class="background-color-medium-gray text-color-gray font-weight-normal">
                         <tr>
-                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,1)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,1)" style="width: 15%;">
+                              Team
+                              <span class="icon-sort unsorted">
+                              </span>
+                           </th>
+                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
                               Giver
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,3)" style="width: 15%;">
                               Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,3)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,4)" style="width: 15%;">
                               Recipient
-                              <span class="icon-sort unsorted">
-                              </span>
-                           </th>
-                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,4)" style="width: 15%;">
-                              Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
@@ -1552,12 +1552,6 @@
                      <tbody>
                         <tr>
                            <td class="middlealign">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Alice Betsy
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign">
                               Team 1
                            </td>
                            <td class="middlealign">
@@ -1568,6 +1562,12 @@
                            </td>
                            <td class="middlealign">
                               Team 1
+                           </td>
+                           <td class="middlealign">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Alice Betsy
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space">
                               <ul>
@@ -1591,12 +1591,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Benny Charles
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 1
                            </td>
                            <td class="middlealign color_neutral">
@@ -1607,6 +1601,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 1
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Benny Charles
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -1625,12 +1625,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Charlie Dávis
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -1641,6 +1635,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Charlie Dávis
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -1659,12 +1659,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Danny Engrid
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -1675,6 +1669,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Danny Engrid
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -1693,12 +1693,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Drop out
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -1709,6 +1703,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Drop out
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -1727,12 +1727,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Extra guy
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -1743,6 +1737,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Extra guy
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -1761,12 +1761,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Emily
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 3
                            </td>
                            <td class="middlealign color_neutral">
@@ -1777,6 +1771,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 3
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Emily
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -1940,23 +1940,23 @@
                   <table class="table table-striped table-bordered dataTable margin-0">
                      <thead class="background-color-medium-gray text-color-gray font-weight-normal">
                         <tr>
-                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,1)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,1)" style="width: 15%;">
+                              Team
+                              <span class="icon-sort unsorted">
+                              </span>
+                           </th>
+                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
                               Giver
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,3)" style="width: 15%;">
                               Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,3)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,4)" style="width: 15%;">
                               Recipient
-                              <span class="icon-sort unsorted">
-                              </span>
-                           </th>
-                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,4)" style="width: 15%;">
-                              Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
@@ -1975,12 +1975,6 @@
                      <tbody>
                         <tr>
                            <td class="middlealign">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Alice Betsy
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign">
                               Team 1
                            </td>
                            <td class="middlealign">
@@ -1991,6 +1985,12 @@
                            </td>
                            <td class="middlealign">
                               Team 1
+                           </td>
+                           <td class="middlealign">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Alice Betsy
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space">
                               110
@@ -2007,6 +2007,9 @@
                         </tr>
                         <tr>
                            <td class="middlealign">
+                              Team 1
+                           </td>
+                           <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Alice Betsy
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
@@ -2020,9 +2023,6 @@
                                  Benny Charles
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign">
-                              Team 1
                            </td>
                            <td class="text-preserve-space">
                               90
@@ -2039,22 +2039,22 @@
                         </tr>
                         <tr>
                            <td class="middlealign">
+                              Team 1
+                           </td>
+                           <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Alice Betsy
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
                            <td class="middlealign">
-                              Team 1
+                              Team 2
                            </td>
                            <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Charlie Dávis
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign">
-                              Team 2
                            </td>
                            <td class="text-preserve-space">
                               50
@@ -2071,22 +2071,22 @@
                         </tr>
                         <tr>
                            <td class="middlealign">
+                              Team 1
+                           </td>
+                           <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Alice Betsy
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
                            <td class="middlealign">
-                              Team 1
+                              Team 2
                            </td>
                            <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Danny Engrid
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign">
-                              Team 2
                            </td>
                            <td class="text-preserve-space">
                               150
@@ -2103,6 +2103,9 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
+                              Team 1
+                           </td>
+                           <td class="middlealign color_neutral">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Benny Charles
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
@@ -2117,8 +2120,39 @@
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
+                           <td class="text-preserve-space color_neutral">
+                              <i>
+                                 No Response
+                              </i>
+                           </td>
+                           <td>
+                              <form action="/page/instructorEditStudentFeedbackPage?user=CFResultsUiT.instr" class="inline" method="post" target="_blank">
+                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
+                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
+                                 <input name="fsname" type="hidden" value="Second Session"/>
+                                 <input name="moderatedquestion" type="hidden" value="6"/>
+                                 <input name="moderatedstudent" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt"/>
+                              </form>
+                           </td>
+                        </tr>
+                        <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
                               Team 1
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Benny Charles
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
+                           </td>
+                           <td class="middlealign color_neutral">
+                              Team 1
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Benny Charles
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -2137,39 +2171,8 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Benny Charles
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
+                              Team 2
                            </td>
-                           <td class="middlealign color_neutral">
-                              Team 1
-                           </td>
-                           <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Benny Charles
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
-                              Team 1
-                           </td>
-                           <td class="text-preserve-space color_neutral">
-                              <i>
-                                 No Response
-                              </i>
-                           </td>
-                           <td>
-                              <form action="/page/instructorEditStudentFeedbackPage?user=CFResultsUiT.instr" class="inline" method="post" target="_blank">
-                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
-                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
-                                 <input name="fsname" type="hidden" value="Second Session"/>
-                                 <input name="moderatedquestion" type="hidden" value="6"/>
-                                 <input name="moderatedstudent" type="hidden" value="CFResultsUiT.benny.c@gmail.tmt"/>
-                              </form>
-                           </td>
-                        </tr>
-                        <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Charlie Dávis
@@ -2184,9 +2187,6 @@
                                  Charlie Dávis
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign color_neutral">
-                              Team 2
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -2205,6 +2205,9 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
+                              Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Charlie Dávis
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
@@ -2218,9 +2221,6 @@
                                  Danny Engrid
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign color_neutral">
-                              Team 2
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -2239,6 +2239,9 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
+                              Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Charlie Dávis
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
@@ -2252,9 +2255,6 @@
                                  Drop out
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign color_neutral">
-                              Team 2
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -2273,6 +2273,9 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
+                              Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Charlie Dávis
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
@@ -2286,9 +2289,6 @@
                                  Extra guy
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign color_neutral">
-                              Team 2
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -2307,6 +2307,9 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
+                              Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Danny Engrid
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
@@ -2321,8 +2324,39 @@
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
+                           <td class="text-preserve-space color_neutral">
+                              <i>
+                                 No Response
+                              </i>
+                           </td>
+                           <td>
+                              <form action="/page/instructorEditStudentFeedbackPage?user=CFResultsUiT.instr" class="inline" method="post" target="_blank">
+                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
+                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
+                                 <input name="fsname" type="hidden" value="Second Session"/>
+                                 <input name="moderatedquestion" type="hidden" value="6"/>
+                                 <input name="moderatedstudent" type="hidden" value="CFResultsUiT.danny.e@gmail.tmt"/>
+                              </form>
+                           </td>
+                        </tr>
+                        <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Danny Engrid
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
+                           </td>
+                           <td class="middlealign color_neutral">
+                              Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Danny Engrid
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -2341,39 +2375,8 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Danny Engrid
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
-                           <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Danny Engrid
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
-                              Team 2
-                           </td>
-                           <td class="text-preserve-space color_neutral">
-                              <i>
-                                 No Response
-                              </i>
-                           </td>
-                           <td>
-                              <form action="/page/instructorEditStudentFeedbackPage?user=CFResultsUiT.instr" class="inline" method="post" target="_blank">
-                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
-                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
-                                 <input name="fsname" type="hidden" value="Second Session"/>
-                                 <input name="moderatedquestion" type="hidden" value="6"/>
-                                 <input name="moderatedstudent" type="hidden" value="CFResultsUiT.danny.e@gmail.tmt"/>
-                              </form>
-                           </td>
-                        </tr>
-                        <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Danny Engrid
@@ -2389,9 +2392,6 @@
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
-                           <td class="middlealign color_neutral">
-                              Team 2
-                           </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
                                  No Response
@@ -2408,6 +2408,9 @@
                            </td>
                         </tr>
                         <tr class="pending_response_row">
+                           <td class="middlealign color_neutral">
+                              Team 2
+                           </td>
                            <td class="middlealign color_neutral">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Danny Engrid
@@ -2423,9 +2426,6 @@
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
-                           <td class="middlealign color_neutral">
-                              Team 2
-                           </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
                                  No Response
@@ -2442,6 +2442,9 @@
                            </td>
                         </tr>
                         <tr class="pending_response_row">
+                           <td class="middlealign color_neutral">
+                              Team 2
+                           </td>
                            <td class="middlealign color_neutral">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Drop out
@@ -2457,9 +2460,6 @@
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
-                           <td class="middlealign color_neutral">
-                              Team 2
-                           </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
                                  No Response
@@ -2476,6 +2476,9 @@
                            </td>
                         </tr>
                         <tr class="pending_response_row">
+                           <td class="middlealign color_neutral">
+                              Team 2
+                           </td>
                            <td class="middlealign color_neutral">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Drop out
@@ -2491,8 +2494,39 @@
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
+                           <td class="text-preserve-space color_neutral">
+                              <i>
+                                 No Response
+                              </i>
+                           </td>
+                           <td>
+                              <form action="/page/instructorEditStudentFeedbackPage?user=CFResultsUiT.instr" class="inline" method="post" target="_blank">
+                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
+                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
+                                 <input name="fsname" type="hidden" value="Second Session"/>
+                                 <input name="moderatedquestion" type="hidden" value="6"/>
+                                 <input name="moderatedstudent" type="hidden" value="drop.out@gmail.tmt"/>
+                              </form>
+                           </td>
+                        </tr>
+                        <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Drop out
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
+                           </td>
+                           <td class="middlealign color_neutral">
+                              Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Drop out
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -2511,39 +2545,8 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Drop out
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
-                           <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Drop out
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
-                              Team 2
-                           </td>
-                           <td class="text-preserve-space color_neutral">
-                              <i>
-                                 No Response
-                              </i>
-                           </td>
-                           <td>
-                              <form action="/page/instructorEditStudentFeedbackPage?user=CFResultsUiT.instr" class="inline" method="post" target="_blank">
-                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
-                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
-                                 <input name="fsname" type="hidden" value="Second Session"/>
-                                 <input name="moderatedquestion" type="hidden" value="6"/>
-                                 <input name="moderatedstudent" type="hidden" value="drop.out@gmail.tmt"/>
-                              </form>
-                           </td>
-                        </tr>
-                        <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Drop out
@@ -2559,9 +2562,6 @@
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
-                           <td class="middlealign color_neutral">
-                              Team 2
-                           </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
                                  No Response
@@ -2578,6 +2578,9 @@
                            </td>
                         </tr>
                         <tr class="pending_response_row">
+                           <td class="middlealign color_neutral">
+                              Team 2
+                           </td>
                            <td class="middlealign color_neutral">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Extra guy
@@ -2593,9 +2596,6 @@
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
-                           <td class="middlealign color_neutral">
-                              Team 2
-                           </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
                                  No Response
@@ -2612,6 +2612,9 @@
                            </td>
                         </tr>
                         <tr class="pending_response_row">
+                           <td class="middlealign color_neutral">
+                              Team 2
+                           </td>
                            <td class="middlealign color_neutral">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Extra guy
@@ -2627,9 +2630,6 @@
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
-                           <td class="middlealign color_neutral">
-                              Team 2
-                           </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
                                  No Response
@@ -2646,6 +2646,9 @@
                            </td>
                         </tr>
                         <tr class="pending_response_row">
+                           <td class="middlealign color_neutral">
+                              Team 2
+                           </td>
                            <td class="middlealign color_neutral">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Extra guy
@@ -2661,8 +2664,39 @@
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
+                           <td class="text-preserve-space color_neutral">
+                              <i>
+                                 No Response
+                              </i>
+                           </td>
+                           <td>
+                              <form action="/page/instructorEditStudentFeedbackPage?user=CFResultsUiT.instr" class="inline" method="post" target="_blank">
+                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
+                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
+                                 <input name="fsname" type="hidden" value="Second Session"/>
+                                 <input name="moderatedquestion" type="hidden" value="6"/>
+                                 <input name="moderatedstudent" type="hidden" value="extra.guy@gmail.tmt"/>
+                              </form>
+                           </td>
+                        </tr>
+                        <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Extra guy
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
+                           </td>
+                           <td class="middlealign color_neutral">
+                              Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Extra guy
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -2681,39 +2715,8 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Extra guy
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
+                              Team 3
                            </td>
-                           <td class="middlealign color_neutral">
-                              Team 2
-                           </td>
-                           <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Extra guy
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
-                              Team 2
-                           </td>
-                           <td class="text-preserve-space color_neutral">
-                              <i>
-                                 No Response
-                              </i>
-                           </td>
-                           <td>
-                              <form action="/page/instructorEditStudentFeedbackPage?user=CFResultsUiT.instr" class="inline" method="post" target="_blank">
-                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
-                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
-                                 <input name="fsname" type="hidden" value="Second Session"/>
-                                 <input name="moderatedquestion" type="hidden" value="6"/>
-                                 <input name="moderatedstudent" type="hidden" value="extra.guy@gmail.tmt"/>
-                              </form>
-                           </td>
-                        </tr>
-                        <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Emily
@@ -2728,9 +2731,6 @@
                                  Emily
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign color_neutral">
-                              Team 3
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -3083,23 +3083,23 @@
                   <table class="table table-striped table-bordered dataTable margin-0">
                      <thead class="background-color-medium-gray text-color-gray font-weight-normal">
                         <tr>
-                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,1)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,1)" style="width: 15%;">
+                              Team
+                              <span class="icon-sort unsorted">
+                              </span>
+                           </th>
+                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
                               Giver
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,3)" style="width: 15%;">
                               Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,3)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,4)" style="width: 15%;">
                               Recipient
-                              <span class="icon-sort unsorted">
-                              </span>
-                           </th>
-                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,4)" style="width: 15%;">
-                              Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
@@ -3118,12 +3118,6 @@
                      <tbody>
                         <tr>
                            <td class="middlealign">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Alice Betsy
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign">
                               Team 1
                            </td>
                            <td class="middlealign">
@@ -3134,6 +3128,12 @@
                            </td>
                            <td class="middlealign">
                               Team 1
+                           </td>
+                           <td class="middlealign">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Alice Betsy
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space">
                               <span class="color-positive">
@@ -3159,6 +3159,9 @@
                         </tr>
                         <tr>
                            <td class="middlealign">
+                              Team 1
+                           </td>
+                           <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Alice Betsy
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
@@ -3172,9 +3175,6 @@
                                  Benny Charles
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign">
-                              Team 1
                            </td>
                            <td class="text-preserve-space">
                               <span class="color_neutral">
@@ -3193,6 +3193,9 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
+                              Team 1
+                           </td>
+                           <td class="middlealign color_neutral">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Benny Charles
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
@@ -3206,9 +3209,6 @@
                                  Alice Betsy
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign color_neutral">
-                              Team 1
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -3227,12 +3227,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Benny Charles
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 1
                            </td>
                            <td class="middlealign color_neutral">
@@ -3243,6 +3237,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 1
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Benny Charles
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -3268,12 +3268,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Charlie Dávis
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -3284,6 +3278,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Charlie Dávis
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -3302,6 +3302,9 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
+                              Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Charlie Dávis
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
@@ -3315,9 +3318,6 @@
                                  Danny Engrid
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign color_neutral">
-                              Team 2
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -3336,6 +3336,9 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
+                              Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Charlie Dávis
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
@@ -3349,9 +3352,6 @@
                                  Drop out
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign color_neutral">
-                              Team 2
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -3370,6 +3370,9 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
+                              Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Charlie Dávis
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
@@ -3383,9 +3386,6 @@
                                  Extra guy
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
-                           </td>
-                           <td class="middlealign color_neutral">
-                              Team 2
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -3404,6 +3404,9 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
+                              Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Danny Engrid
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
@@ -3418,8 +3421,39 @@
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
+                           <td class="text-preserve-space color_neutral">
+                              <i>
+                                 No Response
+                              </i>
+                           </td>
+                           <td>
+                              <form action="/page/instructorEditStudentFeedbackPage?user=CFResultsUiT.instr" class="inline" method="post" target="_blank">
+                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
+                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
+                                 <input name="fsname" type="hidden" value="Second Session"/>
+                                 <input name="moderatedquestion" type="hidden" value="7"/>
+                                 <input name="moderatedstudent" type="hidden" value="CFResultsUiT.danny.e@gmail.tmt"/>
+                              </form>
+                           </td>
+                        </tr>
+                        <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Danny Engrid
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
+                           </td>
+                           <td class="middlealign color_neutral">
+                              Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Danny Engrid
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -3438,39 +3472,8 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Danny Engrid
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
-                           <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Danny Engrid
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
-                              Team 2
-                           </td>
-                           <td class="text-preserve-space color_neutral">
-                              <i>
-                                 No Response
-                              </i>
-                           </td>
-                           <td>
-                              <form action="/page/instructorEditStudentFeedbackPage?user=CFResultsUiT.instr" class="inline" method="post" target="_blank">
-                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
-                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
-                                 <input name="fsname" type="hidden" value="Second Session"/>
-                                 <input name="moderatedquestion" type="hidden" value="7"/>
-                                 <input name="moderatedstudent" type="hidden" value="CFResultsUiT.danny.e@gmail.tmt"/>
-                              </form>
-                           </td>
-                        </tr>
-                        <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Danny Engrid
@@ -3486,9 +3489,6 @@
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
-                           <td class="middlealign color_neutral">
-                              Team 2
-                           </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
                                  No Response
@@ -3505,6 +3505,9 @@
                            </td>
                         </tr>
                         <tr class="pending_response_row">
+                           <td class="middlealign color_neutral">
+                              Team 2
+                           </td>
                            <td class="middlealign color_neutral">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Danny Engrid
@@ -3520,9 +3523,6 @@
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
-                           <td class="middlealign color_neutral">
-                              Team 2
-                           </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
                                  No Response
@@ -3539,6 +3539,9 @@
                            </td>
                         </tr>
                         <tr class="pending_response_row">
+                           <td class="middlealign color_neutral">
+                              Team 2
+                           </td>
                            <td class="middlealign color_neutral">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Drop out
@@ -3554,9 +3557,6 @@
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
-                           <td class="middlealign color_neutral">
-                              Team 2
-                           </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
                                  No Response
@@ -3573,6 +3573,9 @@
                            </td>
                         </tr>
                         <tr class="pending_response_row">
+                           <td class="middlealign color_neutral">
+                              Team 2
+                           </td>
                            <td class="middlealign color_neutral">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Drop out
@@ -3588,8 +3591,39 @@
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
+                           <td class="text-preserve-space color_neutral">
+                              <i>
+                                 No Response
+                              </i>
+                           </td>
+                           <td>
+                              <form action="/page/instructorEditStudentFeedbackPage?user=CFResultsUiT.instr" class="inline" method="post" target="_blank">
+                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
+                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
+                                 <input name="fsname" type="hidden" value="Second Session"/>
+                                 <input name="moderatedquestion" type="hidden" value="7"/>
+                                 <input name="moderatedstudent" type="hidden" value="drop.out@gmail.tmt"/>
+                              </form>
+                           </td>
+                        </tr>
+                        <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Drop out
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
+                           </td>
+                           <td class="middlealign color_neutral">
+                              Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Drop out
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -3608,39 +3642,8 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Drop out
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
-                           <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Drop out
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
-                              Team 2
-                           </td>
-                           <td class="text-preserve-space color_neutral">
-                              <i>
-                                 No Response
-                              </i>
-                           </td>
-                           <td>
-                              <form action="/page/instructorEditStudentFeedbackPage?user=CFResultsUiT.instr" class="inline" method="post" target="_blank">
-                                 <input class="btn btn-default btn-xs" data-original-title="Edit the responses given by this student" data-toggle="tooltip" title="" type="submit" value="Moderate Response"/>
-                                 <input name="courseid" type="hidden" value="CFResultsUiT.CS2104"/>
-                                 <input name="fsname" type="hidden" value="Second Session"/>
-                                 <input name="moderatedquestion" type="hidden" value="7"/>
-                                 <input name="moderatedstudent" type="hidden" value="drop.out@gmail.tmt"/>
-                              </form>
-                           </td>
-                        </tr>
-                        <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Drop out
@@ -3656,9 +3659,6 @@
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
-                           <td class="middlealign color_neutral">
-                              Team 2
-                           </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
                                  No Response
@@ -3675,6 +3675,9 @@
                            </td>
                         </tr>
                         <tr class="pending_response_row">
+                           <td class="middlealign color_neutral">
+                              Team 2
+                           </td>
                            <td class="middlealign color_neutral">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Extra guy
@@ -3690,9 +3693,6 @@
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
-                           <td class="middlealign color_neutral">
-                              Team 2
-                           </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
                                  No Response
@@ -3709,6 +3709,9 @@
                            </td>
                         </tr>
                         <tr class="pending_response_row">
+                           <td class="middlealign color_neutral">
+                              Team 2
+                           </td>
                            <td class="middlealign color_neutral">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Extra guy
@@ -3724,9 +3727,6 @@
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
-                           <td class="middlealign color_neutral">
-                              Team 2
-                           </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
                                  No Response
@@ -3743,6 +3743,9 @@
                            </td>
                         </tr>
                         <tr class="pending_response_row">
+                           <td class="middlealign color_neutral">
+                              Team 2
+                           </td>
                            <td class="middlealign color_neutral">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Extra guy
@@ -3758,9 +3761,6 @@
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
-                           <td class="middlealign color_neutral">
-                              Team 2
-                           </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
                                  No Response
@@ -3778,12 +3778,6 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Extra guy
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
-                           <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
@@ -3794,6 +3788,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Extra guy
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -3811,12 +3811,6 @@
                            </td>
                         </tr>
                         <tr class="pending_response_row">
-                           <td class="middlealign color_neutral">
-                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
-                                 Emily
-                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
-                              </div>
-                           </td>
                            <td class="middlealign color_neutral">
                               Team 3
                            </td>
@@ -3828,6 +3822,12 @@
                            </td>
                            <td class="middlealign color_neutral">
                               Team 3
+                           </td>
+                           <td class="middlealign color_neutral">
+                              <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
+                                 Emily
+                                 <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
+                              </div>
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -3894,23 +3894,23 @@
                   <table class="table table-striped table-bordered dataTable margin-0">
                      <thead class="background-color-medium-gray text-color-gray font-weight-normal">
                         <tr>
-                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,1)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,1)" style="width: 15%;">
+                              Team
+                              <span class="icon-sort unsorted">
+                              </span>
+                           </th>
+                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
                               Giver
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,3)" style="width: 15%;">
                               Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,3)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,4)" style="width: 15%;">
                               Recipient
-                              <span class="icon-sort unsorted">
-                              </span>
-                           </th>
-                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,4)" style="width: 15%;">
-                              Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
@@ -3929,19 +3929,19 @@
                      <tbody>
                         <tr>
                            <td class="middlealign">
+                              Team 1
+                           </td>
+                           <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Alice Betsy
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
                            <td class="middlealign">
-                              Team 1
+                              Anonymous student 227201833's Team
                            </td>
                            <td class="middlealign">
                               Anonymous student 227201833
-                           </td>
-                           <td class="middlealign">
-                              Anonymous student 227201833's Team
                            </td>
                            <td class="text-preserve-space">
                               3
@@ -3958,19 +3958,19 @@
                         </tr>
                         <tr>
                            <td class="middlealign">
+                              Team 1
+                           </td>
+                           <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Alice Betsy
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
                            <td class="middlealign">
-                              Team 1
+                              Anonymous student 410339386's Team
                            </td>
                            <td class="middlealign">
                               Anonymous student 410339386
-                           </td>
-                           <td class="middlealign">
-                              Anonymous student 410339386's Team
                            </td>
                            <td class="text-preserve-space">
                               4
@@ -4104,23 +4104,23 @@
                   <table class="table table-striped table-bordered dataTable margin-0">
                      <thead class="background-color-medium-gray text-color-gray font-weight-normal">
                         <tr>
-                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,1)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,1)" style="width: 15%;">
+                              Team
+                              <span class="icon-sort unsorted">
+                              </span>
+                           </th>
+                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
                               Giver
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,3)" style="width: 15%;">
                               Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,3)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,4)" style="width: 15%;">
                               Recipient
-                              <span class="icon-sort unsorted">
-                              </span>
-                           </th>
-                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,4)" style="width: 15%;">
-                              Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
@@ -4139,10 +4139,10 @@
                      <tbody>
                         <tr>
                            <td class="middlealign">
-                              Anonymous student 410339386
+                              Anonymous student 410339386's Team
                            </td>
                            <td class="middlealign">
-                              Anonymous student 410339386's Team
+                              Anonymous student 410339386
                            </td>
                            <td class="middlealign">
                               -
@@ -4492,23 +4492,23 @@
                   <table class="table table-striped table-bordered dataTable margin-0">
                      <thead class="background-color-medium-gray text-color-gray font-weight-normal">
                         <tr>
-                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,1)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,1)" style="width: 15%;">
+                              Team
+                              <span class="icon-sort unsorted">
+                              </span>
+                           </th>
+                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
                               Giver
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,3)" style="width: 15%;">
                               Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,3)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,4)" style="width: 15%;">
                               Recipient
-                              <span class="icon-sort unsorted">
-                              </span>
-                           </th>
-                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,4)" style="width: 15%;">
-                              Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
@@ -4527,19 +4527,19 @@
                      <tbody>
                         <tr>
                            <td class="middlealign">
+                              Team 1
+                           </td>
+                           <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Alice Betsy
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
                            <td class="middlealign">
-                              Team 1
+                              Anonymous student 227201833's Team
                            </td>
                            <td class="middlealign">
                               Anonymous student 227201833
-                           </td>
-                           <td class="middlealign">
-                              Anonymous student 227201833's Team
                            </td>
                            <td class="text-preserve-space">
                               <span class="color_neutral">
@@ -4558,19 +4558,19 @@
                         </tr>
                         <tr>
                            <td class="middlealign">
+                              Team 1
+                           </td>
+                           <td class="middlealign">
                               <div class="profile-pic-icon-hover" data-link="/page/studentProfilePic?studentemail=${student.email.enc}&courseid=${course.id.enc}&user=CFResultsUiT.instr" data-original-title="" title="">
                                  Alice Betsy
                                  <img alt="No Image Given" class="hidden profile-pic-icon-hidden" src=""/>
                               </div>
                            </td>
                            <td class="middlealign">
-                              Team 1
+                              Anonymous student 410339386's Team
                            </td>
                            <td class="middlealign">
                               Anonymous student 410339386
-                           </td>
-                           <td class="middlealign">
-                              Anonymous student 410339386's Team
                            </td>
                            <td class="text-preserve-space">
                               <span class="color_neutral">
@@ -4626,23 +4626,23 @@
                   <table class="table table-striped table-bordered dataTable margin-0">
                      <thead class="background-color-medium-gray text-color-gray font-weight-normal">
                         <tr>
-                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,1)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,1)" style="width: 15%;">
+                              Team
+                              <span class="icon-sort unsorted">
+                              </span>
+                           </th>
+                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
                               Giver
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,3)" style="width: 15%;">
                               Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,3)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,4)" style="width: 15%;">
                               Recipient
-                              <span class="icon-sort unsorted">
-                              </span>
-                           </th>
-                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,4)" style="width: 15%;">
-                              Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
@@ -4661,14 +4661,14 @@
                      <tbody>
                         <tr>
                            <td class="middlealign">
-                              Team 1
-                           </td>
-                           <td class="middlealign">
                            </td>
                            <td class="middlealign">
                               Team 1
                            </td>
                            <td class="middlealign">
+                           </td>
+                           <td class="middlealign">
+                              Team 1
                            </td>
                            <td class="text-preserve-space">
                               Response from benny to Team 1 (own team)
@@ -4685,14 +4685,14 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              Team 2
-                           </td>
-                           <td class="middlealign color_neutral">
                            </td>
                            <td class="middlealign color_neutral">
                               Team 2
                            </td>
                            <td class="middlealign color_neutral">
+                           </td>
+                           <td class="middlealign color_neutral">
+                              Team 2
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -4711,14 +4711,14 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              Team 3
-                           </td>
-                           <td class="middlealign color_neutral">
                            </td>
                            <td class="middlealign color_neutral">
                               Team 3
                            </td>
                            <td class="middlealign color_neutral">
+                           </td>
+                           <td class="middlealign color_neutral">
+                              Team 3
                            </td>
                            <td class="text-preserve-space color_neutral">
                               <i>
@@ -4854,23 +4854,23 @@
                   <table class="table table-striped table-bordered dataTable margin-0">
                      <thead class="background-color-medium-gray text-color-gray font-weight-normal">
                         <tr>
-                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,1)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,1)" style="width: 15%;">
+                              Team
+                              <span class="icon-sort unsorted">
+                              </span>
+                           </th>
+                           <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
                               Giver
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,3)" style="width: 15%;">
                               Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
-                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,3)" style="width: 15%;">
+                           <th class="button-sort-none" id="button_sortToName" onclick="toggleSort(this,4)" style="width: 15%;">
                               Recipient
-                              <span class="icon-sort unsorted">
-                              </span>
-                           </th>
-                           <th class="button-sort-ascending" id="button_sortToTeam" onclick="toggleSort(this,4)" style="width: 15%;">
-                              Team
                               <span class="icon-sort unsorted">
                               </span>
                            </th>
@@ -4889,9 +4889,9 @@
                      <tbody>
                         <tr>
                            <td class="middlealign">
-                              Team 1
                            </td>
                            <td class="middlealign">
+                              Team 1
                            </td>
                            <td class="middlealign">
                               -
@@ -4914,9 +4914,9 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              Team 2
                            </td>
                            <td class="middlealign color_neutral">
+                              Team 2
                            </td>
                            <td class="middlealign color_neutral">
                               -
@@ -4941,9 +4941,9 @@
                         </tr>
                         <tr class="pending_response_row">
                            <td class="middlealign color_neutral">
-                              Team 3
                            </td>
                            <td class="middlealign color_neutral">
+                              Team 3
                            </td>
                            <td class="middlealign color_neutral">
                               -

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionRecipientQuestionGiver.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionRecipientQuestionGiver.html
@@ -399,13 +399,13 @@
                                                       <th>
                                                          Photo
                                                       </th>
-                                                      <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                         Giver
+                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                         Team
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
-                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                         Team
+                                                      <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                         Giver
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
@@ -431,10 +431,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign">
-                                                         Anonymous student 410339386
+                                                         Anonymous student 410339386's Team
                                                       </td>
                                                       <td class="middlealign">
-                                                         Anonymous student 410339386's Team
+                                                         Anonymous student 410339386
                                                       </td>
                                                       <td class="text-preserve-space">
                                                          -0.5
@@ -546,13 +546,13 @@
                                                       <th>
                                                          Photo
                                                       </th>
-                                                      <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                         Giver
+                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                         Team
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
-                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                         Team
+                                                      <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                         Giver
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
@@ -578,9 +578,9 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign">
-                                                         Team 1
                                                       </td>
                                                       <td class="middlealign">
+                                                         Team 1
                                                       </td>
                                                       <td class="text-preserve-space">
                                                          0
@@ -604,9 +604,9 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign color_neutral">
-                                                         Team 2
                                                       </td>
                                                       <td class="middlealign color_neutral">
+                                                         Team 2
                                                       </td>
                                                       <td class="text-preserve-space color_neutral">
                                                          <i>
@@ -632,9 +632,9 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign color_neutral">
-                                                         Team 3
                                                       </td>
                                                       <td class="middlealign color_neutral">
+                                                         Team 3
                                                       </td>
                                                       <td class="text-preserve-space color_neutral">
                                                          <i>
@@ -753,13 +753,13 @@
                                                       <th>
                                                          Photo
                                                       </th>
-                                                      <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                         Giver
+                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                         Team
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
-                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                         Team
+                                                      <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                         Giver
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
@@ -786,10 +786,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign">
-                                                         Alice Betsy
+                                                         Team 1
                                                       </td>
                                                       <td class="middlealign">
-                                                         Team 1
+                                                         Alice Betsy
                                                       </td>
                                                       <td class="text-preserve-space">
                                                          3
@@ -837,13 +837,13 @@
                                                       <th>
                                                          Photo
                                                       </th>
-                                                      <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                         Giver
+                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                         Team
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
-                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                         Team
+                                                      <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                         Giver
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
@@ -870,10 +870,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign">
-                                                         Alice Betsy
+                                                         Team 1
                                                       </td>
                                                       <td class="middlealign">
-                                                         Team 1
+                                                         Alice Betsy
                                                       </td>
                                                       <td class="text-preserve-space">
                                                          <span class="color_neutral">
@@ -967,13 +967,13 @@
                                                       <th>
                                                          Photo
                                                       </th>
-                                                      <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                         Giver
+                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                         Team
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
-                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                         Team
+                                                      <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                         Giver
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
@@ -1000,10 +1000,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign">
-                                                         Alice Betsy
+                                                         Team 1
                                                       </td>
                                                       <td class="middlealign">
-                                                         Team 1
+                                                         Alice Betsy
                                                       </td>
                                                       <td class="text-preserve-space">
                                                          4
@@ -1051,13 +1051,13 @@
                                                       <th>
                                                          Photo
                                                       </th>
-                                                      <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                         Giver
+                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                         Team
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
-                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                         Team
+                                                      <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                         Giver
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
@@ -1084,10 +1084,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign">
-                                                         Alice Betsy
+                                                         Team 1
                                                       </td>
                                                       <td class="middlealign">
-                                                         Team 1
+                                                         Alice Betsy
                                                       </td>
                                                       <td class="text-preserve-space">
                                                          <span class="color_neutral">
@@ -1682,13 +1682,13 @@
                                                       <th>
                                                          Photo
                                                       </th>
-                                                      <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                         Giver
+                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                         Team
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
-                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                         Team
+                                                      <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                         Giver
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
@@ -1715,10 +1715,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign">
-                                                         Alice Betsy
+                                                         Team 1
                                                       </td>
                                                       <td class="middlealign">
-                                                         Team 1
+                                                         Alice Betsy
                                                       </td>
                                                       <td class="text-preserve-space">
                                                          <ul class="selectedOptionsList">
@@ -1824,13 +1824,13 @@
                                                       <th>
                                                          Photo
                                                       </th>
-                                                      <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                         Giver
+                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                         Team
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
-                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                         Team
+                                                      <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                         Giver
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
@@ -1857,10 +1857,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign">
-                                                         Alice Betsy
+                                                         Team 1
                                                       </td>
                                                       <td class="middlealign">
-                                                         Team 1
+                                                         Alice Betsy
                                                       </td>
                                                       <td class="text-preserve-space">
                                                          <ul class="selectedOptionsList">
@@ -1986,13 +1986,13 @@
                                                       <th>
                                                          Photo
                                                       </th>
-                                                      <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                         Giver
+                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                         Team
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
-                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                         Team
+                                                      <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                         Giver
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
@@ -2019,10 +2019,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign">
-                                                         Alice Betsy
+                                                         Team 1
                                                       </td>
                                                       <td class="middlealign">
-                                                         Team 1
+                                                         Alice Betsy
                                                       </td>
                                                       <td class="text-preserve-space">
                                                          3.5
@@ -2137,13 +2137,13 @@
                                                       <th>
                                                          Photo
                                                       </th>
-                                                      <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                         Giver
+                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                         Team
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
-                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                         Team
+                                                      <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                         Giver
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
@@ -2170,10 +2170,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign">
-                                                         Alice Betsy
+                                                         Team 1
                                                       </td>
                                                       <td class="middlealign">
-                                                         Team 1
+                                                         Alice Betsy
                                                       </td>
                                                       <td class="text-preserve-space">
                                                          <ul>
@@ -2285,13 +2285,13 @@
                                                       <th>
                                                          Photo
                                                       </th>
-                                                      <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                         Giver
+                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                         Team
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
-                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                         Team
+                                                      <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                         Giver
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
@@ -2318,10 +2318,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign">
-                                                         Alice Betsy
+                                                         Team 1
                                                       </td>
                                                       <td class="middlealign">
-                                                         Team 1
+                                                         Alice Betsy
                                                       </td>
                                                       <td class="text-preserve-space">
                                                          110
@@ -2346,10 +2346,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign color_neutral">
-                                                         Benny Charles
+                                                         Team 1
                                                       </td>
                                                       <td class="middlealign color_neutral">
-                                                         Team 1
+                                                         Benny Charles
                                                       </td>
                                                       <td class="text-preserve-space color_neutral">
                                                          <i>
@@ -2399,13 +2399,13 @@
                                                       <th>
                                                          Photo
                                                       </th>
-                                                      <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                         Giver
+                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                         Team
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
-                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                         Team
+                                                      <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                         Giver
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
@@ -2432,10 +2432,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign">
-                                                         Alice Betsy
+                                                         Team 1
                                                       </td>
                                                       <td class="middlealign">
-                                                         Team 1
+                                                         Alice Betsy
                                                       </td>
                                                       <td class="text-preserve-space">
                                                          <span class="color-positive">
@@ -2469,10 +2469,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign color_neutral">
-                                                         Benny Charles
+                                                         Team 1
                                                       </td>
                                                       <td class="middlealign color_neutral">
-                                                         Team 1
+                                                         Benny Charles
                                                       </td>
                                                       <td class="text-preserve-space color_neutral">
                                                          <i>
@@ -2604,13 +2604,13 @@
                                                       <th>
                                                          Photo
                                                       </th>
-                                                      <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                         Giver
+                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                         Team
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
-                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                         Team
+                                                      <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                         Giver
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
@@ -2637,10 +2637,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign">
-                                                         Alice Betsy
+                                                         Team 1
                                                       </td>
                                                       <td class="middlealign">
-                                                         Team 1
+                                                         Alice Betsy
                                                       </td>
                                                       <td class="text-preserve-space">
                                                          90
@@ -2665,10 +2665,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign color_neutral">
-                                                         Benny Charles
+                                                         Team 1
                                                       </td>
                                                       <td class="middlealign color_neutral">
-                                                         Team 1
+                                                         Benny Charles
                                                       </td>
                                                       <td class="text-preserve-space color_neutral">
                                                          <i>
@@ -2718,13 +2718,13 @@
                                                       <th>
                                                          Photo
                                                       </th>
-                                                      <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                         Giver
+                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                         Team
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
-                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                         Team
+                                                      <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                         Giver
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
@@ -2751,10 +2751,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign">
-                                                         Alice Betsy
+                                                         Team 1
                                                       </td>
                                                       <td class="middlealign">
-                                                         Team 1
+                                                         Alice Betsy
                                                       </td>
                                                       <td class="text-preserve-space">
                                                          <span class="color_neutral">
@@ -2781,10 +2781,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign color_neutral">
-                                                         Benny Charles
+                                                         Team 1
                                                       </td>
                                                       <td class="middlealign color_neutral">
-                                                         Team 1
+                                                         Benny Charles
                                                       </td>
                                                       <td class="text-preserve-space color_neutral">
                                                          <i>
@@ -2853,13 +2853,13 @@
                                                       <th>
                                                          Photo
                                                       </th>
-                                                      <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                         Giver
+                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                         Team
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
-                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                         Team
+                                                      <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                         Giver
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
@@ -2885,9 +2885,9 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign">
-                                                         Team 1
                                                       </td>
                                                       <td class="middlealign">
+                                                         Team 1
                                                       </td>
                                                       <td class="text-preserve-space">
                                                          Response from benny to Team 1 (own team)
@@ -3151,13 +3151,13 @@
                                                       <th>
                                                          Photo
                                                       </th>
-                                                      <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                         Giver
+                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                         Team
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
-                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                         Team
+                                                      <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                         Giver
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
@@ -3184,10 +3184,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign">
-                                                         Alice Betsy
+                                                         Team 1
                                                       </td>
                                                       <td class="middlealign">
-                                                         Team 1
+                                                         Alice Betsy
                                                       </td>
                                                       <td class="text-preserve-space">
                                                          50
@@ -3212,10 +3212,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign color_neutral">
-                                                         Charlie Dávis
+                                                         Team 2
                                                       </td>
                                                       <td class="middlealign color_neutral">
-                                                         Team 2
+                                                         Charlie Dávis
                                                       </td>
                                                       <td class="text-preserve-space color_neutral">
                                                          <i>
@@ -3242,10 +3242,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign color_neutral">
-                                                         Danny Engrid
+                                                         Team 2
                                                       </td>
                                                       <td class="middlealign color_neutral">
-                                                         Team 2
+                                                         Danny Engrid
                                                       </td>
                                                       <td class="text-preserve-space color_neutral">
                                                          <i>
@@ -3272,10 +3272,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign color_neutral">
-                                                         Drop out
+                                                         Team 2
                                                       </td>
                                                       <td class="middlealign color_neutral">
-                                                         Team 2
+                                                         Drop out
                                                       </td>
                                                       <td class="text-preserve-space color_neutral">
                                                          <i>
@@ -3302,10 +3302,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign color_neutral">
-                                                         Extra guy
+                                                         Team 2
                                                       </td>
                                                       <td class="middlealign color_neutral">
-                                                         Team 2
+                                                         Extra guy
                                                       </td>
                                                       <td class="text-preserve-space color_neutral">
                                                          <i>
@@ -3437,13 +3437,13 @@
                                                       <th>
                                                          Photo
                                                       </th>
-                                                      <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                         Giver
+                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                         Team
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
-                                                      <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                         Team
+                                                      <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                         Giver
                                                          <span class="icon-sort unsorted">
                                                          </span>
                                                       </th>
@@ -3470,10 +3470,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign">
-                                                         Alice Betsy
+                                                         Team 1
                                                       </td>
                                                       <td class="middlealign">
-                                                         Team 1
+                                                         Alice Betsy
                                                       </td>
                                                       <td class="text-preserve-space">
                                                          150
@@ -3498,10 +3498,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign color_neutral">
-                                                         Charlie Dávis
+                                                         Team 2
                                                       </td>
                                                       <td class="middlealign color_neutral">
-                                                         Team 2
+                                                         Charlie Dávis
                                                       </td>
                                                       <td class="text-preserve-space color_neutral">
                                                          <i>
@@ -3528,10 +3528,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign color_neutral">
-                                                         Danny Engrid
+                                                         Team 2
                                                       </td>
                                                       <td class="middlealign color_neutral">
-                                                         Team 2
+                                                         Danny Engrid
                                                       </td>
                                                       <td class="text-preserve-space color_neutral">
                                                          <i>
@@ -3558,10 +3558,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign color_neutral">
-                                                         Drop out
+                                                         Team 2
                                                       </td>
                                                       <td class="middlealign color_neutral">
-                                                         Team 2
+                                                         Drop out
                                                       </td>
                                                       <td class="text-preserve-space color_neutral">
                                                          <i>
@@ -3588,10 +3588,10 @@
                                                          </div>
                                                       </td>
                                                       <td class="middlealign color_neutral">
-                                                         Extra guy
+                                                         Team 2
                                                       </td>
                                                       <td class="middlealign color_neutral">
-                                                         Team 2
+                                                         Extra guy
                                                       </td>
                                                       <td class="text-preserve-space color_neutral">
                                                          <i>

--- a/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionRecipientQuestionGiverTeam.html
+++ b/src/test/resources/pages/instructorFeedbackResultsSortSecondSessionRecipientQuestionGiverTeam.html
@@ -381,13 +381,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Giver
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Giver
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -413,10 +413,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Anonymous student 410339386
+                                                Anonymous student 410339386's Team
                                              </td>
                                              <td class="middlealign">
-                                                Anonymous student 410339386's Team
+                                                Anonymous student 410339386
                                              </td>
                                              <td class="text-preserve-space">
                                                 -0.5
@@ -528,13 +528,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Giver
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Giver
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -560,9 +560,9 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Team 1
                                              </td>
                                              <td class="middlealign">
+                                                Team 1
                                              </td>
                                              <td class="text-preserve-space">
                                                 0
@@ -586,9 +586,9 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign color_neutral">
-                                                Team 2
                                              </td>
                                              <td class="middlealign color_neutral">
+                                                Team 2
                                              </td>
                                              <td class="text-preserve-space color_neutral">
                                                 <i>
@@ -614,9 +614,9 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign color_neutral">
-                                                Team 3
                                              </td>
                                              <td class="middlealign color_neutral">
+                                                Team 3
                                              </td>
                                              <td class="text-preserve-space color_neutral">
                                                 <i>
@@ -759,13 +759,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Giver
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Giver
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -792,10 +792,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Alice Betsy
+                                                Team 1
                                              </td>
                                              <td class="middlealign">
-                                                Team 1
+                                                Alice Betsy
                                              </td>
                                              <td class="text-preserve-space">
                                                 <ul class="selectedOptionsList">
@@ -901,13 +901,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Giver
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Giver
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -934,10 +934,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Alice Betsy
+                                                Team 1
                                              </td>
                                              <td class="middlealign">
-                                                Team 1
+                                                Alice Betsy
                                              </td>
                                              <td class="text-preserve-space">
                                                 <ul class="selectedOptionsList">
@@ -1063,13 +1063,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Giver
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Giver
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -1096,10 +1096,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Alice Betsy
+                                                Team 1
                                              </td>
                                              <td class="middlealign">
-                                                Team 1
+                                                Alice Betsy
                                              </td>
                                              <td class="text-preserve-space">
                                                 3.5
@@ -1214,13 +1214,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Giver
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Giver
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -1247,10 +1247,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Alice Betsy
+                                                Team 1
                                              </td>
                                              <td class="middlealign">
-                                                Team 1
+                                                Alice Betsy
                                              </td>
                                              <td class="text-preserve-space">
                                                 <ul>
@@ -1362,13 +1362,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Giver
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Giver
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -1395,10 +1395,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Alice Betsy
+                                                Team 1
                                              </td>
                                              <td class="middlealign">
-                                                Team 1
+                                                Alice Betsy
                                              </td>
                                              <td class="text-preserve-space">
                                                 110
@@ -1423,10 +1423,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign color_neutral">
-                                                Benny Charles
+                                                Team 1
                                              </td>
                                              <td class="middlealign color_neutral">
-                                                Team 1
+                                                Benny Charles
                                              </td>
                                              <td class="text-preserve-space color_neutral">
                                                 <i>
@@ -1476,13 +1476,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Giver
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Giver
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -1509,10 +1509,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Alice Betsy
+                                                Team 1
                                              </td>
                                              <td class="middlealign">
-                                                Team 1
+                                                Alice Betsy
                                              </td>
                                              <td class="text-preserve-space">
                                                 <span class="color-positive">
@@ -1546,10 +1546,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign color_neutral">
-                                                Benny Charles
+                                                Team 1
                                              </td>
                                              <td class="middlealign color_neutral">
-                                                Team 1
+                                                Benny Charles
                                              </td>
                                              <td class="text-preserve-space color_neutral">
                                                 <i>
@@ -1622,13 +1622,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Giver
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Giver
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -1655,10 +1655,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Alice Betsy
+                                                Team 1
                                              </td>
                                              <td class="middlealign">
-                                                Team 1
+                                                Alice Betsy
                                              </td>
                                              <td class="text-preserve-space">
                                                 3
@@ -1706,13 +1706,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Giver
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Giver
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -1739,10 +1739,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Alice Betsy
+                                                Team 1
                                              </td>
                                              <td class="middlealign">
-                                                Team 1
+                                                Alice Betsy
                                              </td>
                                              <td class="text-preserve-space">
                                                 <span class="color_neutral">
@@ -1815,13 +1815,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Giver
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Giver
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -1848,10 +1848,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Alice Betsy
+                                                Team 1
                                              </td>
                                              <td class="middlealign">
-                                                Team 1
+                                                Alice Betsy
                                              </td>
                                              <td class="text-preserve-space">
                                                 4
@@ -1899,13 +1899,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Giver
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Giver
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -1932,10 +1932,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Alice Betsy
+                                                Team 1
                                              </td>
                                              <td class="middlealign">
-                                                Team 1
+                                                Alice Betsy
                                              </td>
                                              <td class="text-preserve-space">
                                                 <span class="color_neutral">
@@ -2067,13 +2067,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Giver
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Giver
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -2100,10 +2100,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Alice Betsy
+                                                Team 1
                                              </td>
                                              <td class="middlealign">
-                                                Team 1
+                                                Alice Betsy
                                              </td>
                                              <td class="text-preserve-space">
                                                 90
@@ -2128,10 +2128,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign color_neutral">
-                                                Benny Charles
+                                                Team 1
                                              </td>
                                              <td class="middlealign color_neutral">
-                                                Team 1
+                                                Benny Charles
                                              </td>
                                              <td class="text-preserve-space color_neutral">
                                                 <i>
@@ -2181,13 +2181,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Giver
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Giver
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -2214,10 +2214,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Alice Betsy
+                                                Team 1
                                              </td>
                                              <td class="middlealign">
-                                                Team 1
+                                                Alice Betsy
                                              </td>
                                              <td class="text-preserve-space">
                                                 <span class="color_neutral">
@@ -2244,10 +2244,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign color_neutral">
-                                                Benny Charles
+                                                Team 1
                                              </td>
                                              <td class="middlealign color_neutral">
-                                                Team 1
+                                                Benny Charles
                                              </td>
                                              <td class="text-preserve-space color_neutral">
                                                 <i>
@@ -2386,13 +2386,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Giver
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Giver
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -2419,10 +2419,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Alice Betsy
+                                                Team 1
                                              </td>
                                              <td class="middlealign">
-                                                Team 1
+                                                Alice Betsy
                                              </td>
                                              <td class="text-preserve-space">
                                                 50
@@ -2447,10 +2447,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign color_neutral">
-                                                Charlie Dávis
+                                                Team 2
                                              </td>
                                              <td class="middlealign color_neutral">
-                                                Team 2
+                                                Charlie Dávis
                                              </td>
                                              <td class="text-preserve-space color_neutral">
                                                 <i>
@@ -2477,10 +2477,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign color_neutral">
-                                                Danny Engrid
+                                                Team 2
                                              </td>
                                              <td class="middlealign color_neutral">
-                                                Team 2
+                                                Danny Engrid
                                              </td>
                                              <td class="text-preserve-space color_neutral">
                                                 <i>
@@ -2507,10 +2507,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign color_neutral">
-                                                Drop out
+                                                Team 2
                                              </td>
                                              <td class="middlealign color_neutral">
-                                                Team 2
+                                                Drop out
                                              </td>
                                              <td class="text-preserve-space color_neutral">
                                                 <i>
@@ -2537,10 +2537,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign color_neutral">
-                                                Extra guy
+                                                Team 2
                                              </td>
                                              <td class="middlealign color_neutral">
-                                                Team 2
+                                                Extra guy
                                              </td>
                                              <td class="text-preserve-space color_neutral">
                                                 <i>
@@ -2672,13 +2672,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Giver
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Giver
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -2705,10 +2705,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Alice Betsy
+                                                Team 1
                                              </td>
                                              <td class="middlealign">
-                                                Team 1
+                                                Alice Betsy
                                              </td>
                                              <td class="text-preserve-space">
                                                 150
@@ -2733,10 +2733,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign color_neutral">
-                                                Charlie Dávis
+                                                Team 2
                                              </td>
                                              <td class="middlealign color_neutral">
-                                                Team 2
+                                                Charlie Dávis
                                              </td>
                                              <td class="text-preserve-space color_neutral">
                                                 <i>
@@ -2763,10 +2763,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign color_neutral">
-                                                Danny Engrid
+                                                Team 2
                                              </td>
                                              <td class="middlealign color_neutral">
-                                                Team 2
+                                                Danny Engrid
                                              </td>
                                              <td class="text-preserve-space color_neutral">
                                                 <i>
@@ -2793,10 +2793,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign color_neutral">
-                                                Drop out
+                                                Team 2
                                              </td>
                                              <td class="middlealign color_neutral">
-                                                Team 2
+                                                Drop out
                                              </td>
                                              <td class="text-preserve-space color_neutral">
                                                 <i>
@@ -2823,10 +2823,10 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign color_neutral">
-                                                Extra guy
+                                                Team 2
                                              </td>
                                              <td class="middlealign color_neutral">
-                                                Team 2
+                                                Extra guy
                                              </td>
                                              <td class="text-preserve-space color_neutral">
                                                 <i>
@@ -2888,13 +2888,13 @@
                                              <th>
                                                 Photo
                                              </th>
-                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,2)" style="width: 15%;">
-                                                Giver
+                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,2)" style="width: 15%;">
+                                                Team
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
-                                             <th class="button-sort-ascending" id="button_sortFromTeam" onclick="toggleSort(this,3)" style="width: 15%;">
-                                                Team
+                                             <th class="button-sort-none" id="button_sortFromName" onclick="toggleSort(this,3)" style="width: 15%;">
+                                                Giver
                                                 <span class="icon-sort unsorted">
                                                 </span>
                                              </th>
@@ -2920,9 +2920,9 @@
                                                 </div>
                                              </td>
                                              <td class="middlealign">
-                                                Team 1
                                              </td>
                                              <td class="middlealign">
+                                                Team 1
                                              </td>
                                              <td class="text-preserve-space">
                                                 Response from benny to Team 1 (own team)


### PR DESCRIPTION
Fixes #4672 

In question view, the team column is moved before the giver/recipient column.
![screenshot_q](https://cloud.githubusercontent.com/assets/10228385/12694389/535aa050-c767-11e5-821d-26d70437972e.jpg)

In giver > question > recipient view, the team column is between the photo column and the recipient column.
![screenshot_gqr](https://cloud.githubusercontent.com/assets/10228385/12694394/810b4266-c767-11e5-8df6-b3a4d708df64.jpg)

In recipient > question > giver view, the team column is between the photo column and the giver column.
![screenshot_rqg](https://cloud.githubusercontent.com/assets/10228385/12694396/9f3e2f8c-c767-11e5-9325-c9247cca05b2.jpg)



