### PR TITLE
Submission counter algorithm is flawed #4271

### DIFF
--- a/src/main/webapp/js/index.js
+++ b/src/main/webapp/js/index.js
@@ -81,18 +81,13 @@ function submissionCounter(currentDate, baseDate, submissionPerHour, baseCount) 
     if (!currentDate || !baseDate) {
         return errorMsg;
     }
-    var CurrBaseDateDifference = new Date(currentDate - baseDate);
-    if (CurrBaseDateDifference < 0) {
+    var currBaseDateDifference = currentDate - baseDate;
+    if (currBaseDateDifference < 0) {
         return errorMsg;
     }
 
-    var dd = CurrBaseDateDifference.getDate();
-    var mm = CurrBaseDateDifference.getMonth();
-    var yyyy = CurrBaseDateDifference.getFullYear() - 1970;
-    var month = mm + yyyy * 12;
-    var days = dd + month * 30;
-    var hr = days * 24;
-    var numberOfSubmissions = hr * submissionPerHour;
+    var hr = currBaseDateDifference / 60 / 60 / 1000; // convert from millisecond to hour
+    var numberOfSubmissions = Math.floor(hr * submissionPerHour);
     numberOfSubmissions += baseCount;
     return formatNumber(numberOfSubmissions);
 }

--- a/src/test/javascript/SubmissionCountJsTest.js
+++ b/src/test/javascript/SubmissionCountJsTest.js
@@ -14,11 +14,12 @@ test('submissionCounter(currDate, baseDate)', function() {
     assert.equal(submissionCounter(currentDate, baseDate, submissionPerHour,baseCount), errorMsg);
     //Check the function with base and current date being in same month
     var baseDate1 = new Date(2013, 11, 20);
-    assert.equal(submissionCounter(currentDate, baseDate1, submissionPerHour,baseCount), "36,096");
+    assert.equal(submissionCounter(currentDate, baseDate1, submissionPerHour,baseCount), "36,048");
     //Check the function with valid base and current date. The resulting value should be (current date -  base date)* submission per hour + base count
     var baseDate2 = new Date(2013, 10, 30);
-    assert.equal(submissionCounter(currentDate, baseDate2, submissionPerHour,baseCount), "37,056");
+    assert.equal(submissionCounter(currentDate, baseDate2, submissionPerHour,baseCount), "37,008");
     //Check the function with a result that requires multiple ','
-    var baseDate3 = new Date(1913, 10, 30);
-    assert.equal(submissionCounter(currentDate, baseDate3, submissionPerHour,baseCount), "1,765,056");
+    var baseDate3 = new Date(2016, 10, 30);
+    var currentDate2 = new Date(2076, 11, 21);
+    assert.equal(submissionCounter(currentDate2, baseDate3, submissionPerHour,baseCount), "1,088,928");
 });


### PR DESCRIPTION
Fixes #4271 
Essentially it is the instantiation of new `Date` in js that caused the test to be prone to location-based failures. Beyond that, there's another flaw in that each month is treated as 30 days. We know that 12 * 30 = 360 < 365/366 days in a year.

The test cases are checked manually for correctness (2 submissions per hour starting at 36,000):
- Case 1: from 20 Dec 2013 to 21 Dec 2013, 1 day = 24 hrs = 48 submissions. It should be 36,048.
- Case 2: from 30 Nov 2013 to 21 Dec 2013, 21 days = 504 hrs = 1,008 submissions. It should be 37,008.
- Case 3: from 30 Nov 2016 to 21 Dec 2076, 21936 days (assuming the calculator I used is correct) = 1,052,928 submissions. It should be 1,088,928.

For case 3 I have to cherry-pick new dates because apparently Firefox has a bug in parsing some dates (and that includes the old dates used).