### PR TITLE
Not enough info in 'severe error log compilation' email #4703

### DIFF
--- a/src/main/java/teammates/logic/core/Emails.java
+++ b/src/main/java/teammates/logic/core/Emails.java
@@ -663,8 +663,7 @@ public class Emails {
                 addEmailToTaskQueue(m, emailDelayTimer);
                 numberOfEmailsSent++;
             } catch (MessagingException e) {
-                log.severe("Error in sending : " + m.toString()
-                        + " Cause : " + e.getMessage());
+                logSevereForErrorInSendingItem("message", m, e);
             }
         }
 
@@ -806,23 +805,24 @@ public class Emails {
             forceSendEmailThroughGaeWithoutLogging(email);
             log.severe("Sent crash report: " + Emails.getEmailInfo(email));
         } catch (Exception e) {
-            log.severe("Error in sending crash report: "
-                    + (email == null ? "" : email.toString()));
+            logSevereForErrorInSendingItem("crash report", email, e);
         }
     
         return email;
     }
 
     public MimeMessage sendLogReport(MimeMessage message) {
-        MimeMessage email = null;
         try {
             forceSendEmailThroughGaeWithoutLogging(message);
         } catch (Exception e) {
-            log.severe("Error in sending log report: "
-                    + (email == null ? "" : email.toString()));
+            logSevereForErrorInSendingItem("log report", message, e);
         }
+        return message;
+    }
     
-        return email;
+    private void logSevereForErrorInSendingItem(String itemType, MimeMessage message, Exception e) {
+        log.severe("Error in sending " + itemType + ": " + (message == null ? "" : message.toString())
+                   + "\nCause: " + TeammatesException.toStringWithStackTrace(e));        
     }
     
     private String fillUpStudentJoinFragment(StudentAttributes s, String emailBody) {


### PR DESCRIPTION
Fixes #4703, fixes #4557 (two duplicate issues)
`sendLogReport` is in particular problematic because the variable `email` appears out of nowhere and makes everything null. Somebody should've copy-pasted it from `sendErrorReport` :p