### PR TITLE
Add default date for student timestamp #4684

### DIFF
--- a/src/main/java/teammates/common/datatransfer/StudentAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/StudentAttributes.java
@@ -364,11 +364,11 @@ public class StudentAttributes extends EntityAttributes {
     }
     
     public Date getCreatedAt() {
-        return (createdAt == null) ? Const.TIME_REPRESENTS_DEFAULT_STUDENT_CREATION_TIMESTAMP : createdAt;
+        return (createdAt == null) ? Const.TIME_REPRESENTS_DEFAULT_TIMESTAMP : createdAt;
     }
 
     public Date getUpdatedAt() {
-        return (updatedAt == null) ? Const.TIME_REPRESENTS_DEFAULT_STUDENT_CREATION_TIMESTAMP : updatedAt;
+        return (updatedAt == null) ? Const.TIME_REPRESENTS_DEFAULT_TIMESTAMP : updatedAt;
     }
     
     /**

--- a/src/main/java/teammates/common/datatransfer/StudentAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/StudentAttributes.java
@@ -364,17 +364,11 @@ public class StudentAttributes extends EntityAttributes {
     }
     
     public Date getCreatedAt() {
-        if (createdAt == null) {
-            createdAt = new Date(Const.DEFAULT_STUDENT_CREATION_DATE);
-        }
-        return createdAt;
+        return (createdAt == null) ? Const.TIME_REPRESENTS_DEFAULT_STUDENT_CREATION_TIMESTAMP : createdAt;
     }
 
     public Date getUpdatedAt() {
-        if (updatedAt == null) {
-            updatedAt = new Date(Const.DEFAULT_STUDENT_CREATION_DATE);
-        }
-        return updatedAt;
+        return (updatedAt == null) ? Const.TIME_REPRESENTS_DEFAULT_STUDENT_CREATION_TIMESTAMP : updatedAt;
     }
     
     /**

--- a/src/main/java/teammates/common/datatransfer/StudentAttributes.java
+++ b/src/main/java/teammates/common/datatransfer/StudentAttributes.java
@@ -364,10 +364,16 @@ public class StudentAttributes extends EntityAttributes {
     }
     
     public Date getCreatedAt() {
+        if (createdAt == null) {
+            createdAt = new Date(Const.DEFAULT_STUDENT_CREATION_DATE);
+        }
         return createdAt;
     }
 
     public Date getUpdatedAt() {
+        if (updatedAt == null) {
+            updatedAt = new Date(Const.DEFAULT_STUDENT_CREATION_DATE);
+        }
         return updatedAt;
     }
     

--- a/src/main/java/teammates/common/util/Const.java
+++ b/src/main/java/teammates/common/util/Const.java
@@ -1193,6 +1193,9 @@ public class Const {
     public static final Date TIME_REPRESENTS_LATER;
     public static final Date TIME_REPRESENTS_NOW;
     
+    //represents time (in milliseconds) from epoch (1/1/1970) to default student creation date (1/1/2011) in UTC
+    public static final long DEFAULT_STUDENT_CREATION_DATE = 1293840060000L;
+    
     static {
         TIME_REPRESENTS_FOLLOW_OPENING = TimeHelper.convertToDate("1970-12-31 00:00 AM UTC");
         TIME_REPRESENTS_FOLLOW_VISIBLE = TimeHelper.convertToDate("1970-06-22 00:00 AM UTC");

--- a/src/main/java/teammates/common/util/Const.java
+++ b/src/main/java/teammates/common/util/Const.java
@@ -1192,16 +1192,15 @@ public class Const {
     public static final Date TIME_REPRESENTS_NEVER;
     public static final Date TIME_REPRESENTS_LATER;
     public static final Date TIME_REPRESENTS_NOW;
-    
-    //represents time (in milliseconds) from epoch (1/1/1970) to default student creation date (1/1/2011) in UTC
-    public static final long DEFAULT_STUDENT_CREATION_DATE = 1293840060000L;
-    
+    public static final Date TIME_REPRESENTS_DEFAULT_STUDENT_CREATION_TIMESTAMP;
+      
     static {
         TIME_REPRESENTS_FOLLOW_OPENING = TimeHelper.convertToDate("1970-12-31 00:00 AM UTC");
         TIME_REPRESENTS_FOLLOW_VISIBLE = TimeHelper.convertToDate("1970-06-22 00:00 AM UTC");
         TIME_REPRESENTS_NEVER = TimeHelper.convertToDate("1970-11-27 00:00 AM UTC");
         TIME_REPRESENTS_LATER = TimeHelper.convertToDate("1970-01-01 00:00 AM UTC");
         TIME_REPRESENTS_NOW = TimeHelper.convertToDate("1970-02-14 00:00 AM UTC");
+        TIME_REPRESENTS_DEFAULT_STUDENT_CREATION_TIMESTAMP = TimeHelper.convertToDate("2011-01-01 00:00 AM UTC");
     }
     
     /* Other Constants

--- a/src/main/java/teammates/common/util/Const.java
+++ b/src/main/java/teammates/common/util/Const.java
@@ -1192,7 +1192,7 @@ public class Const {
     public static final Date TIME_REPRESENTS_NEVER;
     public static final Date TIME_REPRESENTS_LATER;
     public static final Date TIME_REPRESENTS_NOW;
-    public static final Date TIME_REPRESENTS_DEFAULT_STUDENT_CREATION_TIMESTAMP;
+    public static final Date TIME_REPRESENTS_DEFAULT_TIMESTAMP;
       
     static {
         TIME_REPRESENTS_FOLLOW_OPENING = TimeHelper.convertToDate("1970-12-31 00:00 AM UTC");
@@ -1200,7 +1200,7 @@ public class Const {
         TIME_REPRESENTS_NEVER = TimeHelper.convertToDate("1970-11-27 00:00 AM UTC");
         TIME_REPRESENTS_LATER = TimeHelper.convertToDate("1970-01-01 00:00 AM UTC");
         TIME_REPRESENTS_NOW = TimeHelper.convertToDate("1970-02-14 00:00 AM UTC");
-        TIME_REPRESENTS_DEFAULT_STUDENT_CREATION_TIMESTAMP = TimeHelper.convertToDate("2011-01-01 00:00 AM UTC");
+        TIME_REPRESENTS_DEFAULT_TIMESTAMP = TimeHelper.convertToDate("2011-01-01 00:00 AM UTC");
     }
     
     /* Other Constants

--- a/src/main/java/teammates/storage/entity/Student.java
+++ b/src/main/java/teammates/storage/entity/Student.java
@@ -117,7 +117,7 @@ public class Student implements StoreCallback {
     }
     
     public Date getCreatedAt() {
-        return (createdAt == null) ? Const.TIME_REPRESENTS_DEFAULT_STUDENT_CREATION_TIMESTAMP : createdAt;
+        return (createdAt == null) ? Const.TIME_REPRESENTS_DEFAULT_TIMESTAMP : createdAt;
     }
     
     public void setCreatedAt(Date created) {
@@ -126,7 +126,7 @@ public class Student implements StoreCallback {
     }
     
     public Date getUpdatedAt() {
-        return (updatedAt == null) ? Const.TIME_REPRESENTS_DEFAULT_STUDENT_CREATION_TIMESTAMP : updatedAt;
+        return (updatedAt == null) ? Const.TIME_REPRESENTS_DEFAULT_TIMESTAMP : updatedAt;
     }
     
     public void setLastUpdate(Date updatedAt) {

--- a/src/main/java/teammates/storage/entity/Student.java
+++ b/src/main/java/teammates/storage/entity/Student.java
@@ -117,10 +117,7 @@ public class Student implements StoreCallback {
     }
     
     public Date getCreatedAt() {
-        if (createdAt == null) {
-           setCreatedAt(new Date(Const.DEFAULT_STUDENT_CREATION_DATE));
-        }
-        return createdAt;
+        return (createdAt == null) ? Const.TIME_REPRESENTS_DEFAULT_STUDENT_CREATION_TIMESTAMP : createdAt;
     }
     
     public void setCreatedAt(Date created) {
@@ -129,10 +126,7 @@ public class Student implements StoreCallback {
     }
     
     public Date getUpdatedAt() {
-        if (updatedAt == null) {
-            setCreatedAt(new Date(Const.DEFAULT_STUDENT_CREATION_DATE));
-         }
-         return updatedAt;
+        return (updatedAt == null) ? Const.TIME_REPRESENTS_DEFAULT_STUDENT_CREATION_TIMESTAMP : updatedAt;
     }
     
     public void setLastUpdate(Date updatedAt) {

--- a/src/main/java/teammates/storage/entity/Student.java
+++ b/src/main/java/teammates/storage/entity/Student.java
@@ -10,6 +10,7 @@ import javax.jdo.annotations.Persistent;
 import javax.jdo.annotations.PrimaryKey;
 import javax.jdo.listener.StoreCallback;
 
+import teammates.common.util.Const;
 import teammates.common.util.StringHelper;
 
 import com.google.appengine.api.datastore.KeyFactory;
@@ -116,6 +117,9 @@ public class Student implements StoreCallback {
     }
     
     public Date getCreatedAt() {
+        if (createdAt == null) {
+           setCreatedAt(new Date(Const.DEFAULT_STUDENT_CREATION_DATE));
+        }
         return createdAt;
     }
     
@@ -125,7 +129,10 @@ public class Student implements StoreCallback {
     }
     
     public Date getUpdatedAt() {
-        return updatedAt;
+        if (updatedAt == null) {
+            setCreatedAt(new Date(Const.DEFAULT_STUDENT_CREATION_DATE));
+         }
+         return updatedAt;
     }
     
     public void setLastUpdate(Date updatedAt) {

--- a/src/test/java/teammates/test/cases/storage/StudentsDbTest.java
+++ b/src/test/java/teammates/test/cases/storage/StudentsDbTest.java
@@ -8,6 +8,8 @@ import static org.testng.AssertJUnit.assertTrue;
 import static teammates.common.util.FieldValidator.COURSE_ID_ERROR_MESSAGE;
 import static teammates.common.util.FieldValidator.REASON_INCORRECT_FORMAT;
 
+import java.util.Date;
+
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -30,6 +32,38 @@ public class StudentsDbTest extends BaseComponentTestCase {
     @BeforeClass
     public static void setupClass() throws Exception {
         printTestClassHeader();
+    }
+    
+    @Test
+    public void testDefaultTimestamp() throws InvalidParametersException, EntityAlreadyExistsException, EntityDoesNotExistException {        
+        ______TS("success : created");
+        
+        StudentAttributes s = new StudentAttributes();
+        s.name = "a valid student";
+        s.lastName = "last name of student";
+        s.email = "valid-fresh-student@email.com";
+        s.team = "validTeamNameOfStudent";
+        s.section = "aValidSectionName";
+        s.comments = "";
+        s.googleId = "validGoogleIdForStudent";
+        s.course = "valid-course";
+        studentsDb.createEntity(s);
+        
+        StudentAttributes student = studentsDb.getStudentForGoogleId(s.course, s.googleId);
+        assertNotNull(student);
+        
+        student.setCreated_NonProduction(null);
+        student.setUpdatedAt_NonProduction(null);
+        
+        Date defaultStudentCreationTimeStamp = new Date(Const.DEFAULT_STUDENT_CREATION_DATE);
+        
+        ______TS("success : created defaultTimeStamp");
+        
+        assertEquals(defaultStudentCreationTimeStamp, student.getCreatedAt());
+        
+        ______TS("success : update defaultTimeStamp");
+        
+        assertEquals(defaultStudentCreationTimeStamp, student.getUpdatedAt());
     }
     
     @Test

--- a/src/test/java/teammates/test/cases/storage/StudentsDbTest.java
+++ b/src/test/java/teammates/test/cases/storage/StudentsDbTest.java
@@ -55,7 +55,7 @@ public class StudentsDbTest extends BaseComponentTestCase {
         student.setCreated_NonProduction(null);
         student.setUpdatedAt_NonProduction(null);
         
-        Date defaultStudentCreationTimeStamp = new Date(Const.DEFAULT_STUDENT_CREATION_DATE);
+        Date defaultStudentCreationTimeStamp = Const.TIME_REPRESENTS_DEFAULT_STUDENT_CREATION_TIMESTAMP;
         
         ______TS("success : created defaultTimeStamp");
         

--- a/src/test/java/teammates/test/cases/storage/StudentsDbTest.java
+++ b/src/test/java/teammates/test/cases/storage/StudentsDbTest.java
@@ -36,7 +36,6 @@ public class StudentsDbTest extends BaseComponentTestCase {
     
     @Test
     public void testDefaultTimestamp() throws InvalidParametersException, EntityAlreadyExistsException, EntityDoesNotExistException {        
-        ______TS("success : created");
         
         StudentAttributes s = new StudentAttributes();
         s.name = "a valid student";
@@ -57,11 +56,11 @@ public class StudentsDbTest extends BaseComponentTestCase {
         
         Date defaultStudentCreationTimeStamp = Const.TIME_REPRESENTS_DEFAULT_STUDENT_CREATION_TIMESTAMP;
         
-        ______TS("success : created defaultTimeStamp");
+        ______TS("success : defaultTimeStamp for createdAt date");
         
         assertEquals(defaultStudentCreationTimeStamp, student.getCreatedAt());
         
-        ______TS("success : update defaultTimeStamp");
+        ______TS("success : defaultTimeStamp for updatedAt date");
         
         assertEquals(defaultStudentCreationTimeStamp, student.getUpdatedAt());
     }

--- a/src/test/java/teammates/test/cases/storage/StudentsDbTest.java
+++ b/src/test/java/teammates/test/cases/storage/StudentsDbTest.java
@@ -54,7 +54,7 @@ public class StudentsDbTest extends BaseComponentTestCase {
         student.setCreated_NonProduction(null);
         student.setUpdatedAt_NonProduction(null);
         
-        Date defaultStudentCreationTimeStamp = Const.TIME_REPRESENTS_DEFAULT_STUDENT_CREATION_TIMESTAMP;
+        Date defaultStudentCreationTimeStamp = Const.TIME_REPRESENTS_DEFAULT_TIMESTAMP;
         
         ______TS("success : defaultTimeStamp for createdAt date");
         


### PR DESCRIPTION
Fixes #4684 

I have modified the tests as well to check whether students with no createdAt and updatedAt timestamp to return the default timestamp as well.